### PR TITLE
compiler: Compile and run a simple function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
+# Rufus
+
 A programming language for the BEAM.
+
+## Core Erlang resources
+
+- [Core Erlang Initiative](https://www.it.uu.se/research/group/hipe/cerl/) has links to the latest version of the Core Erlang
+  language specification.
+- [Core Erlang by Example](http://blog.erlang.org/core-erlang-by-example/)
+- [Core Erlang Optimizations](http://blog.erlang.org/core-erlang-optimizations/)
+- [Core Erlang Wrap Up](http://blog.erlang.org/core-erlang-wrapup/)
+- [A Gentle Introduction to Core Erlang: Part 1](https://baha.github.io/intro-core-erlang-1/)
+- [A Gentle Introduction to Core Erlang: Part 2](https://baha.github.io/intro-core-erlang-2/)
+- [The Core of Erlang](https://8thlight.com/blog/kofi-gumbs/2017/05/02/core-erlang.html)

--- a/rf/.gitignore
+++ b/rf/.gitignore
@@ -15,3 +15,4 @@ logs
 _build
 .idea
 rebar3.crashdump
+rf

--- a/rf/Makefile
+++ b/rf/Makefile
@@ -1,8 +1,11 @@
-all: 	check build
+all: 	clean check build
+
+clean:
+	@rebar3 clean
+
+check:
+	@rebar3 eunit
 
 build:
 	@rebar3 escriptize
 	@cp _build/default/bin/rf .
-
-check:
-	@rebar3 do eunit

--- a/rf/README.md
+++ b/rf/README.md
@@ -27,9 +27,10 @@ Usage:
 
 The commands are:
 
-    compile:parse   parse source code and print AST
-    compile:scan    scan source code and print tokens
-    version         print Rufus version
+    compile:core-erlang   parse source code and print Core Erlang translation
+    compile:parse         parse source code and print AST
+    compile:scan          scan source code and print tokens
+    version               print Rufus version
 
 Use "rf help [command]" for more information about that command
 

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -7,6 +7,8 @@
 %% escript entry point.
 main(Args) ->
     case Args of
+        ["compile:core-erlang"|CmdArgs] ->
+            compile(CmdArgs);
         ["compile:parse"|CmdArgs] ->
             parse(CmdArgs);
         ["compile:scan"|CmdArgs] ->
@@ -31,9 +33,10 @@ help(_Args) ->
     io:format("~n"),
     io:format("The commands are:~n"),
     io:format("~n"),
-    io:format("    compile:parse   parse source code and print AST~n"),
-    io:format("    compile:scan    scan source code and print tokens~n"),
-    io:format("    version         print Rufus version~n"),
+    io:format("    compile:core-erlang   parse source code and print Core Erlang translation~n"),
+    io:format("    compile:parse         parse source code and print AST~n"),
+    io:format("    compile:scan          scan source code and print tokens~n"),
+    io:format("    version               print Rufus version~n"),
     io:format("~n"),
     io:format("Use \"rf help [command]\" for more information about that command~n"),
     io:format("~n"),
@@ -74,4 +77,18 @@ scan(_Args) ->
     {ok, Tokens, _Lines} = rfc_scan:string(SourceText),
     io:format("source text =>~n~s~n~n", [SourceText]),
     io:format("scanned tokens =>~n~n    ~p~n", [Tokens]),
+    ok.
+
+compile(_Args) ->
+    SourceText ="
+    package example
+
+    func Greet(name string) string {
+        \"Hello \" + name
+    }
+",
+    {ok, Tokens, _Lines} = rfc_scan:string(SourceText),
+    io:format("source text =>~n~s~n~n", [SourceText]),
+    io:format("scanned tokens =>~n~n    ~p~n", [Tokens]),
+    undefined = rfc_compile:beam(Tokens),
     ok.

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -106,11 +106,11 @@ compile(_Args) ->
     {ok, ErlangForms} = rfc_erlang_compiler:forms(Forms),
     io:format("ErlangForms =>~n~n    ~p~n~n", [ErlangForms]),
     case compile:forms(ErlangForms) of
-        {ok, example, BinaryOrCode, Warnings} ->
+        {ok, Module, BinaryOrCode, Warnings} ->
             io:format("Warnings =>~n~n    ~p~n", [Warnings]),
-            code:load_binary(example, "nofile", BinaryOrCode);
-        {ok, example, BinaryOrCode} ->
-            code:load_binary(example, "nofile", BinaryOrCode);
+            code:load_binary(Module, "nofile", BinaryOrCode);
+        {ok, Module, BinaryOrCode} ->
+            code:load_binary(Module, "nofile", BinaryOrCode);
         {error, Errors, Warnings} ->
             io:format("Errors =>~n~n    ~p~n", [Errors]),
             io:format("Warnings =>~n~n    ~p~n", [Warnings]);

--- a/rf/src/rfc_erlang_compiler.erl
+++ b/rf/src/rfc_erlang_compiler.erl
@@ -1,0 +1,29 @@
+%% rfc_erlang_compiler transforms Rufus's abstract form into Erlang's abstract
+%% form.
+-module(rfc_erlang_compiler).
+
+%% API exports
+
+-export([forms/1]).
+
+%% API
+
+forms(Forms) ->
+    ErlangForms = lists:reverse(forms([], Forms)),
+    {ok, ErlangForms}.
+
+%% Private API
+
+forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
+    Form = {clause,LineNumber,[],[],[{integer, LineNumber, Value}]},
+    forms([Form|Acc], T);
+forms(Acc, [{func, LineNumber, Name, _Args, int, Exprs}|T]) ->
+    ExprForms = lists:reverse(forms([], Exprs)),
+    ExportForms = {attribute, LineNumber, export, [{list_to_atom(Name), 0}]},
+    Forms = {function, LineNumber, list_to_atom(Name), 0, ExprForms},
+    forms([Forms|[ExportForms|Acc]], T);
+forms(Acc, [{package, LineNumber, Name}|T]) ->
+    Form = {attribute, LineNumber, module, list_to_atom(Name)},
+    forms([Form|Acc], T);
+forms(Acc, []) ->
+    Acc.

--- a/rf/src/rfc_parse.erl
+++ b/rf/src/rfc_parse.erl
@@ -1,6 +1,6 @@
 -module(rfc_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 20).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 20).
 
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
@@ -13,11 +13,11 @@ token_line({_TokenType, TokenLine, _TokenChars}) ->
 token_type({TokenType, _TokenLine}) ->
     TokenType.
 
--file("/usr/local/Cellar/erlang/20.3.4/lib/erlang/lib/parsetools-2.1.6/include/yeccpre.hrl", 0).
+-file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/yeccpre.hrl", 0).
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2017. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2018. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -72,8 +72,7 @@ return_error(Line, Message) ->
 yeccpars0(Tokens, Tzr, State, States, Vstack) ->
     try yeccpars1(Tokens, Tzr, State, States, Vstack)
     catch 
-        error: Error ->
-            Stacktrace = erlang:get_stacktrace(),
+        error: Error: Stacktrace ->
             try yecc_error_type(Error, Stacktrace) of
                 Desc ->
                     erlang:raise(error, {yecc_bug, ?CODE_VERSION, Desc},
@@ -186,7 +185,7 @@ yecctoken2string(Other) ->
 
 
 
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.erl", 189).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.erl", 188).
 
 -dialyzer({nowarn_function, yeccpars2/7}).
 yeccpars2(0=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -368,7 +367,7 @@ yeccgoto_type(11, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 3).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 3).
 yeccpars2_3_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -376,7 +375,7 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 7).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 7).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -384,7 +383,7 @@ yeccpars2_7_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 6).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 6).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -392,7 +391,7 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_13_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 12).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 12).
 yeccpars2_13_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -400,7 +399,7 @@ yeccpars2_13_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 14).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 14).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -408,7 +407,7 @@ yeccpars2_16_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 10).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 10).
 yeccpars2_17_(__Stack0) ->
  [__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -416,7 +415,7 @@ yeccpars2_17_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 4).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 4).
 yeccpars2_18_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -424,4 +423,4 @@ yeccpars2_18_(__Stack0) ->
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/_build/default/lib/rf/src/rfc_parse.yrl", 32).
+-file("/Users/jkakar/rufus/rf/src/rfc_parse.yrl", 32).

