### PR TITLE
compiler: Parse 0-arity functions that return floats and strings

### DIFF
--- a/rf/src/rufus_erlang_compiler.erl
+++ b/rf/src/rufus_erlang_compiler.erl
@@ -21,7 +21,8 @@ forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
     Form = {clause,LineNumber,[],[],[{integer, LineNumber, Value}]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {string, Value}}|T]) ->
-    Form = {clause,LineNumber,[],[],[{bin, LineNumber, [{bin_element, LineNumber, {string, LineNumber, Value}, default, default}]}]},
+    StringExpr = {bin_element, LineNumber, {string, LineNumber, Value}, default, default},
+    Form = {clause,LineNumber,[],[],[{bin, LineNumber, [StringExpr]}]},
     forms([Form|Acc], T);
 forms(Acc, [{func, LineNumber, Name, _Args, _ReturnType, Exprs}|T]) ->
     ExprForms = lists:reverse(forms([], Exprs)),

--- a/rf/src/rufus_erlang_compiler.erl
+++ b/rf/src/rufus_erlang_compiler.erl
@@ -14,10 +14,13 @@ forms(Forms) ->
 
 %% Private API
 
+forms(Acc, [{expr, LineNumber, {float, Value}}|T]) ->
+    Form = {clause,LineNumber,[],[],[{float, LineNumber, Value}]},
+    forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
     Form = {clause,LineNumber,[],[],[{integer, LineNumber, Value}]},
     forms([Form|Acc], T);
-forms(Acc, [{func, LineNumber, Name, _Args, int, Exprs}|T]) ->
+forms(Acc, [{func, LineNumber, Name, _Args, _ReturnType, Exprs}|T]) ->
     ExprForms = lists:reverse(forms([], Exprs)),
     ExportForms = {attribute, LineNumber, export, [{list_to_atom(Name), 0}]},
     Forms = {function, LineNumber, list_to_atom(Name), 0, ExprForms},

--- a/rf/src/rufus_erlang_compiler.erl
+++ b/rf/src/rufus_erlang_compiler.erl
@@ -8,21 +8,21 @@
 
 %% API
 
-forms(Forms) ->
-    ErlangForms = lists:reverse(forms([], Forms)),
+forms(RufusForms) ->
+    ErlangForms = lists:reverse(forms([], RufusForms)),
     {ok, ErlangForms}.
 
 %% Private API
 
 forms(Acc, [{expr, LineNumber, {float, Value}}|T]) ->
-    Form = {clause,LineNumber,[],[],[{float, LineNumber, Value}]},
+    Form = {clause, LineNumber, [], [], [{float, LineNumber, Value}]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
-    Form = {clause,LineNumber,[],[],[{integer, LineNumber, Value}]},
+    Form = {clause, LineNumber, [], [], [{integer, LineNumber, Value}]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {string, Value}}|T]) ->
     StringExpr = {bin_element, LineNumber, {string, LineNumber, Value}, default, default},
-    Form = {clause,LineNumber,[],[],[{bin, LineNumber, [StringExpr]}]},
+    Form = {clause, LineNumber, [], [], [{bin, LineNumber, [StringExpr]}]},
     forms([Form|Acc], T);
 forms(Acc, [{func, LineNumber, Name, _Args, _ReturnType, Exprs}|T]) ->
     ExprForms = lists:reverse(forms([], Exprs)),

--- a/rf/src/rufus_erlang_compiler.erl
+++ b/rf/src/rufus_erlang_compiler.erl
@@ -20,6 +20,9 @@ forms(Acc, [{expr, LineNumber, {float, Value}}|T]) ->
 forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
     Form = {clause,LineNumber,[],[],[{integer, LineNumber, Value}]},
     forms([Form|Acc], T);
