### PR TITLE
misc: Rename type checker module

### DIFF
--- a/rf/src/rufus_check_types.erl
+++ b/rf/src/rufus_check_types.erl
@@ -1,33 +1,33 @@
-%% rufus_return_type enforces the invariant that the type of a function's return
+%% rufus_check_types enforces the invariant that the type of a function's return
 %% value matches the return type specified in the function signature.
--module(rufus_return_type).
+-module(rufus_check_types).
 
 %% API exports
 
--export([check/1]).
+-export([forms/1]).
 
 %% API
 
-%% check iterates over Rufus forms and determines whether the type of each
+%% forms iterates over RufusForms and determines whether the type of each
 %% function return value matches the return type defined in the function
 %% signature. Iteration stops at the first error. Return values:
-%% - `ok` if no issues are found.
-%% - `{error, unmatched_return_type, Data}` with `Data` containing
-%%   `actual_return_value` and `expected_return_value` atom keys pointing to
-%%   Rufus types if return value types are unmatched.
-check(Forms) ->
-    check(Forms, Forms).
+%% - `{ok, RufusForms}` if no issues are found.
+%% - `{error, unmatched_return_type, Data}` with `Data` containing `actual` and
+%%   `expected` atom keys pointing to Rufus types if return value types are
+%%   unmatched.
+forms(RufusForms) ->
+    forms(RufusForms, RufusForms).
 
 %% Private API
 
-check(Forms, [H|T]) ->
+forms(Forms, [H|T]) ->
     case check_expr(H) of
         ok ->
-            check(Forms, T);
+            forms(Forms, T);
         Error ->
             Error
     end;
-check(Forms, []) ->
+forms(Forms, []) ->
     {ok, Forms}.
 
 check_expr({func, _LineNumber, _Name, _Arguments, ReturnType, Exprs}) ->

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -22,7 +22,7 @@ eval(RufusText) ->
     %% handler returns an error.
     Handlers = [fun scan/1,
                 fun rufus_parse:parse/1,
-                fun rufus_return_type:check/1,
+                fun rufus_check_types:forms/1,
                 fun rufus_compile_erlang:forms/1,
                 fun compile/1
                ],

--- a/rf/test/rufus_check_types_test.erl
+++ b/rf/test/rufus_check_types_test.erl
@@ -1,14 +1,14 @@
--module(rufus_return_type_test).
+-module(rufus_check_types_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
-check_empty_package_test() ->
+forms_with_empty_package_test() ->
     RufusText = "package empty",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    ?assertEqual({ok, Forms}, rufus_return_type:check(Forms)).
+    ?assertEqual({ok, Forms}, rufus_check_types:forms(Forms)).
 
-check_test() ->
+forms_test() ->
     RufusText = "
     package example
 
@@ -16,9 +16,9 @@ check_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    ?assertEqual({ok, Forms}, rufus_return_type:check(Forms)).
+    ?assertEqual({ok, Forms}, rufus_check_types:forms(Forms)).
 
-check_function_with_unmatched_return_type_test() ->
+forms_with_function_having_unmatched_return_types_test() ->
     RufusText = "
     package example
 
@@ -26,4 +26,4 @@ check_function_with_unmatched_return_type_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {error, unmatched_return_type, _Data} = rufus_return_type:check(Forms).
+    {error, unmatched_return_type, _Data} = rufus_check_types:forms(Forms).


### PR DESCRIPTION
`rufus_return_type` is renamed to `rufus_check_types`, to be more consistent with other modules. Also, `check/1` is renamed to `forms/1` to be more consistent with other modules.