--- a/rf/src/rfc_scan.erl
+++ b/rf/src/rfc_scan.erl
@@ -1,4 +1,4 @@
--file("/usr/local/Cellar/erlang/21.1.4/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 0).
+-file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 0).
 %% The source of this file is part of leex distribution, as such it
 %% has the same Copyright as the other files in the leex
 %% distribution. The Copyright is defined in the accompanying file
@@ -17,7 +17,7 @@
 strip(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
 
--file("/usr/local/Cellar/erlang/21.1.4/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 14).
+-file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 14).
 
 format_error({illegal,S}) -> ["illegal characters ",io_lib:write_string(S)];
 format_error({user,S}) -> S.
@@ -1087,4 +1087,4 @@ yyaction_18(TokenLine) ->
 yyaction_19(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
--file("/usr/local/Cellar/erlang/21.1.4/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).
+-file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/test/rfc_erlang_compiler_test.erl
+++ b/rf/test/rfc_erlang_compiler_test.erl
@@ -1,0 +1,18 @@
+-module(rfc_erlang_compiler_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+forms_test() ->
+    RufusText = "
+    package example
+    func Number() int { 42 }
+    ",
+    {ok, Tokens, _} = rfc_scan:string(RufusText),
+    {ok, Forms} = rfc_parse:parse(Tokens),
+    {ok, ErlangForms} = rfc_erlang_compiler:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Number',0}]},
+        {function, 3, 'Number', 0, [{clause,3,[],[],[{integer,3,42}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
A `Makefile` has `clean`, `build` and `check` targets and runs them all by default. An `rfc_erlang_compiler` module transforms Rufus forms for a function that takes no arguments and returns an `int` into Erlang forms that can compiled with `compile:forms(ErlangForms)`, and then loaded with `code:load_binary(Module, "nofile", BinaryOrCode)`. The `rf compile:abstract-erlang` command compiles a simple Rufus function, loads it into the VM and executes it.