### PR TITLE
compiler: Add support for bool type and bool literals

### DIFF
--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -14,6 +14,9 @@ forms(RufusForms) ->
 
 %% Private API
 
+forms(Acc, [{expr, LineNumber, {bool, Value}}|T]) ->
+    Form = {clause, LineNumber, [], [], [box({bool, LineNumber, Value})]},
+    forms([Form|Acc], T);
 forms(Acc, [{expr, LineNumber, {float, Value}}|T]) ->
     Form = {clause, LineNumber, [], [], [box({float, LineNumber, Value})]},
     forms([Form|Acc], T);
@@ -39,6 +42,8 @@ forms(Acc, []) ->
 %% turning `3.14159265359` into `{float, 3.14159265359}`, for example.
 box(Expr = {bin, LineNumber, _Value}) ->
     {tuple, LineNumber, [{atom, LineNumber, string}, Expr]};
+box({bool, LineNumber, Value}) ->
+    {tuple, LineNumber, [{atom, LineNumber, bool}, {atom, LineNumber, Value}]};
 box(Expr = {float, LineNumber, _Value}) ->
     {tuple, LineNumber, [{atom, LineNumber, float}, Expr]};
 box(Expr = {integer, LineNumber, _Value}) ->

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 26).
 
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
@@ -222,18 +222,22 @@ yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -307,18 +311,20 @@ yeccpars2_10(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
-yeccpars2_11(S, float, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_11(S, bool, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_11(S, float, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, string, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
+yeccpars2_11(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_12/7}).
 yeccpars2_12(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 17, Ss, Stack, T, Ts, Tzr);
 yeccpars2_12(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -334,25 +340,27 @@ yeccpars2_15(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_15_(Stack),
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_16/7}).
-yeccpars2_16(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
-yeccpars2_16(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
-yeccpars2_16(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
-yeccpars2_16(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_16(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_16_(Stack),
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_17/7}).
-yeccpars2_17(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_17(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
+yeccpars2_17(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
+yeccpars2_17(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 21, Ss, Stack, T, Ts, Tzr);
+yeccpars2_17(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 22, Ss, Stack, T, Ts, Tzr);
 yeccpars2_17(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_18_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_18/7}).
+yeccpars2_18(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 23, Ss, Stack, T, Ts, Tzr);
+yeccpars2_18(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_19_(Stack),
@@ -363,13 +371,21 @@ yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_21_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_22_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_23(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_23_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_24_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_declaration/7}).
@@ -379,8 +395,8 @@ yeccgoto_declaration(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expression/7}).
-yeccgoto_expression(16, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_17(17, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_expression(17, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(18, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -392,7 +408,7 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(11, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -427,7 +443,7 @@ yeccpars2_8_(__Stack0) ->
 yeccpars2_13_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { float , token_line ( __1 ) }
+   { bool , token_line ( __1 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_14_/1}).
@@ -435,7 +451,7 @@ yeccpars2_13_(__Stack0) ->
 yeccpars2_14_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { int , token_line ( __1 ) }
+   { float , token_line ( __1 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
@@ -443,15 +459,15 @@ yeccpars2_14_(__Stack0) ->
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { string , token_line ( __1 ) }
+   { int , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 16).
-yeccpars2_18_(__Stack0) ->
+-compile({inline,yeccpars2_16_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
+yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
+   { string , token_line ( __1 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
@@ -459,7 +475,7 @@ yeccpars2_18_(__Stack0) ->
 yeccpars2_19_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
+   [ { expr , token_line ( __1 ) , { bool , token_chars ( __1 ) } } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
@@ -467,24 +483,40 @@ yeccpars2_19_(__Stack0) ->
 yeccpars2_20_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
+   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_21_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
 yeccpars2_21_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_22_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
+yeccpars2_22_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_23_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
+yeccpars2_23_(__Stack0) ->
  [__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { func , token_line ( __1 ) , token_chars ( __2 ) , [ ] , token_type ( __5 ) , __7 }
   end | __Stack].
 
--compile({inline,yeccpars2_22_/1}).
+-compile({inline,yeccpars2_24_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 4).
-yeccpars2_22_(__Stack0) ->
+yeccpars2_24_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 36).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 38).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,6 +1,6 @@
 Nonterminals declaration expression function root type.
 
-Terminals '(' ')' '{' '}' func identifier import package float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' func identifier import package bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
@@ -13,10 +13,12 @@ declaration -> function : '$1'.
 
 function -> func identifier '(' ')' type '{' expression '}' : {func, token_line('$1'), token_chars('$2'), [], token_type('$5'), '$7'}.
 
+type -> bool : {bool, token_line('$1')}.
 type -> float : {float, token_line('$1')}.
 type -> int : {int, token_line('$1')}.
 type -> string : {string, token_line('$1')}.
 
+expression -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
 expression -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
 expression -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
 expression -> string_lit : [{expr, token_line('$1'), {string, token_chars('$1')}}].

--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -12,7 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 64).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 65).
 
 strip(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
@@ -309,714 +309,766 @@ adjust_line(T, A, [_|Cs], L) ->
 %% input.
 
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.erl", 310).
-yystate() -> 54.
+yystate() -> 58.
 
-yystate(61, [97|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 20, Tlen);
-yystate(61, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(61, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,61};
-yystate(60, [110|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(60, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,60};
-yystate(59, [46|Ics], Line, Tlen, _, _) ->
-    yystate(57, Ics, Line, Tlen+1, 11, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(59, Ics, Line, Tlen+1, 11, Tlen);
-yystate(59, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,59};
-yystate(58, [32|Ics], Line, Tlen, _, _) ->
-    yystate(58, Ics, Line, Tlen+1, 0, Tlen);
-yystate(58, [9|Ics], Line, Tlen, _, _) ->
-    yystate(58, Ics, Line, Tlen+1, 0, Tlen);
-yystate(58, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,58};
-yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,57};
-yystate(56, [99|Ics], Line, Tlen, _, _) ->
-    yystate(48, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [97|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [98|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(56, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,56};
-yystate(55, [99|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [97|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [98|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(55, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,55};
-yystate(54, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(38, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [113|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [112|Ics], Line, Tlen, Action, Alen) ->
-    yystate(61, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [105|Ics], Line, Tlen, Action, Alen) ->
-    yystate(7, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [103|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(52, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(11, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(51, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(25, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [44|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [43|Ics], Line, Tlen, Action, Alen) ->
-    yystate(9, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(2, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(10, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(58, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(50, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(54, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(58, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(59, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 111 ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(54, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,54};
-yystate(53, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 5, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
-yystate(53, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,53};
-yystate(52, [117|Ics], Line, Tlen, _, _) ->
-    yystate(60, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [108|Ics], Line, Tlen, _, _) ->
-    yystate(40, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [97|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(52, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,52};
-yystate(51, Ics, Line, Tlen, _, _) ->
-    {18,Tlen,Ics,Line};
-yystate(50, [10|Ics], Line, Tlen, _, _) ->
-    yystate(50, Ics, Line+1, Tlen+1, 1, Tlen);
-yystate(50, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,50};
-yystate(49, [45|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(49, [43|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(49, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,49};
-yystate(48, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 8, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
-yystate(48, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line,48};
-yystate(47, [107|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(47, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,47};
-yystate(46, Ics, Line, Tlen, _, _) ->
-    {16,Tlen,Ics,Line};
-yystate(45, [103|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(45, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,45};
-yystate(44, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 7, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
-yystate(44, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,44};
-yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 2, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
-yystate(43, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line,43};
-yystate(42, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(34, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(42, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,42};
-yystate(41, [101|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, [69|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, [45|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, [43|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(41, Ics, Line, Tlen+1, 10, Tlen);
-yystate(41, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,41};
-yystate(40, [111|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(40, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,40};
-yystate(39, [97|Ics], Line, Tlen, _, _) ->
-    yystate(31, Ics, Line, Tlen+1, 20, Tlen);
-yystate(39, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(39, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,39};
-yystate(38, Ics, Line, Tlen, _, _) ->
-    {15,Tlen,Ics,Line};
-yystate(37, [110|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(37, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,37};
-yystate(36, [116|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(36, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,36};
-yystate(35, [116|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(35, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,35};
-yystate(34, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line};
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
-yystate(33, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,33};
-yystate(32, [97|Ics], Line, Tlen, _, _) ->
-    yystate(24, Ics, Line, Tlen+1, 20, Tlen);
-yystate(32, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(32, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,32};
-yystate(31, [103|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(31, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,31};
-yystate(30, [114|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(30, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,30};
-yystate(29, [105|Ics], Line, Tlen, _, _) ->
-    yystate(37, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(29, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,29};
-yystate(28, [114|Ics], Line, Tlen, _, _) ->
-    yystate(36, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(28, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,28};
-yystate(27, [115|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(27, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,27};
-yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(26, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,26};
-yystate(25, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(59, Ics, Line, Tlen+1, Action, Alen);
-yystate(25, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,25};
-yystate(24, [116|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(24, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,24};
-yystate(23, [101|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(23, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,23};
-yystate(22, [117|Ics], Line, Tlen, _, _) ->
-    yystate(14, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(22, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,22};
-yystate(21, [114|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(21, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,21};
-yystate(20, [111|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(20, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,20};
-yystate(19, [110|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(19, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,19};
-yystate(18, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,18};
-yystate(17, Ics, Line, Tlen, _, _) ->
-    {17,Tlen,Ics,Line};
-yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 3, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
-yystate(16, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line,16};
-yystate(15, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 6, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
-yystate(15, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,15};
-yystate(14, [101|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(14, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,14};
-yystate(13, [116|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(13, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,13};
-yystate(12, [112|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(12, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,12};
-yystate(11, [111|Ics], Line, Tlen, _, _) ->
-    yystate(19, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(11, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,11};
-yystate(10, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(18, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(10, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,10};
-yystate(9, Ics, Line, Tlen, _, _) ->
+yystate(65, [99|Ics], Line, Tlen, _, _) ->
+    yystate(59, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [97|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [98|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(65, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,65};
+yystate(64, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 9, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+yystate(64, Ics, Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,64};
+yystate(63, Ics, Line, Tlen, _, _) ->
     {19,Tlen,Ics,Line};
-yystate(8, [108|Ics], Line, Tlen, _, _) ->
-    yystate(0, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(8, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,8};
-yystate(7, [110|Ics], Line, Tlen, _, _) ->
-    yystate(3, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [109|Ics], Line, Tlen, _, _) ->
-    yystate(12, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(7, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,7};
-yystate(6, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 9, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
-yystate(6, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,6};
-yystate(5, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line};
-yystate(4, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 4, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
-yystate(4, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,4};
-yystate(3, [116|Ics], Line, Tlen, _, _) ->
-    yystate(4, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(3, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,3};
-yystate(2, Ics, Line, Tlen, _, _) ->
+yystate(62, [32|Ics], Line, Tlen, _, _) ->
+    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
+yystate(62, [9|Ics], Line, Tlen, _, _) ->
+    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
+yystate(62, Ics, Line, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,62};
+yystate(61, [46|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line, Tlen+1, 12, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(61, Ics, Line, Tlen+1, 12, Tlen);
+yystate(61, Ics, Line, Tlen, _, _) ->
+    {12,Tlen,Ics,Line,61};
+yystate(60, [111|Ics], Line, Tlen, _, _) ->
+    yystate(52, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(60, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,60};
+yystate(59, [107|Ics], Line, Tlen, _, _) ->
+    yystate(51, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(59, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,59};
+yystate(58, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(50, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [123|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(34, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(9, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [113|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [114|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [112|Ics], Line, Tlen, Action, Alen) ->
+    yystate(57, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [105|Ics], Line, Tlen, Action, Alen) ->
+    yystate(19, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [103|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [104|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(40, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [100|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [99|Ics], Line, Tlen, Action, Alen) ->
+    yystate(8, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [98|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(63, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(1, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(6, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(14, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(62, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(54, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(58, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(62, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(61, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 111 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,58};
+yystate(57, [97|Ics], Line, Tlen, _, _) ->
+    yystate(65, Ics, Line, Tlen+1, 21, Tlen);
+yystate(57, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(57, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,57};
+yystate(56, [99|Ics], Line, Tlen, _, _) ->
+    yystate(64, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [97|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [98|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(56, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,56};
+yystate(55, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 2, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+yystate(55, Ics, Line, Tlen, _, _) ->
+    {2,Tlen,Ics,Line,55};
+yystate(54, [10|Ics], Line, Tlen, _, _) ->
+    yystate(54, Ics, Line+1, Tlen+1, 1, Tlen);
+yystate(54, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,54};
+yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(37, Ics, Line, Tlen+1, Action, Alen);
+yystate(53, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,53};
+yystate(52, [97|Ics], Line, Tlen, _, _) ->
+    yystate(44, Ics, Line, Tlen+1, 21, Tlen);
+yystate(52, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(52, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,52};
+yystate(51, [97|Ics], Line, Tlen, _, _) ->
+    yystate(43, Ics, Line, Tlen+1, 21, Tlen);
+yystate(51, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(51, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,51};
+yystate(50, Ics, Line, Tlen, _, _) ->
+    {17,Tlen,Ics,Line};
+yystate(49, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 6, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+yystate(49, Ics, Line, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,49};
+yystate(48, [110|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(48, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,48};
+yystate(47, [108|Ics], Line, Tlen, _, _) ->
+    yystate(55, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(47, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,47};
+yystate(46, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(38, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(46, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,46};
+yystate(45, [45|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(45, [43|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(45, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,45};
+yystate(44, [116|Ics], Line, Tlen, _, _) ->
+    yystate(36, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(44, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,44};
+yystate(43, [103|Ics], Line, Tlen, _, _) ->
+    yystate(35, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(43, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,43};
+yystate(42, Ics, Line, Tlen, _, _) ->
+    {16,Tlen,Ics,Line};
+yystate(41, [103|Ics], Line, Tlen, _, _) ->
+    yystate(49, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(41, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,41};
+yystate(40, [117|Ics], Line, Tlen, _, _) ->
+    yystate(48, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [108|Ics], Line, Tlen, _, _) ->
+    yystate(60, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [97|Ics], Line, Tlen, _, _) ->
+    yystate(28, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(40, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,40};
+yystate(39, [111|Ics], Line, Tlen, _, _) ->
+    yystate(47, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(39, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,39};
+yystate(38, Ics, Line, Tlen, _, _) ->
     {13,Tlen,Ics,Line};
-yystate(1, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(18, Ics, Line, Tlen+1, Action, Alen);
-yystate(1, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,1};
-yystate(0, [115|Ics], Line, Tlen, _, _) ->
-    yystate(14, Ics, Line, Tlen+1, 20, Tlen);
+yystate(37, [101|Ics], Line, Tlen, _, _) ->
+    yystate(45, Ics, Line, Tlen+1, 11, Tlen);
+yystate(37, [69|Ics], Line, Tlen, _, _) ->
+    yystate(45, Ics, Line, Tlen+1, 11, Tlen);
+yystate(37, [45|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(37, [43|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(37, Ics, Line, Tlen+1, 11, Tlen);
+yystate(37, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,37};
+yystate(36, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 4, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+yystate(36, Ics, Line, Tlen, _, _) ->
+    {4,Tlen,Ics,Line,36};
+yystate(35, [101|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(35, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,35};
+yystate(34, [114|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(34, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,34};
+yystate(33, [110|Ics], Line, Tlen, _, _) ->
+    yystate(41, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(33, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,33};
+yystate(32, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 8, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+yystate(32, Ics, Line, Tlen, _, _) ->
+    {8,Tlen,Ics,Line,32};
+yystate(31, [111|Ics], Line, Tlen, _, _) ->
+    yystate(39, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(31, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,31};
+yystate(30, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(30, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,30};
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+yystate(29, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,29};
+yystate(28, [108|Ics], Line, Tlen, _, _) ->
+    yystate(20, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(28, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,28};
+yystate(27, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 7, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+yystate(27, Ics, Line, Tlen, _, _) ->
+    {7,Tlen,Ics,Line,27};
+yystate(26, [117|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(26, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,26};
+yystate(25, [105|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(25, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,25};
+yystate(24, [116|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(24, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,24};
+yystate(23, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 3, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
+yystate(23, Ics, Line, Tlen, _, _) ->
+    {3,Tlen,Ics,Line,23};
+yystate(22, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,22};
+yystate(21, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(61, Ics, Line, Tlen+1, Action, Alen);
+yystate(21, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,21};
+yystate(20, [115|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(20, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,20};
+yystate(19, [110|Ics], Line, Tlen, _, _) ->
+    yystate(11, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [109|Ics], Line, Tlen, _, _) ->
+    yystate(4, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(19, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,19};
+yystate(18, [101|Ics], Line, Tlen, _, _) ->
+    yystate(10, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(18, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,18};
+yystate(17, [114|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(17, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,17};
+yystate(16, [114|Ics], Line, Tlen, _, _) ->
+    yystate(24, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(16, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,16};
+yystate(15, [116|Ics], Line, Tlen, _, _) ->
+    yystate(23, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(15, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,15};
+yystate(14, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(14, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,14};
+yystate(13, Ics, Line, Tlen, _, _) ->
+    {18,Tlen,Ics,Line};
+yystate(12, [111|Ics], Line, Tlen, _, _) ->
+    yystate(16, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(12, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,12};
+yystate(11, [116|Ics], Line, Tlen, _, _) ->
+    yystate(3, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(11, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,11};
+yystate(10, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+yystate(10, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,10};
+yystate(9, [116|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(9, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,9};
+yystate(8, [111|Ics], Line, Tlen, _, _) ->
+    yystate(0, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(8, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,8};
+yystate(7, [115|Ics], Line, Tlen, _, _) ->
+    yystate(15, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(7, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,7};
+yystate(6, Ics, Line, Tlen, _, _) ->
+    {14,Tlen,Ics,Line};
+yystate(5, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line};
+yystate(4, [112|Ics], Line, Tlen, _, _) ->
+    yystate(12, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(4, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,4};
+yystate(3, [34|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 5, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+yystate(3, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,3};
+yystate(2, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(2, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,2};
+yystate(1, Ics, Line, Tlen, _, _) ->
+    {15,Tlen,Ics,Line};
+yystate(0, [110|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 21, Tlen);
 yystate(0, [34|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
 yystate(0, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,0};
+    {21,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -1042,9 +1094,8 @@ yyaction(7, _, _, TokenLine) ->
     yyaction_7(TokenLine);
 yyaction(8, _, _, TokenLine) ->
     yyaction_8(TokenLine);
-yyaction(9, TokenLen, YYtcs, TokenLine) ->
-    TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_9(TokenChars, TokenLine);
+yyaction(9, _, _, TokenLine) ->
+    yyaction_9(TokenLine);
 yyaction(10, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_10(TokenChars, TokenLine);
@@ -1053,9 +1104,10 @@ yyaction(11, TokenLen, YYtcs, TokenLine) ->
     yyaction_11(TokenChars, TokenLine);
 yyaction(12, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_12(TokenChars, TokenLen, TokenLine);
-yyaction(13, _, _, TokenLine) ->
-    yyaction_13(TokenLine);
+    yyaction_12(TokenChars, TokenLine);
+yyaction(13, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_13(TokenChars, TokenLen, TokenLine);
 yyaction(14, _, _, TokenLine) ->
     yyaction_14(TokenLine);
 yyaction(15, _, _, TokenLine) ->
@@ -1068,9 +1120,11 @@ yyaction(18, _, _, TokenLine) ->
     yyaction_18(TokenLine);
 yyaction(19, _, _, TokenLine) ->
     yyaction_19(TokenLine);
-yyaction(20, TokenLen, YYtcs, TokenLine) ->
+yyaction(20, _, _, TokenLine) ->
+    yyaction_20(TokenLine);
+yyaction(21, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_20(TokenChars, TokenLine);
+    yyaction_21(TokenChars, TokenLine);
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/0}).
@@ -1086,97 +1140,102 @@ yyaction_1() ->
 -compile({inline,yyaction_2/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 38).
 yyaction_2(TokenLine) ->
-     { token, { const, TokenLine } } .
+     { token, { bool, TokenLine } } .
 
 -compile({inline,yyaction_3/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 39).
 yyaction_3(TokenLine) ->
-     { token, { float, TokenLine } } .
+     { token, { const, TokenLine } } .
 
 -compile({inline,yyaction_4/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 40).
 yyaction_4(TokenLine) ->
-     { token, { int, TokenLine } } .
+     { token, { float, TokenLine } } .
 
 -compile({inline,yyaction_5/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 41).
 yyaction_5(TokenLine) ->
-     { token, { string, TokenLine } } .
+     { token, { int, TokenLine } } .
 
 -compile({inline,yyaction_6/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 43).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 42).
 yyaction_6(TokenLine) ->
-     { token, { package, TokenLine } } .
+     { token, { string, TokenLine } } .
 
 -compile({inline,yyaction_7/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 44).
 yyaction_7(TokenLine) ->
-     { token, { import, TokenLine } } .
+     { token, { package, TokenLine } } .
 
 -compile({inline,yyaction_8/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
 yyaction_8(TokenLine) ->
-     { token, { func, TokenLine } } .
+     { token, { import, TokenLine } } .
 
--compile({inline,yyaction_9/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 47).
-yyaction_9(TokenChars, TokenLine) ->
-     { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
+-compile({inline,yyaction_9/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 46).
+yyaction_9(TokenLine) ->
+     { token, { func, TokenLine } } .
 
 -compile({inline,yyaction_10/2}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 48).
 yyaction_10(TokenChars, TokenLine) ->
-     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+     { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
 
 -compile({inline,yyaction_11/2}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 49).
 yyaction_11(TokenChars, TokenLine) ->
+     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+
+-compile({inline,yyaction_12/2}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
+yyaction_12(TokenChars, TokenLine) ->
      { token, { int_lit, TokenLine, list_to_integer (TokenChars) } } .
 
--compile({inline,yyaction_12/3}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
-yyaction_12(TokenChars, TokenLen, TokenLine) ->
+-compile({inline,yyaction_13/3}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 51).
+yyaction_13(TokenChars, TokenLen, TokenLine) ->
      S = strip (TokenChars, TokenLen),
      { token, { string_lit, TokenLine, S } } .
-
--compile({inline,yyaction_13/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 53).
-yyaction_13(TokenLine) ->
-     { token, { '(', TokenLine } } .
 
 -compile({inline,yyaction_14/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 54).
 yyaction_14(TokenLine) ->
-     { token, { ')', TokenLine } } .
+     { token, { '(', TokenLine } } .
 
 -compile({inline,yyaction_15/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 55).
 yyaction_15(TokenLine) ->
-     { token, { '{', TokenLine } } .
+     { token, { ')', TokenLine } } .
 
 -compile({inline,yyaction_16/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 56).
 yyaction_16(TokenLine) ->
-     { token, { '}', TokenLine } } .
+     { token, { '{', TokenLine } } .
 
 -compile({inline,yyaction_17/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 57).
 yyaction_17(TokenLine) ->
-     { token, { ',', TokenLine } } .
+     { token, { '}', TokenLine } } .
 
 -compile({inline,yyaction_18/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 58).
 yyaction_18(TokenLine) ->
-     { token, { '=', TokenLine } } .
+     { token, { ',', TokenLine } } .
 
 -compile({inline,yyaction_19/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 59).
 yyaction_19(TokenLine) ->
+     { token, { '=', TokenLine } } .
+
+-compile({inline,yyaction_20/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 60).
+yyaction_20(TokenLine) ->
      { token, { '+', TokenLine } } .
 
--compile({inline,yyaction_20/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 60).
-yyaction_20(TokenChars, TokenLine) ->
+-compile({inline,yyaction_21/2}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 61).
+yyaction_21(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
 -file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -12,7 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 61).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 64).
 
 strip(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
@@ -309,630 +309,714 @@ adjust_line(T, A, [_|Cs], L) ->
 %% input.
 
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.erl", 310).
-yystate() -> 48.
+yystate() -> 54.
 
-yystate(55, [45|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
-yystate(55, [43|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
-yystate(55, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,55};
-yystate(54, [99|Ics], Line, Tlen, _, _) ->
-    yystate(46, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [97|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [98|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(54, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,54};
-yystate(53, [97|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 19, Tlen);
-yystate(53, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(53, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,53};
-yystate(52, [32|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 0, Tlen);
-yystate(52, [9|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 0, Tlen);
-yystate(52, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,52};
-yystate(51, [107|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(51, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,51};
-yystate(50, [110|Ics], Line, Tlen, _, _) ->
-    yystate(54, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(50, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,50};
-yystate(49, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(47, Ics, Line, Tlen+1, Action, Alen);
-yystate(49, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,49};
-yystate(48, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(40, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [113|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [112|Ics], Line, Tlen, Action, Alen) ->
-    yystate(35, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [105|Ics], Line, Tlen, Action, Alen) ->
-    yystate(21, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [103|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [44|Ics], Line, Tlen, Action, Alen) ->
-    yystate(27, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [43|Ics], Line, Tlen, Action, Alen) ->
-    yystate(19, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(11, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(3, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(4, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(52, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(44, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(48, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(52, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+yystate(61, [97|Ics], Line, Tlen, _, _) ->
+    yystate(55, Ics, Line, Tlen+1, 20, Tlen);
+yystate(61, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(61, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,61};
+yystate(60, [110|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(60, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,60};
+yystate(59, [46|Ics], Line, Tlen, _, _) ->
+    yystate(57, Ics, Line, Tlen+1, 11, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(59, Ics, Line, Tlen+1, 11, Tlen);
+yystate(59, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,59};
+yystate(58, [32|Ics], Line, Tlen, _, _) ->
+    yystate(58, Ics, Line, Tlen+1, 0, Tlen);
+yystate(58, [9|Ics], Line, Tlen, _, _) ->
+    yystate(58, Ics, Line, Tlen+1, 0, Tlen);
+yystate(58, Ics, Line, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,58};
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
     yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 111 ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 116, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,48};
-yystate(47, [101|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 9, Tlen);
-yystate(47, [69|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 9, Tlen);
-yystate(47, [45|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
-yystate(47, [43|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
+yystate(57, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,57};
+yystate(56, [99|Ics], Line, Tlen, _, _) ->
+    yystate(48, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [97|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [98|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(56, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,56};
+yystate(55, [99|Ics], Line, Tlen, _, _) ->
+    yystate(47, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [97|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [98|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(55, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,55};
+yystate(54, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [123|Ics], Line, Tlen, Action, Alen) ->
+    yystate(38, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [113|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [114|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [112|Ics], Line, Tlen, Action, Alen) ->
+    yystate(61, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [105|Ics], Line, Tlen, Action, Alen) ->
+    yystate(7, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [103|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [104|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(52, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [100|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [99|Ics], Line, Tlen, Action, Alen) ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [98|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(51, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(25, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(17, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(9, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(2, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(50, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(54, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(59, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 111 ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,54};
+yystate(53, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 5, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 5, Tlen);
+yystate(53, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,53};
+yystate(52, [117|Ics], Line, Tlen, _, _) ->
+    yystate(60, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [108|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [97|Ics], Line, Tlen, _, _) ->
+    yystate(8, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(52, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,52};
+yystate(51, Ics, Line, Tlen, _, _) ->
+    {18,Tlen,Ics,Line};
+yystate(50, [10|Ics], Line, Tlen, _, _) ->
+    yystate(50, Ics, Line+1, Tlen+1, 1, Tlen);
+yystate(50, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,50};
+yystate(49, [45|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [43|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(49, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,49};
+yystate(48, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 8, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 8, Tlen);
+yystate(48, Ics, Line, Tlen, _, _) ->
+    {8,Tlen,Ics,Line,48};
+yystate(47, [107|Ics], Line, Tlen, _, _) ->
+    yystate(39, Ics, Line, Tlen+1, 20, Tlen);
+yystate(47, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(47, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(47, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,47};
-yystate(46, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 8, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 8, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 8, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 8, Tlen);
+    {20,Tlen,Ics,Line,47};
 yystate(46, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line,46};
+    {16,Tlen,Ics,Line};
 yystate(45, [103|Ics], Line, Tlen, _, _) ->
-    yystate(37, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(53, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(45, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,45};
-yystate(44, [10|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line+1, Tlen+1, 1, Tlen);
+    {20,Tlen,Ics,Line,45};
+yystate(44, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 7, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 7, Tlen);
 yystate(44, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,44};
-yystate(43, [99|Ics], Line, Tlen, _, _) ->
-    yystate(51, Ics, Line, Tlen+1, 19, Tlen);
-yystate(43, [97|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(43, [98|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    {7,Tlen,Ics,Line,44};
 yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 2, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 2, Tlen);
 yystate(43, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,43};
-yystate(42, [117|Ics], Line, Tlen, _, _) ->
-    yystate(50, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [108|Ics], Line, Tlen, _, _) ->
-    yystate(38, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(42, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,42};
-yystate(41, [46|Ics], Line, Tlen, _, _) ->
+    {2,Tlen,Ics,Line,43};
+yystate(42, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(34, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(42, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,42};
+yystate(41, [101|Ics], Line, Tlen, _, _) ->
     yystate(49, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [69|Ics], Line, Tlen, _, _) ->
+    yystate(49, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [45|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(41, [43|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(41, Ics, Line, Tlen+1, 10, Tlen);
 yystate(41, Ics, Line, Tlen, _, _) ->
     {10,Tlen,Ics,Line,41};
+yystate(40, [111|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 20, Tlen);
+yystate(40, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(40, Ics, Line, Tlen, _, _) ->
-    {15,Tlen,Ics,Line};
+    {20,Tlen,Ics,Line,40};
+yystate(39, [97|Ics], Line, Tlen, _, _) ->
+    yystate(31, Ics, Line, Tlen+1, 20, Tlen);
+yystate(39, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(39, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(39, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,39};
-yystate(38, [111|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 19, Tlen);
-yystate(38, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    {20,Tlen,Ics,Line,39};
 yystate(38, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,38};
-yystate(37, [101|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 19, Tlen);
+    {15,Tlen,Ics,Line};
+yystate(37, [110|Ics], Line, Tlen, _, _) ->
+    yystate(45, Ics, Line, Tlen+1, 20, Tlen);
 yystate(37, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(37, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,37};
-yystate(36, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(28, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(36, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,36};
-yystate(35, [97|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 19, Tlen);
+    {20,Tlen,Ics,Line,37};
+yystate(36, [116|Ics], Line, Tlen, _, _) ->
+    yystate(44, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(36, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,36};
+yystate(35, [116|Ics], Line, Tlen, _, _) ->
+    yystate(43, Ics, Line, Tlen+1, 20, Tlen);
 yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(35, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,35};
-yystate(34, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 7, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 7, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 7, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 7, Tlen);
+    {20,Tlen,Ics,Line,35};
 yystate(34, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,34};
-yystate(33, Ics, Line, Tlen, _, _) ->
-    {17,Tlen,Ics,Line};
-yystate(32, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line};
-yystate(31, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(31, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,31};
-yystate(30, [97|Ics], Line, Tlen, _, _) ->
-    yystate(22, Ics, Line, Tlen+1, 19, Tlen);
-yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(30, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,30};
-yystate(29, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 6, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 6, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 6, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 6, Tlen);
-yystate(29, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,29};
-yystate(28, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line};
-yystate(27, Ics, Line, Tlen, _, _) ->
-    {16,Tlen,Ics,Line};
-yystate(26, [116|Ics], Line, Tlen, _, _) ->
-    yystate(34, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(26, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,26};
-yystate(25, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 2, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 2, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 2, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 2, Tlen);
-yystate(25, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line,25};
-yystate(24, [116|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(24, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,24};
-yystate(23, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(23, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,23};
-yystate(22, [116|Ics], Line, Tlen, _, _) ->
-    yystate(14, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(22, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,22};
-yystate(21, [110|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [109|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(21, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,21};
-yystate(20, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(20, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,20};
-yystate(19, Ics, Line, Tlen, _, _) ->
-    {18,Tlen,Ics,Line};
-yystate(18, [114|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(18, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,18};
-yystate(17, [116|Ics], Line, Tlen, _, _) ->
-    yystate(25, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(17, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,17};
-yystate(16, [114|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(16, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,16};
-yystate(15, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 5, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 5, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 5, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 5, Tlen);
-yystate(15, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,15};
-yystate(14, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 3, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 3, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 3, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 3, Tlen);
-yystate(14, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line,14};
-yystate(13, [116|Ics], Line, Tlen, _, _) ->
-    yystate(5, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(13, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,13};
-yystate(12, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,12};
-yystate(11, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line};
-yystate(10, [111|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(10, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,10};
-yystate(9, [115|Ics], Line, Tlen, _, _) ->
-    yystate(17, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(9, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,9};
-yystate(8, [105|Ics], Line, Tlen, _, _) ->
-    yystate(0, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(8, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,8};
-yystate(7, [103|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(7, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,7};
-yystate(6, [111|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(6, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,6};
-yystate(5, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 4, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 4, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 4, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 4, Tlen);
-yystate(5, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,5};
-yystate(4, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(4, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,4};
-yystate(3, Ics, Line, Tlen, _, _) ->
     {12,Tlen,Ics,Line};
-yystate(2, [112|Ics], Line, Tlen, _, _) ->
-    yystate(10, Ics, Line, Tlen+1, 19, Tlen);
-yystate(2, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(33, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,33};
+yystate(32, [97|Ics], Line, Tlen, _, _) ->
+    yystate(24, Ics, Line, Tlen+1, 20, Tlen);
+yystate(32, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(32, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,32};
+yystate(31, [103|Ics], Line, Tlen, _, _) ->
+    yystate(23, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(31, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,31};
+yystate(30, [114|Ics], Line, Tlen, _, _) ->
+    yystate(22, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(30, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,30};
+yystate(29, [105|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(29, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,29};
+yystate(28, [114|Ics], Line, Tlen, _, _) ->
+    yystate(36, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(28, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,28};
+yystate(27, [115|Ics], Line, Tlen, _, _) ->
+    yystate(35, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(27, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,27};
+yystate(26, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(26, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,26};
+yystate(25, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(59, Ics, Line, Tlen+1, Action, Alen);
+yystate(25, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,25};
+yystate(24, [116|Ics], Line, Tlen, _, _) ->
+    yystate(16, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(24, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,24};
+yystate(23, [101|Ics], Line, Tlen, _, _) ->
+    yystate(15, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(23, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,23};
+yystate(22, [117|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(22, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,22};
+yystate(21, [114|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(21, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,21};
+yystate(20, [111|Ics], Line, Tlen, _, _) ->
+    yystate(28, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(20, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,20};
+yystate(19, [110|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(19, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,19};
+yystate(18, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(18, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,18};
+yystate(17, Ics, Line, Tlen, _, _) ->
+    {17,Tlen,Ics,Line};
+yystate(16, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 3, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 3, Tlen);
+yystate(16, Ics, Line, Tlen, _, _) ->
+    {3,Tlen,Ics,Line,16};
+yystate(15, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 6, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 6, Tlen);
+yystate(15, Ics, Line, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,15};
+yystate(14, [101|Ics], Line, Tlen, _, _) ->
+    yystate(6, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(14, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,14};
+yystate(13, [116|Ics], Line, Tlen, _, _) ->
+    yystate(21, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(13, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,13};
+yystate(12, [112|Ics], Line, Tlen, _, _) ->
+    yystate(20, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(12, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,12};
+yystate(11, [111|Ics], Line, Tlen, _, _) ->
+    yystate(19, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(11, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,11};
+yystate(10, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(18, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(10, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,10};
+yystate(9, Ics, Line, Tlen, _, _) ->
+    {19,Tlen,Ics,Line};
+yystate(8, [108|Ics], Line, Tlen, _, _) ->
+    yystate(0, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(8, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,8};
+yystate(7, [110|Ics], Line, Tlen, _, _) ->
+    yystate(3, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [109|Ics], Line, Tlen, _, _) ->
+    yystate(12, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(7, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,7};
+yystate(6, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 9, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 9, Tlen);
+yystate(6, Ics, Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,6};
+yystate(5, Ics, Line, Tlen, _, _) ->
+    {14,Tlen,Ics,Line};
+yystate(4, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 4, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 4, Tlen);
+yystate(4, Ics, Line, Tlen, _, _) ->
+    {4,Tlen,Ics,Line,4};
+yystate(3, [116|Ics], Line, Tlen, _, _) ->
+    yystate(4, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(3, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line,3};
 yystate(2, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,2};
-yystate(1, [110|Ics], Line, Tlen, _, _) ->
-    yystate(9, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(1, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,1};
-yystate(0, [110|Ics], Line, Tlen, _, _) ->
-    yystate(7, Ics, Line, Tlen+1, 19, Tlen);
+    {13,Tlen,Ics,Line};
+yystate(1, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(18, Ics, Line, Tlen+1, Action, Alen);
+yystate(1, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,1};
+yystate(0, [115|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 20, Tlen);
 yystate(0, [34|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 20, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(20, Ics, Line, Tlen+1, 19, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(26, Ics, Line, Tlen+1, 20, Tlen);
 yystate(0, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line,0};
+    {20,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -966,9 +1050,10 @@ yyaction(10, TokenLen, YYtcs, TokenLine) ->
     yyaction_10(TokenChars, TokenLine);
 yyaction(11, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_11(TokenChars, TokenLen, TokenLine);
-yyaction(12, _, _, TokenLine) ->
-    yyaction_12(TokenLine);
+    yyaction_11(TokenChars, TokenLine);
+yyaction(12, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_12(TokenChars, TokenLen, TokenLine);
 yyaction(13, _, _, TokenLine) ->
     yyaction_13(TokenLine);
 yyaction(14, _, _, TokenLine) ->
@@ -981,110 +1066,117 @@ yyaction(17, _, _, TokenLine) ->
     yyaction_17(TokenLine);
 yyaction(18, _, _, TokenLine) ->
     yyaction_18(TokenLine);
-yyaction(19, TokenLen, YYtcs, TokenLine) ->
+yyaction(19, _, _, TokenLine) ->
+    yyaction_19(TokenLine);
+yyaction(20, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_19(TokenChars, TokenLine);
+    yyaction_20(TokenChars, TokenLine);
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/0}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 33).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 35).
 yyaction_0() ->
      skip_token .
 
 -compile({inline,yyaction_1/0}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 34).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 36).
 yyaction_1() ->
      skip_token .
 
 -compile({inline,yyaction_2/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 36).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 38).
 yyaction_2(TokenLine) ->
      { token, { const, TokenLine } } .
 
 -compile({inline,yyaction_3/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 37).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 39).
 yyaction_3(TokenLine) ->
      { token, { float, TokenLine } } .
 
 -compile({inline,yyaction_4/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 38).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 40).
 yyaction_4(TokenLine) ->
      { token, { int, TokenLine } } .
 
 -compile({inline,yyaction_5/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 39).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 41).
 yyaction_5(TokenLine) ->
      { token, { string, TokenLine } } .
 
 -compile({inline,yyaction_6/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 41).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 43).
 yyaction_6(TokenLine) ->
      { token, { package, TokenLine } } .
 
 -compile({inline,yyaction_7/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 42).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 44).
 yyaction_7(TokenLine) ->
      { token, { import, TokenLine } } .
 
 -compile({inline,yyaction_8/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 43).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
 yyaction_8(TokenLine) ->
      { token, { func, TokenLine } } .
 
 -compile({inline,yyaction_9/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 47).
 yyaction_9(TokenChars, TokenLine) ->
-     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+     { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
 
 -compile({inline,yyaction_10/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 46).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 48).
 yyaction_10(TokenChars, TokenLine) ->
+     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+
+-compile({inline,yyaction_11/2}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 49).
+yyaction_11(TokenChars, TokenLine) ->
      { token, { int_lit, TokenLine, list_to_integer (TokenChars) } } .
 
--compile({inline,yyaction_11/3}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 47).
-yyaction_11(TokenChars, TokenLen, TokenLine) ->
+-compile({inline,yyaction_12/3}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
+yyaction_12(TokenChars, TokenLen, TokenLine) ->
      S = strip (TokenChars, TokenLen),
      { token, { string_lit, TokenLine, S } } .
 
--compile({inline,yyaction_12/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
-yyaction_12(TokenLine) ->
+-compile({inline,yyaction_13/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 53).
+yyaction_13(TokenLine) ->
      { token, { '(', TokenLine } } .
 
--compile({inline,yyaction_13/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 51).
-yyaction_13(TokenLine) ->
+-compile({inline,yyaction_14/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 54).
+yyaction_14(TokenLine) ->
      { token, { ')', TokenLine } } .
 
--compile({inline,yyaction_14/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 52).
-yyaction_14(TokenLine) ->
+-compile({inline,yyaction_15/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 55).
+yyaction_15(TokenLine) ->
      { token, { '{', TokenLine } } .
 
--compile({inline,yyaction_15/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 53).
-yyaction_15(TokenLine) ->
+-compile({inline,yyaction_16/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 56).
+yyaction_16(TokenLine) ->
      { token, { '}', TokenLine } } .
 
--compile({inline,yyaction_16/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 54).
-yyaction_16(TokenLine) ->
+-compile({inline,yyaction_17/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 57).
+yyaction_17(TokenLine) ->
      { token, { ',', TokenLine } } .
 
--compile({inline,yyaction_17/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 55).
-yyaction_17(TokenLine) ->
+-compile({inline,yyaction_18/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 58).
+yyaction_18(TokenLine) ->
      { token, { '=', TokenLine } } .
 
--compile({inline,yyaction_18/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 56).
-yyaction_18(TokenLine) ->
+-compile({inline,yyaction_19/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 59).
+yyaction_19(TokenLine) ->
      { token, { '+', TokenLine } } .
 
--compile({inline,yyaction_19/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 57).
-yyaction_19(TokenChars, TokenLine) ->
+-compile({inline,yyaction_20/2}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 60).
+yyaction_20(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
 -file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/src/rufus_scan.xrl
+++ b/rf/src/rufus_scan.xrl
@@ -37,6 +37,7 @@ Rules.
 {Whitespace}+   : skip_token.
 {Newline}+      : skip_token.
 
+{BoolType}      : {token, {bool, TokenLine}}.
 {ConstType}     : {token, {const, TokenLine}}.
 {FloatType}     : {token, {float, TokenLine}}.
 {IntType}       : {token, {int, TokenLine}}.

--- a/rf/src/rufus_scan.xrl
+++ b/rf/src/rufus_scan.xrl
@@ -12,6 +12,7 @@ RightParen    = \)
 LeftBrace     = \{
 RightBrace    = \}
 
+BoolType      = bool
 ConstType     = const
 FloatType     = float
 IntType       = int
@@ -21,6 +22,7 @@ Package       = package
 Import        = import
 Func          = func
 
+BoolLiteral   = (true|false)
 Exponent      = (e|E)?(\+|\-)?{Digit}+
 FloatLiteral  = \-?{Digit}+\.{Digit}+{Exponent}?
 IntLiteral    = \-?{Digit}+
@@ -44,6 +46,7 @@ Rules.
 {Import}        : {token, {import, TokenLine}}.
 {Func}          : {token, {func, TokenLine}}.
 
+{BoolLiteral}   : {token, {bool_lit, TokenLine, list_to_atom(TokenChars)}}.
 {FloatLiteral}  : {token, {float_lit, TokenLine, list_to_float(TokenChars)}}.
 {IntLiteral}    : {token, {int_lit, TokenLine, list_to_integer(TokenChars)}}.
 {StringLiteral} : S = strip(TokenChars, TokenLen),

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -2,6 +2,23 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+forms_for_function_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func False() bool { false }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    BoolExpr = {atom, 3, false},
+    BoxedBoolExpr = {tuple, 3, [{atom, 3, bool}, BoolExpr]},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'False', 0}]},
+        {function, 3, 'False', 0, [{clause, 3, [], [], [BoxedBoolExpr]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
 forms_for_function_returning_a_float_test() ->
     RufusText = "
     package example

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -13,8 +13,16 @@ eval_chain_with_error_handler_test() ->
     Error = fun(_) -> {error, reason} end,
     Explode = fun(_) -> throw(explode) end,
     %% Explode never runs because eval_chain stops iterating over handlers when
-    %% it encounters an error.
+    %% it encounters a failure from Error.
     ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
+
+eval_with_function_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func True() bool { true }
+    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual({bool, true}, example:'True'()).
 
 eval_with_function_returning_a_float_test() ->
     RufusText = "

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -5,20 +5,53 @@
 parse_empty_package_test() ->
     {ok, Tokens, _} = rufus_scan:string("package empty"),
     {ok, AST} = rufus_parse:parse(Tokens),
-    [
+    ?assertEqual([
      {package, 1, "empty"}
-    ] = AST.
+    ], AST).
+
+parse_function_returning_a_bool_test() ->
+    {ok, Tokens, _} = rufus_scan:string("
+     package example
+     func True() bool { true }
+    "),
+    {ok, AST} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
+    ], AST).
+
+parse_function_returning_a_float_test() ->
+    {ok, Tokens, _} = rufus_scan:string("
+     package math
+     func Pi() float { 3.14159265359 }
+    "),
+    {ok, AST} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "math"},
+     {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
+    ], AST).
 
 parse_function_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string("
      package rand
-     func Int() int { 42 }
+     func Number() int { 42 }
     "),
     {ok, AST} = rufus_parse:parse(Tokens),
-    [
+    ?assertEqual([
      {package, 2, "rand"},
-     {func, 3, "Int", [], int, [{expr,3,{int,42}}]}
-    ] = AST.
+     {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
+    ], AST).
+
+parse_function_returning_a_string_test() ->
+    {ok, Tokens, _} = rufus_scan:string("
+     package example
+     func Greeting() string { \"Hello\" }
+    "),
+    {ok, AST} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
+    ], AST).
 
 parse_import_test() ->
     {ok, Tokens, _} = rufus_scan:string("
@@ -26,7 +59,7 @@ package foo
 import \"bar\"
 "),
     {ok, AST} = rufus_parse:parse(Tokens),
-    [
+    ?assertEqual([
      {package, 2, "foo"},
      {import, 3, "bar"}
-    ] = AST.
+    ], AST).

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -25,7 +25,7 @@ string_with_import_test() ->
 
 %% Const
 
-string_with_false_bool_test() ->
+string_with_false_bool_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Bool = false"),
     ?assertEqual([
      {const, 1},
@@ -34,7 +34,7 @@ string_with_false_bool_test() ->
      {bool_lit, 1, false}
     ], Tokens).
 
-string_with_true_bool_test() ->
+string_with_true_bool_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Bool = true"),
     ?assertEqual([
      {const, 1},
@@ -43,7 +43,7 @@ string_with_true_bool_test() ->
      {bool_lit, 1, true}
     ], Tokens).
 
-string_with_float_test() ->
+string_with_float_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Float = 3.1415"),
     ?assertEqual([
      {const, 1},
@@ -52,7 +52,7 @@ string_with_float_test() ->
      {float_lit, 1, 3.1415}
     ], Tokens).
 
-string_with_negative_float_test() ->
+string_with_negative_float_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloat = -3.1415"),
     ?assertEqual([
      {const, 1},
@@ -61,7 +61,7 @@ string_with_negative_float_test() ->
      {float_lit, 1, -3.1415}
     ], Tokens).
 
-string_with_float_with_positive_exponent_test() ->
+string_with_float_with_positive_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const FloatWithPositiveExponent = 4.0e+2"),
     ?assertEqual([
      {const, 1},
@@ -70,7 +70,7 @@ string_with_float_with_positive_exponent_test() ->
      {float_lit, 1, 4.0e+2}
     ], Tokens).
 
-string_with_negative_float_with_positive_exponent_test() ->
+string_with_negative_float_with_positive_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloatWithPositiveExponent = -4.0e+2"),
     ?assertEqual([
      {const, 1},
@@ -79,7 +79,7 @@ string_with_negative_float_with_positive_exponent_test() ->
      {float_lit, 1, -4.0e+2}
     ], Tokens).
 
-string_with_float_with_negative_exponent_test() ->
+string_with_float_with_negative_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const FloatWithNegativeExponent = 48.0e-2"),
     ?assertEqual([
      {const, 1},
@@ -88,7 +88,7 @@ string_with_float_with_negative_exponent_test() ->
      {float_lit, 1, 48.0e-2}
     ], Tokens).
 
-string_with_negative_float_with_negative_exponent_test() ->
+string_with_negative_float_with_negative_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloatWithNegativeExponent = -48.0e-2"),
     ?assertEqual([
      {const, 1},
@@ -97,7 +97,7 @@ string_with_negative_float_with_negative_exponent_test() ->
      {float_lit, 1, -48.0e-2}
     ], Tokens).
 
-string_with_int_test() ->
+string_with_int_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Int = 1"),
     ?assertEqual([
      {const, 1},
@@ -106,7 +106,7 @@ string_with_int_test() ->
      {int_lit, 1, 1}
     ], Tokens).
 
-string_with_negative_int_test() ->
+string_with_negative_int_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeInt = -1"),
     ?assertEqual([
      {const, 1},
@@ -115,7 +115,7 @@ string_with_negative_int_test() ->
      {int_lit, 1, -1}
     ], Tokens).
 
-string_with_string_test() ->
+string_with_string_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Name = \"Rufus\""),
     ?assertEqual([
      {const, 1},
@@ -124,7 +124,7 @@ string_with_string_test() ->
      {string_lit, 1, "Rufus"}
     ], Tokens).
 
-string_with_string_containing_number_test() ->
+string_with_string_containing_number_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Number = \"42\""),
     ?assertEqual([
      {const, 1},
@@ -133,7 +133,7 @@ string_with_string_containing_number_test() ->
      {string_lit, 1, "42"}
     ], Tokens).
 
-string_with_string_containing_whitespace_test() ->
+string_with_string_containing_whitespace_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Whitespace = \"hello world\""),
     ?assertEqual([
      {const, 1},
@@ -147,11 +147,24 @@ string_with_string_containing_whitespace_test() ->
 
 %% Functions
 
-string_with_function_returning_a_float_test() ->
-    {ok, Tokens, _} = rufus_scan:string("func number42() float { 42.0 }"),
+string_with_function_returning_a_bool_test() ->
+    {ok, Tokens, _} = rufus_scan:string("func False() bool { false }"),
     ?assertEqual([
      {func, 1},
-     {identifier, 1, "number42"},
+     {identifier, 1, "False"},
+     {'(', 1},
+     {')', 1},
+     {bool, 1},
+     {'{', 1},
+     {bool_lit, 1, false},
+     {'}', 1}
+    ], Tokens).
+
+string_with_function_returning_a_float_test() ->
+    {ok, Tokens, _} = rufus_scan:string("func number() float { 42.0 }"),
+    ?assertEqual([
+     {func, 1},
+     {identifier, 1, "number"},
      {'(', 1},
      {')', 1},
      {float, 1},
@@ -161,10 +174,10 @@ string_with_function_returning_a_float_test() ->
     ], Tokens).
 
 string_with_function_returning_an_int_test() ->
-    {ok, Tokens, _} = rufus_scan:string("func number42() int { 42 }"),
+    {ok, Tokens, _} = rufus_scan:string("func number() int { 42 }"),
     ?assertEqual([
      {func, 1},
-     {identifier, 1, "number42"},
+     {identifier, 1, "number"},
      {'(', 1},
      {')', 1},
      {int, 1},
@@ -174,10 +187,10 @@ string_with_function_returning_an_int_test() ->
     ], Tokens).
 
 string_with_function_returning_a_string_test() ->
-    {ok, Tokens, _} = rufus_scan:string("func text42() string { \"42\" }"),
+    {ok, Tokens, _} = rufus_scan:string("func text() string { \"42\" }"),
     ?assertEqual([
      {func, 1},
-     {identifier, 1, "text42"},
+     {identifier, 1, "text"},
      {'(', 1},
      {')', 1},
      {string, 1},
@@ -188,13 +201,13 @@ string_with_function_returning_a_string_test() ->
 
 string_with_multiline_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_scan:string("
-func text42() string {
+func text() string {
     \"42\"
 }
 "),
     ?assertEqual([
      {func, 2},
-     {identifier, 2, "text42"},
+     {identifier, 2, "text"},
      {'(', 2},
      {')', 2},
      {string, 2},
@@ -219,10 +232,10 @@ string_with_function_takes_an_int_and_returning_an_int_test() ->
     ], Tokens).
 
 string_with_function_tokes_an_int_and_a_string_and_returning_a_float_test() ->
-    {ok, Tokens, _} = rufus_scan:string("func float42(n int, s string) float { 42.0 }"),
+    {ok, Tokens, _} = rufus_scan:string("func number(n int, s string) float { 42.0 }"),
     ?assertEqual([
      {func, 1},
-     {identifier, 1, "float42"},
+     {identifier, 1, "number"},
      {'(', 1},
      {identifier, 1, "n"},
      {int, 1},

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -6,123 +6,141 @@
 
 string_with_empty_package_test() ->
     {ok, Tokens, _} = rufus_scan:string("package empty"),
-    [
+    ?assertEqual([
      {package, 1},
      {identifier, 1, "empty"}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_import_test() ->
     {ok, Tokens, _} = rufus_scan:string("
      package foo
      import \"bar\"
     "),
-    [
+    ?assertEqual([
      {package, 2},
      {identifier, 2, "foo"},
      {import, 3},
      {string_lit, 3, "bar"}
-    ] = Tokens.
+    ], Tokens).
 
 %% Const
 
+string_with_false_bool_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const Bool = false"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "Bool"},
+     {'=', 1},
+     {bool_lit, 1, false}
+    ], Tokens).
+
+string_with_true_bool_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const Bool = true"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "Bool"},
+     {'=', 1},
+     {bool_lit, 1, true}
+    ], Tokens).
+
 string_with_float_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Float = 3.1415"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "Float"},
      {'=', 1},
      {float_lit, 1, 3.1415}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_negative_float_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloat = -3.1415"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "NegativeFloat"},
      {'=', 1},
      {float_lit, 1, -3.1415}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_float_with_positive_exponent_test() ->
     {ok, Tokens, _} = rufus_scan:string("const FloatWithPositiveExponent = 4.0e+2"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "FloatWithPositiveExponent"},
      {'=', 1},
      {float_lit, 1, 4.0e+2}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_negative_float_with_positive_exponent_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloatWithPositiveExponent = -4.0e+2"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "NegativeFloatWithPositiveExponent"},
      {'=', 1},
      {float_lit, 1, -4.0e+2}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_float_with_negative_exponent_test() ->
     {ok, Tokens, _} = rufus_scan:string("const FloatWithNegativeExponent = 48.0e-2"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "FloatWithNegativeExponent"},
      {'=', 1},
      {float_lit, 1, 48.0e-2}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_negative_float_with_negative_exponent_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeFloatWithNegativeExponent = -48.0e-2"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "NegativeFloatWithNegativeExponent"},
      {'=', 1},
      {float_lit, 1, -48.0e-2}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_int_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Int = 1"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "Int"},
      {'=', 1},
      {int_lit, 1, 1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_negative_int_test() ->
     {ok, Tokens, _} = rufus_scan:string("const NegativeInt = -1"),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "NegativeInt"},
      {'=', 1},
      {int_lit, 1, -1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_string_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Name = \"Rufus\""),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "Name"},
      {'=', 1},
      {string_lit, 1, "Rufus"}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_string_containing_number_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Number = \"42\""),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "Number"},
      {'=', 1},
      {string_lit, 1, "42"}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_string_containing_whitespace_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Whitespace = \"hello world\""),
-    [
+    ?assertEqual([
      {const, 1},
      {identifier, 1, "Whitespace"},
      {'=', 1},
      {string_lit, 1, "hello world"}
-    ] = Tokens.
+    ], Tokens).
 
 % string_with_string_containing_punctuation_test
 % string_with_string_containing_multibyte_utf8_character_test
@@ -131,7 +149,7 @@ string_with_string_containing_whitespace_test() ->
 
 string_with_function_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_scan:string("func number42() float { 42.0 }"),
-    [
+    ?assertEqual([
      {func, 1},
      {identifier, 1, "number42"},
      {'(', 1},
@@ -140,11 +158,11 @@ string_with_function_returning_a_float_test() ->
      {'{', 1},
      {float_lit, 1, 42.0},
      {'}', 1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_function_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string("func number42() int { 42 }"),
-    [
+    ?assertEqual([
      {func, 1},
      {identifier, 1, "number42"},
      {'(', 1},
@@ -153,11 +171,11 @@ string_with_function_returning_an_int_test() ->
      {'{', 1},
      {int_lit, 1, 42},
      {'}', 1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_scan:string("func text42() string { \"42\" }"),
-    [
+    ?assertEqual([
      {func, 1},
      {identifier, 1, "text42"},
      {'(', 1},
@@ -166,7 +184,7 @@ string_with_function_returning_a_string_test() ->
      {'{', 1},
      {string_lit, 1, "42"},
      {'}', 1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_multiline_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_scan:string("
@@ -174,7 +192,7 @@ func text42() string {
     \"42\"
 }
 "),
-    [
+    ?assertEqual([
      {func, 2},
      {identifier, 2, "text42"},
      {'(', 2},
@@ -183,11 +201,11 @@ func text42() string {
      {'{', 2},
      {string_lit, 3, "42"},
      {'}', 4}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_function_takes_an_int_and_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string("func echo(n int) int { n }"),
-    [
+    ?assertEqual([
      {func, 1},
      {identifier, 1, "echo"},
      {'(', 1},
@@ -198,11 +216,11 @@ string_with_function_takes_an_int_and_returning_an_int_test() ->
      {'{', 1},
      {identifier, 1, "n"},
      {'}', 1}
-    ] = Tokens.
+    ], Tokens).
 
 string_with_function_tokes_an_int_and_a_string_and_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_scan:string("func float42(n int, s string) float { 42.0 }"),
-    [
+    ?assertEqual([
      {func, 1},
      {identifier, 1, "float42"},
      {'(', 1},
@@ -216,7 +234,7 @@ string_with_function_tokes_an_int_and_a_string_and_returning_a_float_test() ->
      {'{', 1},
      {float_lit, 1, 42.0},
      {'}', 1}
-    ] = Tokens.
+    ], Tokens).
 
 %% string_with_function_takes_an_unused_argument_test() ->
 %%     {ok, Tokens, _} = rufus_scan:string("func unused(_ int) int { 0 }")


### PR DESCRIPTION
`rufus_scan.xrl` and `rufus_parse.yrl` both have support for parsing a `bool` type with `true` and `false` literals. `rufus_compile` and `rufus_compile_erlang` can compile and run simple functions that return `bool` values.