### PR TITLE
compiler: Add compiler module with function return type checking

### DIFF
--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -2,9 +2,11 @@
 -module(rf).
 
 %% API exports
+
 -export([main/1]).
 
-%% escript entry point.
+%% escript entry point
+
 main(Args) ->
     case Args of
         ["compile:abstract-erlang"|CmdArgs] ->
@@ -20,9 +22,7 @@ main(Args) ->
     end,
     erlang:halt(0).
 
-%%====================================================================
-%% Commands
-%%====================================================================
+%% Private API
 
 help(_Args) ->
     io:format("rf provides tools for working with Rufus programs.~n"),
@@ -103,6 +103,8 @@ compile(_Args) ->
     io:format("Tokens =>~n~n    ~p~n~n", [Tokens]),
     {ok, Forms} = rufus_parse:parse(Tokens),
     io:format("Forms =>~n~n    ~p~n~n", [Forms]),
+    {ok, Forms} = rufus_return_type:check(Forms),
+    io:format("rufus_return_type:check(Forms) =>~n~n    ok~n~n", []),
     {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
     io:format("ErlangForms =>~n~n    ~p~n~n", [ErlangForms]),
     case compile:forms(ErlangForms) of

--- a/rf/src/rufus_compiler.erl
+++ b/rf/src/rufus_compiler.erl
@@ -1,0 +1,61 @@
+%% rufus_compiler compiles and loads Rufus source code.
+-module(rufus_compiler).
+
+%% API exports
+
+-export([eval/1]).
+
+-ifdef(EUNIT).
+-export([eval_chain/2]).
+-endif.
+
+%% API
+
+%% eval parses, type checks, compiles and loads Rufus source code. Return
+%% values:
+%% - `{ok, Module}` if compilation completed and `Module` is loaded.
+%% - `error` or `{error, ...}` if an error occurs.
+eval(RufusText) ->
+    %% RufusText is the input for the first handler. Handlers are run in order
+    %% using the output from the previous function. Each function returns data
+    %% of the shape {ok, Output} or some form of error. Processing stops when a
+    %% handler returns an error.
+    Handlers = [fun scan/1,
+                fun rufus_parse:parse/1,
+                fun rufus_return_type:check/1,
+                fun rufus_erlang_compiler:forms/1,
+                fun compile/1
+               ],
+    eval_chain(RufusText, Handlers).
+
+%% Private API
+
+eval_chain(Input, [H|T]) ->
+    case H(Input) of
+        {ok, Forms} ->
+            eval_chain(Forms, T);
+        Error ->
+            Error
+    end;
+eval_chain(Input, []) ->
+    {ok, Input}.
+
+scan(RufusText) ->
+    case rufus_scan:string(RufusText) of
+        {ok, Tokens, _Lines} ->
+            {ok, Tokens};
+        Error ->
+            Error
+    end.
+
+compile(ErlangForms) ->
+    case compile:forms(ErlangForms) of
+        {ok, Module, BinaryOrCode, _Warnings} ->
+            code:load_binary(Module, "nofile", BinaryOrCode),
+            {ok, Module};
+        {ok, Module, BinaryOrCode} ->
+            code:load_binary(Module, "nofile", BinaryOrCode),
+            {ok, Module};
+        Error ->
+            Error
+    end.

--- a/rf/src/rufus_error.erl
+++ b/rf/src/rufus_error.erl
@@ -1,0 +1,15 @@
+%% rufus_error converts data from compilation errors into human-readable
+%% strings.
+-module(rufus_error).
+
+%% API exports
+
+-export([message/2]).
+
+%% API
+
+message(unmatched_return_type, Data) ->
+    Actual = maps:get(actual, Data),
+    Expected = maps:get(expected, Data),
+    Message = io_lib:format("mismatched return type, got ~p but want ~p.", [Actual, Expected]),
+    list_to_binary(Message).

--- a/rf/src/rufus_return_type.erl
+++ b/rf/src/rufus_return_type.erl
@@ -1,0 +1,42 @@
+%% rufus_return_type enforces the invariant that the type of a function's return
+%% value matches the return type specified in the function signature.
+-module(rufus_return_type).
+
+%% API exports
+
+-export([check/1]).
+
+%% API
+
+%% check iterates over Rufus forms and determines whether the type of each
+%% function return value matches the return type defined in the function
+%% signature. Iteration stops at the first error. Return values:
+%% - `ok` if no issues are found.
+%% - `{error, unmatched_return_type, Data}` with `Data` containing
+%%   `actual_return_value` and `expected_return_value` atom keys pointing to
+%%   Rufus types if return value types are unmatched.
+check(Forms) ->
+    check(Forms, Forms).
+
+%% Private API
+
+check(Forms, [H|T]) ->
+    case check_expr(H) of
+        ok ->
+            check(Forms, T);
+        Error ->
+            Error
+    end;
+check(Forms, []) ->
+    {ok, Forms}.
+
+check_expr({func, _LineNumber, _Name, _Arguments, ReturnType, Exprs}) ->
+    check_expr(ReturnType, lists:last(Exprs));
+check_expr(_) ->
+    ok.
+
+check_expr(ReturnType, {expr, _LineNumber, {ReturnType, _Literal}}) ->
+    ok;
+check_expr(ReturnType, {expr, _LineNumber, {ActualReturnType, _Literal}}) ->
+    Data = #{expected => ReturnType, actual => ActualReturnType},
+    {error, unmatched_return_type, Data}.

--- a/rf/test/rufus_compiler_test.erl
+++ b/rf/test/rufus_compiler_test.erl
@@ -1,0 +1,48 @@
+-module(rufus_compiler_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+eval_chain_without_handlers_test() ->
+    ?assertEqual({ok, "hello!"}, rufus_compiler:eval_chain("hello!", [])).
+
+eval_chain_with_ok_handler_test() ->
+    Reverse = fun(Word) -> {ok, lists:reverse(Word)} end,
+    ?assertEqual({ok, "ahah"}, rufus_compiler:eval_chain("haha", [Reverse])).
+
+eval_chain_with_error_handler_test() ->
+    Error = fun(_) -> {error, reason} end,
+    Explode = fun(_) -> throw(explode) end,
+    %% Explode never runs because eval_chain stops iterating over handlers when
+    %% it encounters an error.
+    ?assertEqual({error, reason}, rufus_compiler:eval_chain("haha", [Error, Explode])).
+
+eval_with_function_returning_a_float_test() ->
+    RufusText = "
+    package example
+    func Pi() float { 3.14159265359 }
+    ",
+    {ok, example} = rufus_compiler:eval(RufusText),
+    ?assertEqual(3.14159265359, example:'Pi'()).
+
+eval_with_function_returning_an_int_test() ->
+    RufusText = "
+    package example
+    func Number() int { 42 }
+    ",
+    {ok, example} = rufus_compiler:eval(RufusText),
+    ?assertEqual(42, example:'Number'()).
+
+eval_with_function_returning_a_string_test() ->
+    RufusText = "
+    package example
+    func Greeting() string { \"Hello\" }
+    ",
+    {ok, example} = rufus_compiler:eval(RufusText),
+    ?assertEqual(<<"Hello">>, example:'Greeting'()).
+
+eval_with_function_having_unmatched_return_types_test() ->
+    RufusText = "
+    package example
+    func Number() float { 42 }
+    ",
+    {error, unmatched_return_type, _Data} = rufus_compiler:eval(RufusText).

--- a/rf/test/rufus_error_test.erl
+++ b/rf/test/rufus_error_test.erl
@@ -1,0 +1,8 @@
+-module(rufus_error_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+message_for_unmatched_return_type_test() ->
+    Data = #{actual => int, expected => float},
+    Message = rufus_error:message(unmatched_return_type, Data),
+    ?assertEqual(<<"mismatched return type, got int but want float.">>, Message).

--- a/rf/test/rufus_return_type_test.erl
+++ b/rf/test/rufus_return_type_test.erl
@@ -1,0 +1,29 @@
+-module(rufus_return_type_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+check_empty_package_test() ->
+    RufusText = "package empty",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual({ok, Forms}, rufus_return_type:check(Forms)).
+
+check_test() ->
+    RufusText = "
+    package example
+
+    func Number() int { 42 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual({ok, Forms}, rufus_return_type:check(Forms)).
+
+check_function_with_unmatched_return_type_test() ->
+    RufusText = "
+    package example
+
+    func Number() int { 42.0 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {error, unmatched_return_type, _Data} = rufus_return_type:check(Forms).


### PR DESCRIPTION
A new `rufus_compiler:eval/1` function takes Rufus source text and compiles and loads it. A new `rufus_return_type:check/1` function runs type checks to ensure that the type of a value returned from a function matches the return type in the function signature. Finally, a new `rufus_error:message/1` function transforms compiler errors into human-readable strings.