### PR TITLE
rf: Cleaner compile subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	@cd rf && make && _build/default/bin/rf compile:abstract-erlang
+	@cd rf && make && _build/default/bin/rf compile

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -9,8 +9,8 @@
 
 main(Args) ->
     application:start(rf),
-    case Args of
-        ["compile:abstract-erlang"|SubArgs] ->
+    ExitCode = case Args of
+        ["compile"|SubArgs] ->
             compile(SubArgs);
         ["compile:parse"|SubArgs] ->
             parse(SubArgs);
@@ -22,7 +22,7 @@ main(Args) ->
             help(Args)
     end,
     application:stop(rf),
-    erlang:halt(0).
+    erlang:halt(ExitCode).
 
 %% Private API
 
@@ -35,10 +35,10 @@ help(_Args) ->
     io:format("~n"),
     io:format("The commands are:~n"),
     io:format("~n"),
-    io:format("    compile:abstract-erlang  Parse source code and print Erlang's abstract form~n"),
-    io:format("    compile:parse            Parse source code and print parse forms~n"),
-    io:format("    compile:scan             Scan source code and print parse tokens~n"),
-    io:format("    version                  Print Rufus version~n"),
+    io:format("    compile        Compile source code and then run it and print its output~n"),
+    io:format("    compile:parse  Parse source code and print parse forms~n"),
+    io:format("    compile:scan   Scan source code and print parse tokens~n"),
+    io:format("    version        Print Rufus version~n"),
     io:format("~n"),
     io:format("Use \"rf help [command]\" for more information about that command~n"),
     io:format("~n"),
@@ -48,16 +48,17 @@ help(_Args) ->
     io:format("~n"),
     io:format("Use \"rf help [topic]\" for more information about that topic~n"),
     io:format("~n"),
-    ok.
+    0.
 
 version(_Args) ->
     case application:get_key(rf, vsn) of
         {ok, Version} ->
-            io:format("rufus version v~s~n", [Version]);
+            io:format("rufus version v~s~n", [Version]),
+            0;
         Error ->
-            io:format("Error: ~p~n", [Error])
-    end,
-    ok.
+            io:format("Error: ~p~n", [Error]),
+            -1
+    end.
 
 parse(_Args) ->
     RufusText = "
@@ -73,15 +74,15 @@ parse(_Args) ->
     case rufus_parse:parse(Tokens) of
         {ok, Forms} ->
             io:format("Forms =>~n~n    ~p~n", [Forms]),
-            ok;
+            0;
         {error, {Line, _, [{ErrorPrefix, ErrorSuffix}, Token]}} ->
             Error = {error, {Line, {ErrorPrefix, ErrorSuffix}, Token}},
             io:format("Error =>~n~n    ~p~n", [Error]),
-            error;
+            -1;
         {error, {Line, _, [Error, Token]}} ->
             Error = {error, {Line, Error, Token}},
             io:format("Error =>~n~n    ~p~n", [Error]),
-            error
+            -1
     end.
 
 scan(_Args) ->
@@ -95,7 +96,7 @@ scan(_Args) ->
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, Tokens, _Lines} = rufus_scan:string(RufusText),
     io:format("Tokens =>~n~n    ~p~n", [Tokens]),
-    ok.
+    0.
 
 compile(_Args) ->
     RufusText ="
@@ -106,25 +107,6 @@ compile(_Args) ->
     }
 ",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
-    {ok, Tokens, _Lines} = rufus_scan:string(RufusText),
-    io:format("Tokens =>~n~n    ~p~n~n", [Tokens]),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    io:format("Forms =>~n~n    ~p~n~n", [Forms]),
-    {ok, Forms} = rufus_return_type:check(Forms),
-    io:format("rufus_return_type:check(Forms) =>~n~n    ok~n~n", []),
-    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
-    io:format("ErlangForms =>~n~n    ~p~n~n", [ErlangForms]),
-    case compile:forms(ErlangForms) of
-        {ok, Module, BinaryOrCode, Warnings} ->
-            io:format("Warnings =>~n~n    ~p~n", [Warnings]),
-            code:load_binary(Module, "nofile", BinaryOrCode);
-        {ok, Module, BinaryOrCode} ->
-            code:load_binary(Module, "nofile", BinaryOrCode);
-        {error, Errors, Warnings} ->
-            io:format("Errors =>~n~n    ~p~n", [Errors]),
-            io:format("Warnings =>~n~n    ~p~n", [Warnings]);
-        error ->
-            io:format("ERROR!~n")
-    end,
+    {ok, example} = rufus_compiler:eval(RufusText),
     io:format("example:Number() =>~n~n    ~p~n", [example:'Number'()]),
-    ok.
+    0.


### PR DESCRIPTION
The `rf compile` subcommand uses the `rufus_compiler:eval/1` function to build and run example code, which eliminates some duplication and pushes compilation details out of the command logic. Exit codes from subcommands are now returned by the main loop.