### PR TITLE
misc: Rename compiler modules

### DIFF
--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -107,6 +107,6 @@ compile(_Args) ->
     }
 ",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
-    {ok, example} = rufus_compiler:eval(RufusText),
+    {ok, example} = rufus_compile:eval(RufusText),
     io:format("example:Number() =>~n~n    ~p~n", [example:'Number'()]),
     0.

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -1,5 +1,5 @@
-%% rufus_compiler compiles and loads Rufus source code.
--module(rufus_compiler).
+%% rufus_compile compiles and loads Rufus source code.
+-module(rufus_compile).
 
 %% API exports
 

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -23,7 +23,7 @@ eval(RufusText) ->
     Handlers = [fun scan/1,
                 fun rufus_parse:parse/1,
                 fun rufus_return_type:check/1,
-                fun rufus_erlang_compiler:forms/1,
+                fun rufus_compile_erlang:forms/1,
                 fun compile/1
                ],
     eval_chain(RufusText, Handlers).

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -1,6 +1,6 @@
-%% rufus_erlang_compiler transforms Rufus's abstract form into Erlang's abstract
+%% rufus_compile_erlang transforms Rufus's abstract form into Erlang's abstract
 %% form.
--module(rufus_erlang_compiler).
+-module(rufus_compile_erlang).
 
 %% API exports
 

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -1,4 +1,4 @@
--module(rufus_erlang_compiler_test).
+-module(rufus_compile_erlang_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -9,7 +9,7 @@ forms_for_function_returning_a_float_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
     FloatExpr = {float, 3, 3.14159265359},
     BoxedFloatExpr = {tuple, 3, [{atom, 3, float}, FloatExpr]},
     Expected = [
@@ -26,7 +26,7 @@ forms_for_function_returning_an_int_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
     IntegerExpr = {integer, 3, 42},
     BoxedIntegerExpr = {tuple, 3, [{atom, 3, int}, IntegerExpr]},
     Expected = [
@@ -43,7 +43,7 @@ forms_for_function_returning_a_string_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang_compiler:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
     StringExpr = {bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]},
     BoxedStringExpr = {tuple, 3, [{atom, 3, string}, StringExpr]},
     Expected = [

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -1,27 +1,27 @@
--module(rufus_compiler_test).
+-module(rufus_compile_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
 eval_chain_without_handlers_test() ->
-    ?assertEqual({ok, "hello!"}, rufus_compiler:eval_chain("hello!", [])).
+    ?assertEqual({ok, "hello!"}, rufus_compile:eval_chain("hello!", [])).
 
 eval_chain_with_ok_handler_test() ->
     Reverse = fun(Word) -> {ok, lists:reverse(Word)} end,
-    ?assertEqual({ok, "ahah"}, rufus_compiler:eval_chain("haha", [Reverse])).
+    ?assertEqual({ok, "ahah"}, rufus_compile:eval_chain("haha", [Reverse])).
 
 eval_chain_with_error_handler_test() ->
     Error = fun(_) -> {error, reason} end,
     Explode = fun(_) -> throw(explode) end,
     %% Explode never runs because eval_chain stops iterating over handlers when
     %% it encounters an error.
-    ?assertEqual({error, reason}, rufus_compiler:eval_chain("haha", [Error, Explode])).
+    ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
 
 eval_with_function_returning_a_float_test() ->
     RufusText = "
     package example
     func Pi() float { 3.14159265359 }
     ",
-    {ok, example} = rufus_compiler:eval(RufusText),
+    {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({float, 3.14159265359}, example:'Pi'()).
 
 eval_with_function_returning_an_int_test() ->
@@ -29,7 +29,7 @@ eval_with_function_returning_an_int_test() ->
     package example
     func Number() int { 42 }
     ",
-    {ok, example} = rufus_compiler:eval(RufusText),
+    {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({int, 42}, example:'Number'()).
 
 eval_with_function_returning_a_string_test() ->
@@ -37,7 +37,7 @@ eval_with_function_returning_a_string_test() ->
     package example
     func Greeting() string { \"Hello\" }
     ",
-    {ok, example} = rufus_compiler:eval(RufusText),
+    {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
 eval_with_function_having_unmatched_return_types_test() ->
@@ -45,4 +45,4 @@ eval_with_function_having_unmatched_return_types_test() ->
     package example
     func Number() float { 42 }
     ",
-    {error, unmatched_return_type, _Data} = rufus_compiler:eval(RufusText).
+    {error, unmatched_return_type, _Data} = rufus_compile:eval(RufusText).


### PR DESCRIPTION
`rufus_compiler` is renamed to `rufus_compile`, and `rufus_erlang_compiler` is renamed to `rufus_compile_erlang`. These names fit a bit better with the other modules.