### PR TITLE
build: Introduce a Makefile with usage instructions

### DIFF
--- a/rf/Makefile
+++ b/rf/Makefile
@@ -1,0 +1,8 @@
+all: 	check build
+
+build:
+	@rebar3 escriptize
+	@cp _build/default/bin/rf .
+
+check:
+	@rebar3 do eunit

--- a/rf/README.md
+++ b/rf/README.md
@@ -4,11 +4,49 @@
 
 ## Build
 
-    `rebar3 escriptize`
+Run the tests and build an `rf` binary:
+
+```
+make
+```
 
 ## Run
 
-    `_build/default/bin/rf`
+There's a single `rf` escript command that contains subcommands for all Rufus
+tools.
+
+```
+rf
+```
+```
+rf provides tools for working with Rufus programs.
+
+Usage:
+
+    rf COMMAND [OPTION]...
+
+The commands are:
+
+    compile:parse   parse source code and print AST
+    compile:scan    scan source code and print tokens
+    version         print Rufus version
+
+Use "rf help [command]" for more information about that command
+
+Additional help topics:
+
+    spec            language specification
+
+Use "rf help [topic]" for more information about that topic
+```
+
+## Test
+
+Run the tests:
+
+```
+make check
+```
 
 ## Code layout
 

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -27,7 +27,7 @@ help(_Args) ->
     io:format("~n"),
     io:format("Usage:~n"),
     io:format("~n"),
-    io:format("    rf command [OPTION]...~n"),
+    io:format("    rf COMMAND [OPTION]...~n"),
     io:format("~n"),
     io:format("The commands are:~n"),
     io:format("~n"),


### PR DESCRIPTION
A new `Makefile` contains `all`, `build`, and `check` directives. The README had been updated with build instructions.