### PR TITLE
compiler: Tokenize unary minus operator in input source

### DIFF
--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -12,7 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 65).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 67).
 
 strip(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
@@ -312,21 +312,21 @@ adjust_line(T, A, [_|Cs], L) ->
 yystate() -> 58.
 
 yystate(65, [99|Ics], Line, Tlen, _, _) ->
-    yystate(59, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(59, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [97|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [98|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(65, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,65};
+    {22,Tlen,Ics,Line,65};
 yystate(64, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 9, Tlen);
 yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -352,33 +352,33 @@ yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
 yystate(61, Ics, Line, Tlen, _, _) ->
     {12,Tlen,Ics,Line,61};
 yystate(60, [111|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(52, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(60, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,60};
+    {22,Tlen,Ics,Line,60};
 yystate(59, [107|Ics], Line, Tlen, _, _) ->
-    yystate(51, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(51, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(59, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,59};
+    {22,Tlen,Ics,Line,59};
 yystate(58, [125|Ics], Line, Tlen, Action, Alen) ->
     yystate(50, Ics, Line, Tlen+1, Action, Alen);
 yystate(58, [123|Ics], Line, Tlen, Action, Alen) ->
@@ -442,33 +442,33 @@ yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
 yystate(58, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,58};
 yystate(57, [97|Ics], Line, Tlen, _, _) ->
-    yystate(65, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(65, Ics, Line, Tlen+1, 22, Tlen);
 yystate(57, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(57, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,57};
+    {22,Tlen,Ics,Line,57};
 yystate(56, [99|Ics], Line, Tlen, _, _) ->
-    yystate(64, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(64, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [97|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [98|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,56};
+    {22,Tlen,Ics,Line,56};
 yystate(55, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 2, Tlen);
 yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -488,29 +488,29 @@ yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
 yystate(53, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,53};
 yystate(52, [97|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(44, Ics, Line, Tlen+1, 22, Tlen);
 yystate(52, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(52, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,52};
+    {22,Tlen,Ics,Line,52};
 yystate(51, [97|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(43, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,51};
+    {22,Tlen,Ics,Line,51};
 yystate(50, Ics, Line, Tlen, _, _) ->
     {17,Tlen,Ics,Line};
 yystate(49, [34|Ics], Line, Tlen, _, _) ->
@@ -524,33 +524,33 @@ yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
 yystate(49, Ics, Line, Tlen, _, _) ->
     {6,Tlen,Ics,Line,49};
 yystate(48, [110|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(56, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,48};
+    {22,Tlen,Ics,Line,48};
 yystate(47, [108|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(55, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,47};
+    {22,Tlen,Ics,Line,47};
 yystate(46, [34|Ics], Line, Tlen, Action, Alen) ->
     yystate(38, Ics, Line, Tlen+1, Action, Alen);
 yystate(46, [32|Ics], Line, Tlen, Action, Alen) ->
@@ -574,83 +574,83 @@ yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
 yystate(45, Ics, Line, Tlen, _, _) ->
     {11,Tlen,Ics,Line,45};
 yystate(44, [116|Ics], Line, Tlen, _, _) ->
-    yystate(36, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(36, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,44};
+    {22,Tlen,Ics,Line,44};
 yystate(43, [103|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(35, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,43};
+    {22,Tlen,Ics,Line,43};
 yystate(42, Ics, Line, Tlen, _, _) ->
     {16,Tlen,Ics,Line};
 yystate(41, [103|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(49, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(41, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,41};
+    {22,Tlen,Ics,Line,41};
 yystate(40, [117|Ics], Line, Tlen, _, _) ->
-    yystate(48, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(48, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [108|Ics], Line, Tlen, _, _) ->
-    yystate(60, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(60, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [97|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(28, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,40};
+    {22,Tlen,Ics,Line,40};
 yystate(39, [111|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(47, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,39};
+    {22,Tlen,Ics,Line,39};
 yystate(38, Ics, Line, Tlen, _, _) ->
     {13,Tlen,Ics,Line};
 yystate(37, [101|Ics], Line, Tlen, _, _) ->
@@ -676,47 +676,47 @@ yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
 yystate(36, Ics, Line, Tlen, _, _) ->
     {4,Tlen,Ics,Line,36};
 yystate(35, [101|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(27, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,35};
+    {22,Tlen,Ics,Line,35};
 yystate(34, [114|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(26, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,34};
+    {22,Tlen,Ics,Line,34};
 yystate(33, [110|Ics], Line, Tlen, _, _) ->
-    yystate(41, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(41, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,33};
+    {22,Tlen,Ics,Line,33};
 yystate(32, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 8, Tlen);
 yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -728,47 +728,47 @@ yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
 yystate(32, Ics, Line, Tlen, _, _) ->
     {8,Tlen,Ics,Line,32};
 yystate(31, [111|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(39, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,31};
+    {22,Tlen,Ics,Line,31};
 yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(30, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,30};
+    {22,Tlen,Ics,Line,30};
 yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
     yystate(29, Ics, Line, Tlen+1, 11, Tlen);
 yystate(29, Ics, Line, Tlen, _, _) ->
     {11,Tlen,Ics,Line,29};
 yystate(28, [108|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(20, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,28};
+    {22,Tlen,Ics,Line,28};
 yystate(27, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 7, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -780,47 +780,47 @@ yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
 yystate(27, Ics, Line, Tlen, _, _) ->
     {7,Tlen,Ics,Line,27};
 yystate(26, [117|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(18, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,26};
+    {22,Tlen,Ics,Line,26};
 yystate(25, [105|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(33, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,25};
+    {22,Tlen,Ics,Line,25};
 yystate(24, [116|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(32, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,24};
+    {22,Tlen,Ics,Line,24};
 yystate(23, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 3, Tlen);
 yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -835,96 +835,96 @@ yystate(22, [34|Ics], Line, Tlen, Action, Alen) ->
     yystate(30, Ics, Line, Tlen+1, Action, Alen);
 yystate(22, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,22};
-yystate(21, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(61, Ics, Line, Tlen+1, Action, Alen);
-yystate(21, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,21};
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(61, Ics, Line, Tlen+1, 21, Tlen);
+yystate(21, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,21};
 yystate(20, [115|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(18, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(20, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,20};
+    {22,Tlen,Ics,Line,20};
 yystate(19, [110|Ics], Line, Tlen, _, _) ->
-    yystate(11, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(11, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [109|Ics], Line, Tlen, _, _) ->
-    yystate(4, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(4, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,19};
+    {22,Tlen,Ics,Line,19};
 yystate(18, [101|Ics], Line, Tlen, _, _) ->
-    yystate(10, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(10, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,18};
+    {22,Tlen,Ics,Line,18};
 yystate(17, [114|Ics], Line, Tlen, _, _) ->
-    yystate(25, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(25, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,17};
+    {22,Tlen,Ics,Line,17};
 yystate(16, [114|Ics], Line, Tlen, _, _) ->
-    yystate(24, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(24, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,16};
+    {22,Tlen,Ics,Line,16};
 yystate(15, [116|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(23, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,15};
+    {22,Tlen,Ics,Line,15};
 yystate(14, [95|Ics], Line, Tlen, Action, Alen) ->
     yystate(22, Ics, Line, Tlen+1, Action, Alen);
 yystate(14, [32|Ics], Line, Tlen, Action, Alen) ->
@@ -942,33 +942,33 @@ yystate(14, Ics, Line, Tlen, Action, Alen) ->
 yystate(13, Ics, Line, Tlen, _, _) ->
     {18,Tlen,Ics,Line};
 yystate(12, [111|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(16, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,12};
+    {22,Tlen,Ics,Line,12};
 yystate(11, [116|Ics], Line, Tlen, _, _) ->
-    yystate(3, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(3, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,11};
+    {22,Tlen,Ics,Line,11};
 yystate(10, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 10, Tlen);
 yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -980,65 +980,67 @@ yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
 yystate(10, Ics, Line, Tlen, _, _) ->
     {10,Tlen,Ics,Line,10};
 yystate(9, [116|Ics], Line, Tlen, _, _) ->
-    yystate(17, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(17, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(9, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,9};
+    {22,Tlen,Ics,Line,9};
 yystate(8, [111|Ics], Line, Tlen, _, _) ->
-    yystate(0, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(0, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(8, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,8};
+    {22,Tlen,Ics,Line,8};
 yystate(7, [115|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(15, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,7};
+    {22,Tlen,Ics,Line,7};
 yystate(6, Ics, Line, Tlen, _, _) ->
     {14,Tlen,Ics,Line};
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(61, Ics, Line, Tlen+1, 20, Tlen);
 yystate(5, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line};
+    {20,Tlen,Ics,Line,5};
 yystate(4, [112|Ics], Line, Tlen, _, _) ->
-    yystate(12, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(12, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,4};
+    {22,Tlen,Ics,Line,4};
 yystate(3, [34|Ics], Line, Tlen, _, _) ->
     yystate(2, Ics, Line, Tlen+1, 5, Tlen);
 yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
@@ -1056,19 +1058,19 @@ yystate(2, Ics, Line, Tlen, Action, Alen) ->
 yystate(1, Ics, Line, Tlen, _, _) ->
     {15,Tlen,Ics,Line};
 yystate(0, [110|Ics], Line, Tlen, _, _) ->
-    yystate(7, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,0};
+    {22,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -1122,120 +1124,127 @@ yyaction(19, _, _, TokenLine) ->
     yyaction_19(TokenLine);
 yyaction(20, _, _, TokenLine) ->
     yyaction_20(TokenLine);
-yyaction(21, TokenLen, YYtcs, TokenLine) ->
+yyaction(21, _, _, TokenLine) ->
+    yyaction_21(TokenLine);
+yyaction(22, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_21(TokenChars, TokenLine);
+    yyaction_22(TokenChars, TokenLine);
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/0}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 35).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 36).
 yyaction_0() ->
      skip_token .
 
 -compile({inline,yyaction_1/0}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 36).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 37).
 yyaction_1() ->
      skip_token .
 
 -compile({inline,yyaction_2/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 38).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 39).
 yyaction_2(TokenLine) ->
      { token, { bool, TokenLine } } .
 
 -compile({inline,yyaction_3/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 39).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 40).
 yyaction_3(TokenLine) ->
      { token, { const, TokenLine } } .
 
 -compile({inline,yyaction_4/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 40).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 41).
 yyaction_4(TokenLine) ->
      { token, { float, TokenLine } } .
 
 -compile({inline,yyaction_5/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 41).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 42).
 yyaction_5(TokenLine) ->
      { token, { int, TokenLine } } .
 
 -compile({inline,yyaction_6/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 42).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 43).
 yyaction_6(TokenLine) ->
      { token, { string, TokenLine } } .
 
 -compile({inline,yyaction_7/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 44).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
 yyaction_7(TokenLine) ->
      { token, { package, TokenLine } } .
 
 -compile({inline,yyaction_8/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 46).
 yyaction_8(TokenLine) ->
      { token, { import, TokenLine } } .
 
 -compile({inline,yyaction_9/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 46).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 47).
 yyaction_9(TokenLine) ->
      { token, { func, TokenLine } } .
 
 -compile({inline,yyaction_10/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 48).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 49).
 yyaction_10(TokenChars, TokenLine) ->
      { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
 
 -compile({inline,yyaction_11/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 49).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
 yyaction_11(TokenChars, TokenLine) ->
      { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
 
 -compile({inline,yyaction_12/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 50).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 51).
 yyaction_12(TokenChars, TokenLine) ->
      { token, { int_lit, TokenLine, list_to_integer (TokenChars) } } .
 
 -compile({inline,yyaction_13/3}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 51).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 52).
 yyaction_13(TokenChars, TokenLen, TokenLine) ->
      S = strip (TokenChars, TokenLen),
      { token, { string_lit, TokenLine, S } } .
 
 -compile({inline,yyaction_14/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 54).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 55).
 yyaction_14(TokenLine) ->
      { token, { '(', TokenLine } } .
 
 -compile({inline,yyaction_15/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 55).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 56).
 yyaction_15(TokenLine) ->
      { token, { ')', TokenLine } } .
 
 -compile({inline,yyaction_16/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 56).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 57).
 yyaction_16(TokenLine) ->
      { token, { '{', TokenLine } } .
 
 -compile({inline,yyaction_17/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 57).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 58).
 yyaction_17(TokenLine) ->
      { token, { '}', TokenLine } } .
 
 -compile({inline,yyaction_18/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 58).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 59).
 yyaction_18(TokenLine) ->
      { token, { ',', TokenLine } } .
 
 -compile({inline,yyaction_19/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 59).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 60).
 yyaction_19(TokenLine) ->
      { token, { '=', TokenLine } } .
 
 -compile({inline,yyaction_20/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 60).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 61).
 yyaction_20(TokenLine) ->
      { token, { '+', TokenLine } } .
 
--compile({inline,yyaction_21/2}).
--file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 61).
-yyaction_21(TokenChars, TokenLine) ->
+-compile({inline,yyaction_21/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 62).
+yyaction_21(TokenLine) ->
+     { token, { '-', TokenLine } } .
+
+-compile({inline,yyaction_22/2}).
+-file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 63).
+yyaction_22(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
 -file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/src/rufus_scan.xrl
+++ b/rf/src/rufus_scan.xrl
@@ -24,13 +24,14 @@ Func          = func
 
 BoolLiteral   = (true|false)
 Exponent      = (e|E)?(\+|\-)?{Digit}+
-FloatLiteral  = \-?{Digit}+\.{Digit}+{Exponent}?
-IntLiteral    = \-?{Digit}+
+FloatLiteral  = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
+IntLiteral    = (\+|\-)?{Digit}+
 StringLiteral = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
 
 Comma         = ,
 Match         = =
 Plus          = \+
+Minus         = \-
 
 Rules.
 
@@ -60,6 +61,7 @@ Rules.
 {Comma}         : {token, {',', TokenLine}}.
 {Match}         : {token, {'=', TokenLine}}.
 {Plus}          : {token, {'+', TokenLine}}.
+{Minus}         : {token, {'-', TokenLine}}.
 {Identifier}    : {token, {identifier, TokenLine, TokenChars}}.
 
 Erlang code.

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -61,6 +61,15 @@ string_with_negative_float_literal_test() ->
      {float_lit, 1, -3.1415}
     ], Tokens).
 
+string_with_positive_float_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const PositiveFloat = +3.1415"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "PositiveFloat"},
+     {'=', 1},
+     {float_lit, 1, 3.1415}
+    ], Tokens).
+
 string_with_float_with_positive_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const FloatWithPositiveExponent = 4.0e+2"),
     ?assertEqual([
@@ -77,6 +86,15 @@ string_with_negative_float_with_positive_exponent_literal_test() ->
      {identifier, 1, "NegativeFloatWithPositiveExponent"},
      {'=', 1},
      {float_lit, 1, -4.0e+2}
+    ], Tokens).
+
+string_with_positive_float_with_positive_exponent_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const PositiveFloatWithPositiveExponent = +4.0e+2"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "PositiveFloatWithPositiveExponent"},
+     {'=', 1},
+     {float_lit, 1, 4.0e+2}
     ], Tokens).
 
 string_with_float_with_negative_exponent_literal_test() ->
@@ -97,6 +115,15 @@ string_with_negative_float_with_negative_exponent_literal_test() ->
      {float_lit, 1, -48.0e-2}
     ], Tokens).
 
+string_with_positive_float_with_negative_exponent_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const PositiveFloatWithNegativeExponent = +48.0e-2"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "PositiveFloatWithNegativeExponent"},
+     {'=', 1},
+     {float_lit, 1, 48.0e-2}
+    ], Tokens).
+
 string_with_int_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Int = 1"),
     ?assertEqual([
@@ -113,6 +140,15 @@ string_with_negative_int_literal_test() ->
      {identifier, 1, "NegativeInt"},
      {'=', 1},
      {int_lit, 1, -1}
+    ], Tokens).
+
+string_with_positive_int_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const PositiveInt = +1"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "PositiveInt"},
+     {'=', 1},
+     {int_lit, 1, 1}
     ], Tokens).
 
 string_with_string_literal_test() ->


### PR DESCRIPTION
The scanner has early support for unary `+` and unary `-` operators. Positive `float` and `int` literals like `+42.6` and `+17` are now allowed, in addition to their negative counterparts, such as `-89.3` and `-9`.