+forms(Acc, [{expr, LineNumber, {string, Value}}|T]) ->
+    Form = {clause,LineNumber,[],[],[{bin, LineNumber, [{bin_element, LineNumber, {string, LineNumber, Value}, default, default}]}]},
+    forms([Form|Acc], T);
 forms(Acc, [{func, LineNumber, Name, _Args, _ReturnType, Exprs}|T]) ->
     ExprForms = lists:reverse(forms([], Exprs)),
     ExportForms = {attribute, LineNumber, export, [{list_to_atom(Name), 0}]},

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
 
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
@@ -218,14 +218,18 @@ yeccpars2(13=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -299,14 +303,16 @@ yeccpars2_10(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
-yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_11(S, float, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
+yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_12/7}).
 yeccpars2_12(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
 yeccpars2_12(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -314,30 +320,40 @@ yeccpars2_13(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_13_(Stack),
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_14/7}).
-yeccpars2_14(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
-yeccpars2_14(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_14_(Stack),
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_15/7}).
-yeccpars2_15(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_15(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 17, Ss, Stack, T, Ts, Tzr);
+yeccpars2_15(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
 yeccpars2_15(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_16(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_16_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_16/7}).
+yeccpars2_16(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
+yeccpars2_16(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_17(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_17_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_18_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_19_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_20_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_declaration/7}).
@@ -347,8 +363,8 @@ yeccgoto_declaration(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expression/7}).
-yeccgoto_expression(14, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_15(15, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_expression(15, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_16(16, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -360,7 +376,7 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(11, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -395,32 +411,48 @@ yeccpars2_8_(__Stack0) ->
 yeccpars2_13_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
+   { float , token_line ( __1 ) }
+  end | __Stack].
+
+-compile({inline,yeccpars2_14_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 13).
+yeccpars2_14_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
    { int , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
-yeccpars2_16_(__Stack0) ->
+-compile({inline,yeccpars2_17_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
+yeccpars2_17_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_18_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 16).
+yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_17_/1}).
+-compile({inline,yeccpars2_19_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
-yeccpars2_17_(__Stack0) ->
+yeccpars2_19_(__Stack0) ->
  [__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { func , token_line ( __1 ) , token_chars ( __2 ) , [ ] , token_type ( __5 ) , __7 }
   end | __Stack].
 
--compile({inline,yeccpars2_18_/1}).
+-compile({inline,yeccpars2_20_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 4).
-yeccpars2_18_(__Stack0) ->
+yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 32).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 34).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
 
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
@@ -220,16 +220,20 @@ yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -307,12 +311,14 @@ yeccpars2_11(S, float, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
+yeccpars2_11(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_12/7}).
 yeccpars2_12(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
 yeccpars2_12(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -324,36 +330,46 @@ yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_14_(Stack),
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_15/7}).
-yeccpars2_15(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 17, Ss, Stack, T, Ts, Tzr);
-yeccpars2_15(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
-yeccpars2_15(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_15(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_15_(Stack),
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_16/7}).
-yeccpars2_16(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_16(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
+yeccpars2_16(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
+yeccpars2_16(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
 yeccpars2_16(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_17(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_17_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_17/7}).
+yeccpars2_17(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 21, Ss, Stack, T, Ts, Tzr);
+yeccpars2_17(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_18_(Stack),
  yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_19_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_20_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_21_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_22_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_declaration/7}).
@@ -363,8 +379,8 @@ yeccgoto_declaration(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expression/7}).
-yeccgoto_expression(15, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_16(16, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_expression(16, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_17(17, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -376,7 +392,7 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(11, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -422,12 +438,12 @@ yeccpars2_14_(__Stack0) ->
    { int , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
-yeccpars2_17_(__Stack0) ->
+-compile({inline,yeccpars2_15_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
+yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
+   { string , token_line ( __1 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
@@ -435,24 +451,40 @@ yeccpars2_17_(__Stack0) ->
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
+   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
 yeccpars2_19_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_20_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
+yeccpars2_20_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_21_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
+yeccpars2_21_(__Stack0) ->
  [__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { func , token_line ( __1 ) , token_chars ( __2 ) , [ ] , token_type ( __5 ) , __7 }
   end | __Stack].
 
--compile({inline,yeccpars2_20_/1}).
+-compile({inline,yeccpars2_22_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 4).
-yeccpars2_20_(__Stack0) ->
+yeccpars2_22_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 34).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 36).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,6 +1,6 @@
 Nonterminals declaration expression function root type.
 
-Terminals '(' ')' '{' '}' func identifier import package float float_lit int int_lit string_lit.
+Terminals '(' ')' '{' '}' func identifier import package float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
@@ -15,9 +15,11 @@ function -> func identifier '(' ')' type '{' expression '}' : {func, token_line(
 
 type -> float : {float, token_line('$1')}.
 type -> int : {int, token_line('$1')}.
+type -> string : {string, token_line('$1')}.
 
 expression -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
 expression -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
+expression -> string_lit : [{expr, token_line('$1'), {string, token_chars('$1')}}].
 
 Erlang code.
 

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,6 +1,6 @@
 Nonterminals declaration expression function root type.
 
-Terminals '(' ')' '{' '}' func identifier import package int int_lit string_lit.
+Terminals '(' ')' '{' '}' func identifier import package float float_lit int int_lit string_lit.
 
 Rootsymbol root.
 
@@ -13,8 +13,10 @@ declaration -> function : '$1'.
 
 function -> func identifier '(' ')' type '{' expression '}' : {func, token_line('$1'), token_chars('$2'), [], token_type('$5'), '$7'}.
 
+type -> float : {float, token_line('$1')}.
 type -> int : {int, token_line('$1')}.
 
+expression -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
 expression -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
 
 Erlang code.

--- a/rf/test/rufus_erlang_compiler_test.erl
+++ b/rf/test/rufus_erlang_compiler_test.erl
@@ -2,6 +2,21 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+forms_for_function_returning_an_float_test() ->
+    RufusText = "
+    package example
+    func Pi() float { 3.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Pi', 0}]},
+        {function, 3, 'Pi', 0, [{clause, 3, [], [], [{float, 3, 3.14159265359}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
 forms_for_function_returning_an_int_test() ->
     RufusText = "
     package example

--- a/rf/test/rufus_erlang_compiler_test.erl
+++ b/rf/test/rufus_erlang_compiler_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-forms_for_function_returning_an_float_test() ->
+forms_for_function_returning_a_float_test() ->
     RufusText = "
     package example
     func Pi() float { 3.14159265359 }
@@ -29,5 +29,20 @@ forms_for_function_returning_an_int_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Number', 0}]},
         {function, 3, 'Number', 0, [{clause, 3, [], [], [{integer, 3, 42}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_string_test() ->
+    RufusText = "
+    package example
+    func Greeting() string { \"Hello\" }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Greeting', 0}]},
+        {function, 3, 'Greeting', 0, [{clause, 3, [], [], [{bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_compiler_test.erl
+++ b/rf/test/rufus_erlang_compiler_test.erl
@@ -40,9 +40,10 @@ forms_for_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    StringExpr = {bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Greeting', 0}]},
-        {function, 3, 'Greeting', 0, [{clause, 3, [], [], [{bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]}]}]}
+        {function, 3, 'Greeting', 0, [{clause, 3, [], [], [StringExpr]}]}
     ],
     ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
The `rufus_erlang_compiler` module can transform Rufus forms for 0-arity functions that return either `float` or `string` results into loadable code.