### PR TITLE
compiler: Use boxed values

### DIFF
--- a/rf/src/rufus_erlang_compiler.erl
+++ b/rf/src/rufus_erlang_compiler.erl
@@ -15,14 +15,14 @@ forms(RufusForms) ->
 %% Private API
 
 forms(Acc, [{expr, LineNumber, {float, Value}}|T]) ->
-    Form = {clause, LineNumber, [], [], [{float, LineNumber, Value}]},
+    Form = {clause, LineNumber, [], [], [box({float, LineNumber, Value})]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {int, Value}}|T]) ->
-    Form = {clause, LineNumber, [], [], [{integer, LineNumber, Value}]},
+    Form = {clause, LineNumber, [], [], [box({integer, LineNumber, Value})]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {string, Value}}|T]) ->
     StringExpr = {bin_element, LineNumber, {string, LineNumber, Value}, default, default},
-    Form = {clause, LineNumber, [], [], [{bin, LineNumber, [StringExpr]}]},
+    Form = {clause, LineNumber, [], [], [box({bin, LineNumber, [StringExpr]})]},
     forms([Form|Acc], T);
 forms(Acc, [{func, LineNumber, Name, _Args, _ReturnType, Exprs}|T]) ->
     ExprForms = lists:reverse(forms([], Exprs)),
@@ -34,3 +34,12 @@ forms(Acc, [{package, LineNumber, Name}|T]) ->
     forms([Form|Acc], T);
 forms(Acc, []) ->
     Acc.
+
+%% box converts Rufus types into Erlang `{<type>, <value>}` 2-tuples, such as
+%% turning `3.14159265359` into `{float, 3.14159265359}`, for example.
+box(Expr = {bin, LineNumber, _Value}) ->
+    {tuple, LineNumber, [{atom, LineNumber, string}, Expr]};
+box(Expr = {float, LineNumber, _Value}) ->
+    {tuple, LineNumber, [{atom, LineNumber, float}, Expr]};
+box(Expr = {integer, LineNumber, _Value}) ->
+    {tuple, LineNumber, [{atom, LineNumber, int}, Expr]}.

--- a/rf/test/rufus_compiler_test.erl
+++ b/rf/test/rufus_compiler_test.erl
@@ -22,7 +22,7 @@ eval_with_function_returning_a_float_test() ->
     func Pi() float { 3.14159265359 }
     ",
     {ok, example} = rufus_compiler:eval(RufusText),
-    ?assertEqual(3.14159265359, example:'Pi'()).
+    ?assertEqual({float, 3.14159265359}, example:'Pi'()).
 
 eval_with_function_returning_an_int_test() ->
     RufusText = "
@@ -30,7 +30,7 @@ eval_with_function_returning_an_int_test() ->
     func Number() int { 42 }
     ",
     {ok, example} = rufus_compiler:eval(RufusText),
-    ?assertEqual(42, example:'Number'()).
+    ?assertEqual({int, 42}, example:'Number'()).
 
 eval_with_function_returning_a_string_test() ->
     RufusText = "
@@ -38,7 +38,7 @@ eval_with_function_returning_a_string_test() ->
     func Greeting() string { \"Hello\" }
     ",
     {ok, example} = rufus_compiler:eval(RufusText),
-    ?assertEqual(<<"Hello">>, example:'Greeting'()).
+    ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
 eval_with_function_having_unmatched_return_types_test() ->
     RufusText = "

--- a/rf/test/rufus_erlang_compiler_test.erl
+++ b/rf/test/rufus_erlang_compiler_test.erl
@@ -10,10 +10,12 @@ forms_for_function_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    FloatExpr = {float, 3, 3.14159265359},
+    BoxedFloatExpr = {tuple, 3, [{atom, 3, float}, FloatExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Pi', 0}]},
-        {function, 3, 'Pi', 0, [{clause, 3, [], [], [{float, 3, 3.14159265359}]}]}
+        {function, 3, 'Pi', 0, [{clause, 3, [], [], [BoxedFloatExpr]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -25,10 +27,12 @@ forms_for_function_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    IntegerExpr = {integer, 3, 42},
+    BoxedIntegerExpr = {tuple, 3, [{atom, 3, int}, IntegerExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Number', 0}]},
-        {function, 3, 'Number', 0, [{clause, 3, [], [], [{integer, 3, 42}]}]}
+        {function, 3, 'Number', 0, [{clause, 3, [], [], [BoxedIntegerExpr]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -41,9 +45,10 @@ forms_for_function_returning_a_string_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
     StringExpr = {bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]},
+    BoxedStringExpr = {tuple, 3, [{atom, 3, string}, StringExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Greeting', 0}]},
-        {function, 3, 'Greeting', 0, [{clause, 3, [], [], [StringExpr]}]}
+        {function, 3, 'Greeting', 0, [{clause, 3, [], [], [BoxedStringExpr]}]}
     ],
     ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
Values for primitive types are represented in Erlang as `{Type, Value}` 2-tuples, such as `{float, 3.14159265359}`, `{int, 42}`, and `{string, <<"Hello!">}`. This puts the first steps in motion to build a Rufus to Erlang compiler based around type boxed values.