### PR TITLE
compiler: Parse and generate code for basic arity 1 functions

### DIFF
--- a/rf/src/rf.app.src
+++ b/rf/src/rf.app.src
@@ -1,6 +1,6 @@
 {application, rf,
  [{description, "rf provides tools for working with Rufus"},
-  {vsn, "0.1.0"},
+  {vsn, "0.0.1"},
   {registered, []},
   {applications,
    [

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -12,10 +12,12 @@ main(Args) ->
     ExitCode = case Args of
         ["compile"|SubArgs] ->
             compile(SubArgs);
-        ["compile:parse"|SubArgs] ->
-            parse(SubArgs);
-        ["compile:scan"|SubArgs] ->
-            scan(SubArgs);
+        ["debug:erlang-forms"|SubArgs] ->
+            debug_erlang_forms(SubArgs);
+        ["debug:parse"|SubArgs] ->
+            debug_parse(SubArgs);
+        ["debug:scan"|SubArgs] ->
+            debug_scan(SubArgs);
         ["version"|SubArgs] ->
             version(SubArgs);
         _ ->
@@ -26,6 +28,15 @@ main(Args) ->
 
 %% Private API
 
+help(["help", "debug:erlang-forms"]) ->
+    io:format("Usage:~n"),
+    io:format("~n"),
+    io:format("    rf debug:erlang-forms FILE~n"),
+    io:format("~n"),
+    io:format("Read Erlang source code from a file and print it to the screen as Erlang~n"),
+    io:format("abstract forms.~n"),
+    io:format("~n"),
+    0;
 help(_Args) ->
     io:format("rf provides tools for working with Rufus programs.~n"),
     io:format("~n"),
@@ -35,10 +46,11 @@ help(_Args) ->
     io:format("~n"),
     io:format("The commands are:~n"),
     io:format("~n"),
-    io:format("    compile        Compile source code and then run it and print its output~n"),
-    io:format("    compile:parse  Parse source code and print parse forms~n"),
-    io:format("    compile:scan   Scan source code and print parse tokens~n"),
-    io:format("    version        Print Rufus version~n"),
+    io:format("    compile             Compile source code and then run it and print its output~n"),
+    io:format("    debug:erlang-forms  Print Erlang source code from a file as abstract forms~n"),
+    io:format("    debug:parse         Parse source code and print parse forms~n"),
+    io:format("    debug:scan          Scan source code and print parse tokens~n"),
+    io:format("    version             Print Rufus version~n"),
     io:format("~n"),
     io:format("Use \"rf help [command]\" for more information about that command~n"),
     io:format("~n"),
@@ -53,14 +65,43 @@ help(_Args) ->
 version(_Args) ->
     case application:get_key(rf, vsn) of
         {ok, Version} ->
-            io:format("rufus version v~s~n", [Version]),
+            io:format("Rufus v~s~n", [Version]),
             0;
         Error ->
             io:format("Error: ~p~n", [Error]),
             -1
     end.
 
-parse(_Args) ->
+
+compile(_Args) ->
+    RufusText ="
+    package example
+
+    func Number() int {
+        42
+    }
+",
+    io:format("RufusText =>~n    ~s~n", [RufusText]),
+    {ok, example} = rufus_compile:eval(RufusText),
+    io:format("example:Number() =>~n~n    ~p~n", [example:'Number'()]),
+    0.
+
+debug_erlang_forms(Args) ->
+    [Filename] = Args,
+    {ok, BinaryContents} = file:read_file(Filename),
+    io:format("ErlangText =>~n~n~s~n", [binary_to_list(BinaryContents)]),
+    Tokens = scan(erl_scan:tokens([], binary_to_list(BinaryContents), 1), []),
+    Parse = fun(X) -> {ok,Y} = erl_parse:parse_form(X), Y end,
+    Forms = [Parse(X) || X <- Tokens],
+    io:format("ErlangForms =>~n~n    ~p~n", [Forms]),
+    0.
+
+scan({done, {ok, Token, Line}, CharSpec}, Rest) ->
+    scan(erl_scan:tokens([], CharSpec, Line), [Token|Rest]);
+scan(_, Res) ->
+    lists:reverse(Res).
+
+debug_parse(_Args) ->
     RufusText = "
     package rand
 
@@ -85,7 +126,7 @@ parse(_Args) ->
             -1
     end.
 
-scan(_Args) ->
+debug_scan(_Args) ->
     RufusText = "
     package example
 
@@ -96,17 +137,4 @@ scan(_Args) ->
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, Tokens, _Lines} = rufus_scan:string(RufusText),
     io:format("Tokens =>~n~n    ~p~n", [Tokens]),
-    0.
-
-compile(_Args) ->
-    RufusText ="
-    package example
-
-    func Number() int {
-        42
-    }
-",
-    io:format("RufusText =>~n    ~s~n", [RufusText]),
-    {ok, example} = rufus_compile:eval(RufusText),
-    io:format("example:Number() =>~n~n    ~p~n", [example:'Number'()]),
     0.

--- a/rf/src/rufus_check_types.erl
+++ b/rf/src/rufus_check_types.erl
@@ -30,13 +30,13 @@ forms(Forms, [H|T]) ->
 forms(Forms, []) ->
     {ok, Forms}.
 
-check_expr({func, _LineNumber, _Name, _Arguments, ReturnType, Exprs}) ->
+check_expr({func, _Line, _Name, _Arguments, ReturnType, Exprs}) ->
     check_expr(ReturnType, lists:last(Exprs));
 check_expr(_) ->
     ok.
 
-check_expr(ReturnType, {expr, _LineNumber, {ReturnType, _Literal}}) ->
+check_expr(ReturnType, {expr, _Line, {ReturnType, _Literal}}) ->
     ok;
-check_expr(ReturnType, {expr, _LineNumber, {ActualReturnType, _Literal}}) ->
+check_expr(ReturnType, {expr, _Line, {ActualReturnType, _Literal}}) ->
     Data = #{expected => ReturnType, actual => ActualReturnType},
     {error, unmatched_return_type, Data}.

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -16,10 +16,6 @@
 %% - `{ok, Module}` if compilation completed and `Module` is loaded.
 %% - `error` or `{error, ...}` if an error occurs.
 eval(RufusText) ->
-    %% RufusText is the input for the first handler. Handlers are run in order
-    %% using the output from the previous function. Each function returns data
-    %% of the shape {ok, Output} or some form of error. Processing stops when a
-    %% handler returns an error.
     Handlers = [fun scan/1,
                 fun rufus_parse:parse/1,
                 fun rufus_check_types:forms/1,
@@ -30,6 +26,9 @@ eval(RufusText) ->
 
 %% Private API
 
+%% eval_chain runs each handler as H(Input) in order. Each handler result must
+%% match {ok, Output}. Any other response is treated as an error. Processing
+%% stops when a handler returns an error.
 eval_chain(Input, [H|T]) ->
     case H(Input) of
         {ok, Forms} ->

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 26).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 30).
 
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
@@ -210,34 +210,44 @@ yeccpars2(9=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_9(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(10=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_10(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(11=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_11(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(11=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_11(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(12=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_12(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(13=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(14=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_14(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(15=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_15(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(16=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_16(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(28=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_28(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(29=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_29(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -304,37 +314,40 @@ yeccpars2_9(S, '(', Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_9(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
--dialyzer({nowarn_function, yeccpars2_10/7}).
-yeccpars2_10(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 11, Ss, Stack, T, Ts, Tzr);
-yeccpars2_10(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_10(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
+yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_10_(Stack),
+ yeccpars2_11(11, Cat, [10 | Ss], NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
-yeccpars2_11(S, bool, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, float, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 14, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, int, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
-yeccpars2_11(S, string, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
+yeccpars2_11(S, ')', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
--dialyzer({nowarn_function, yeccpars2_12/7}).
-yeccpars2_12(S, '{', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_12(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
+yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_12_(Stack),
+ yeccpars2_19(_S, Cat, [12 | Ss], NewStack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccpars2_13/7}).
+yeccpars2_13(S, bool, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
+yeccpars2_13(S, float, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
+yeccpars2_13(S, int, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 17, Ss, Stack, T, Ts, Tzr);
-yeccpars2_12(_, _, _, _, T, _, _) ->
+yeccpars2_13(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
+yeccpars2_13(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_13(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_13_(Stack),
- yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
-
 yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
  NewStack = yeccpars2_14_(Stack),
- yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_argument(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_15(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_15_(Stack),
@@ -344,49 +357,82 @@ yeccpars2_16(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_16_(Stack),
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_17/7}).
-yeccpars2_17(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
-yeccpars2_17(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
-yeccpars2_17(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 21, Ss, Stack, T, Ts, Tzr);
-yeccpars2_17(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 22, Ss, Stack, T, Ts, Tzr);
-yeccpars2_17(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_17(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_17_(Stack),
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_18/7}).
-yeccpars2_18(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 23, Ss, Stack, T, Ts, Tzr);
-yeccpars2_18(_, _, _, _, T, _, _) ->
- yeccerror(T).
+yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_18_(Stack),
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
  NewStack = yeccpars2_19_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_arguments(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_20_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+%% yeccpars2_20: see yeccpars2_13
 
-yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_21_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_21/7}).
+yeccpars2_21(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 22, Ss, Stack, T, Ts, Tzr);
+yeccpars2_21(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_22(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_22_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_22/7}).
+yeccpars2_22(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 24, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 25, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
-yeccpars2_23(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_|Nss] = Ss,
- NewStack = yeccpars2_23_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_23/7}).
+yeccpars2_23(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_24_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_25_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_26_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_27_(Stack),
+ yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_28_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_29_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccgoto_argument/7}).
+yeccgoto_argument(10, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_argument(12, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr).
+
+-dialyzer({nowarn_function, yeccgoto_arguments/7}).
+yeccgoto_arguments(10, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_11(11, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_arguments(12=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_declaration/7}).
 yeccgoto_declaration(0, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -395,8 +441,8 @@ yeccgoto_declaration(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expression/7}).
-yeccgoto_expression(17, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_18(18, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_expression(22, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(23, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -408,11 +454,13 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
-yeccgoto_type(11, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_type(13=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_type(20, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_21(21, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 3).
@@ -438,33 +486,55 @@ yeccpars2_8_(__Stack0) ->
    { import , token_line ( __2 ) , token_chars ( __2 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_13_/1}).
+-compile({inline,yeccpars2_10_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
+yeccpars2_10_(__Stack0) ->
+ [begin
+   [ ]
+  end | __Stack0].
+
+-compile({inline,yeccpars2_12_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
+yeccpars2_12_(__Stack0) ->
+ [begin
+   [ ]
+  end | __Stack0].
+
+-compile({inline,yeccpars2_14_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
+yeccpars2_14_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   { arg , token_line ( __1 ) , token_chars ( __1 ) , token_type ( __2 ) }
+  end | __Stack].
+
+-compile({inline,yeccpars2_15_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 12).
-yeccpars2_13_(__Stack0) ->
+yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    { bool , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_14_/1}).
+-compile({inline,yeccpars2_16_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 13).
-yeccpars2_14_(__Stack0) ->
+yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    { float , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_15_/1}).
+-compile({inline,yeccpars2_17_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
-yeccpars2_15_(__Stack0) ->
+yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    { int , token_line ( __1 ) }
   end | __Stack].
 
--compile({inline,yeccpars2_16_/1}).
+-compile({inline,yeccpars2_18_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
-yeccpars2_16_(__Stack0) ->
+yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    { string , token_line ( __1 ) }
@@ -473,50 +543,58 @@ yeccpars2_16_(__Stack0) ->
 -compile({inline,yeccpars2_19_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
 yeccpars2_19_(__Stack0) ->
+ [__2,__1 | __Stack] = __Stack0,
+ [begin
+   [ __1 | __2 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_24_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 21).
+yeccpars2_24_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { bool , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
-yeccpars2_20_(__Stack0) ->
+-compile({inline,yeccpars2_25_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
+yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_21_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
-yeccpars2_21_(__Stack0) ->
+-compile({inline,yeccpars2_26_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 23).
+yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_22_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
-yeccpars2_22_(__Stack0) ->
+-compile({inline,yeccpars2_27_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
+yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_23_/1}).
+-compile({inline,yeccpars2_28_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
-yeccpars2_23_(__Stack0) ->
- [__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
+yeccpars2_28_(__Stack0) ->
+ [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { func , token_line ( __1 ) , token_chars ( __2 ) , [ ] , token_type ( __5 ) , __7 }
+   { func , token_line ( __1 ) , token_chars ( __2 ) , __4 , token_type ( __6 ) , __8 }
   end | __Stack].
 
--compile({inline,yeccpars2_24_/1}).
+-compile({inline,yeccpars2_29_/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 4).
-yeccpars2_24_(__Stack0) ->
+yeccpars2_29_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 38).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 42).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,4 +1,4 @@
-Nonterminals declaration expression function root type.
+Nonterminals declaration expression function root type argument arguments.
 
 Terminals '(' ')' '{' '}' func identifier import package bool bool_lit float float_lit int int_lit string string_lit.
 
@@ -11,12 +11,16 @@ declaration -> import string_lit : {import, token_line('$2'), token_chars('$2')}
 declaration -> package identifier : {package, token_line('$2'), token_chars('$2')}.
 declaration -> function : '$1'.
 
-function -> func identifier '(' ')' type '{' expression '}' : {func, token_line('$1'), token_chars('$2'), [], token_type('$5'), '$7'}.
+function -> func identifier '(' arguments ')' type '{' expression '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.
 
 type -> bool : {bool, token_line('$1')}.
 type -> float : {float, token_line('$1')}.
 type -> int : {int, token_line('$1')}.
 type -> string : {string, token_line('$1')}.
+
+arguments -> argument arguments : ['$1'|'$2'].
+arguments -> '$empty' : [].
+argument -> identifier type : {arg, token_line('$1'), token_chars('$1'), token_type('$2')}.
 
 expression -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
 expression -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].

--- a/rf/test/rufus_check_types_test.erl
+++ b/rf/test/rufus_check_types_test.erl
@@ -11,7 +11,6 @@ forms_with_empty_package_test() ->
 forms_test() ->
     RufusText = "
     package example
-
     func Number() int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -21,9 +20,9 @@ forms_test() ->
 forms_with_function_having_unmatched_return_types_test() ->
     RufusText = "
     package example
-
     func Number() int { 42.0 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {error, unmatched_return_type, _Data} = rufus_check_types:forms(Forms).
+    {error, unmatched_return_type, Data} = rufus_check_types:forms(Forms),
+    ?assertEqual(#{actual => float, expected => int}, Data).

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -2,6 +2,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Arity-0 functions returning a literal value for primitive types
+
 forms_for_function_returning_a_bool_test() ->
     RufusText = "
     package example
@@ -68,4 +70,75 @@ forms_for_function_returning_a_string_test() ->
         {attribute, 3, export, [{'Greeting', 0}]},
         {function, 3, 'Greeting', 0, [{clause, 3, [], [], [BoxedStringExpr]}]}
     ],
+    ?assertEqual(Expected, ErlangForms).
+
+%% Arity-1 functions using an argument
+
+forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n bool) bool { true }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    Expected = [{attribute, 2, module, example},
+                  {attribute, 3, export, [{'MaybeEcho', 1}]},
+                  {function, 3, 'MaybeEcho', 1,
+                      [{clause, 3,
+                           [{tuple, 3, [{atom, 3, bool}, {var, 3, '_n'}]}],
+                           [],
+                           [{tuple, 3, [{atom, 3, bool}, {atom, 3, true}]}]}]}],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_taking_a_float_and_returning_a_float_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n float) float { 3.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    Expected = [{attribute, 2, module, example},
+                  {attribute, 3, export, [{'MaybeEcho', 1}]},
+                  {function, 3, 'MaybeEcho', 1,
+                      [{clause, 3,
+                           [{tuple, 3, [{atom, 3, float}, {var, 3, '_n'}]}],
+                           [],
+                           [{tuple, 3, [{atom, 3, float}, {float, 3, 3.14159265359}]}]}]}],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_taking_an_int_and_returning_an_int_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n int) int { 42 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    Expected = [{attribute, 2, module, example},
+                  {attribute, 3, export, [{'MaybeEcho', 1}]},
+                  {function, 3, 'MaybeEcho', 1,
+                      [{clause, 3,
+                           [{tuple, 3, [{atom, 3, int}, {var, 3, '_n'}]}],
+                           [],
+                           [{tuple, 3, [{atom, 3, int}, {integer, 3, 42}]}]}]}],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_taking_a_string_and_returning_a_string_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n string) string { \"Hello\" }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    StringExpr = {bin_element, 3, {string, 3, "Hello"}, default, default},
+    Expected = [{attribute, 2, module, example},
+                  {attribute, 3, export, [{'MaybeEcho', 1}]},
+                  {function, 3, 'MaybeEcho', 1,
+                      [{clause, 3,
+                           [{tuple, 3, [{atom, 3, string}, {var, 3, '_n'}]}],
+                           [],
+                           [{tuple, 3, [{atom, 3, string}, {bin,3, [StringExpr]}]}]}]}],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -16,7 +16,7 @@ eval_chain_with_error_handler_test() ->
     %% it encounters a failure from Error.
     ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
 
-%% Arity-0 functions returning literal values for primitive type.
+%% Arity-0 functions returning a literal value for primitive types
 
 eval_with_function_returning_a_bool_test() ->
     RufusText = "
@@ -49,6 +49,44 @@ eval_with_function_returning_a_string_test() ->
     ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
+
+%% Arity-1 functions using an argument
+
+eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n bool) bool { true }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual({bool, true}, example:'MaybeEcho'({bool, false})).
+
+eval_with_function_taking_a_float_and_returning_a_float_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n float) float { 3.14159265359 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual({float, 3.14159265359}, example:'MaybeEcho'({float, 3.14})).
+
+eval_with_function_taking_an_int_and_returning_an_int_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n int) int { 42 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual({int, 42}, example:'MaybeEcho'({int, 42})).
+
+eval_with_function_taking_a_string_and_returning_a_string_test() ->
+    RufusText = "
+    package example
+    func MaybeEcho(n string) string { \"Hello\" }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
 
 %% Type checking return values
 

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -16,6 +16,8 @@ eval_chain_with_error_handler_test() ->
     %% it encounters a failure from Error.
     ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
 
+%% Arity-0 functions returning literal values for primitive type.
+
 eval_with_function_returning_a_bool_test() ->
     RufusText = "
     package example
@@ -47,6 +49,8 @@ eval_with_function_returning_a_string_test() ->
     ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
+
+%% Type checking return values
 
 eval_with_function_having_unmatched_return_types_test() ->
     RufusText = "

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -2,64 +2,125 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Packages
+
 parse_empty_package_test() ->
     {ok, Tokens, _} = rufus_scan:string("package empty"),
-    {ok, AST} = rufus_parse:parse(Tokens),
+    {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 1, "empty"}
-    ], AST).
+    ], Forms).
 
-parse_function_returning_a_bool_test() ->
-    {ok, Tokens, _} = rufus_scan:string("
-     package example
-     func True() bool { true }
-    "),
-    {ok, AST} = rufus_parse:parse(Tokens),
-    ?assertEqual([
-     {package, 2, "example"},
-     {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
-    ], AST).
-
-parse_function_returning_a_float_test() ->
-    {ok, Tokens, _} = rufus_scan:string("
-     package math
-     func Pi() float { 3.14159265359 }
-    "),
-    {ok, AST} = rufus_parse:parse(Tokens),
-    ?assertEqual([
-     {package, 2, "math"},
-     {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
-    ], AST).
-
-parse_function_returning_an_int_test() ->
-    {ok, Tokens, _} = rufus_scan:string("
-     package rand
-     func Number() int { 42 }
-    "),
-    {ok, AST} = rufus_parse:parse(Tokens),
-    ?assertEqual([
-     {package, 2, "rand"},
-     {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
-    ], AST).
-
-parse_function_returning_a_string_test() ->
-    {ok, Tokens, _} = rufus_scan:string("
-     package example
-     func Greeting() string { \"Hello\" }
-    "),
-    {ok, AST} = rufus_parse:parse(Tokens),
-    ?assertEqual([
-     {package, 2, "example"},
-     {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
-    ], AST).
+%% Import
 
 parse_import_test() ->
-    {ok, Tokens, _} = rufus_scan:string("
-package foo
-import \"bar\"
-"),
-    {ok, AST} = rufus_parse:parse(Tokens),
+    RufusText = "
+    package foo
+    import \"bar\"
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 2, "foo"},
      {import, 3, "bar"}
-    ], AST).
+    ], Forms).
+
+%% Arity-0 functions returning a literal value for primitive types
+
+parse_function_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func True() bool { true }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
+    ], Forms).
+
+parse_function_returning_a_float_test() ->
+    RufusText = "
+    package math
+    func Pi() float { 3.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "math"},
+     {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
+    ], Forms).
+
+parse_function_returning_an_int_test() ->
+    RufusText = "
+    package rand
+    func Number() int { 42 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "rand"},
+     {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
+    ], Forms).
+
+parse_function_returning_a_string_test() ->
+    RufusText = "
+    package example
+    func Greeting() string { \"Hello\" }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
+    ], Forms).
+
+%% Arity-1 functions using an argument
+
+parse_function_taking_an_bool_and_returning_an_bool_test() ->
+    RufusText = "
+    package example
+    func Echo(n bool) bool { true }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Echo", [{arg, 3, "n", bool}], bool, [{expr, 3, {bool, true}}]}
+    ], Forms).
+
+parse_function_taking_an_float_and_returning_an_float_test() ->
+    RufusText = "
+    package example
+    func Echo(n float) float { 3.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Echo", [{arg, 3, "n", float}], float, [{expr, 3, {float, 3.14159265359}}]}
+    ], Forms).
+
+parse_function_taking_an_int_and_returning_an_int_test() ->
+    RufusText = "
+    package example
+    func Echo(n int) int { 42 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Echo", [{arg, 3, "n", int}], int, [{expr, 3, {int, 42}}]}
+    ], Forms).
+
+parse_function_taking_an_string_and_returning_an_string_test() ->
+    RufusText = "
+    package example
+    func Echo(n string) string { \"Hello\" }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {package, 2, "example"},
+     {func, 3, "Echo", [{arg, 3, "n", string}], string, [{expr, 3, {string, "Hello"}}]}
+    ], Forms).


### PR DESCRIPTION
`rf compile:scan` and `rf compile:parse` are now `rf debug:scan` and `rf debug:parse`, respectively. A new `rf debug:erlang-forms` command takes a filename as a parameter, loads Erlang source code from it, and prints it to the screen as Erlang abstract forms. The parser and compiler can parse and generate code for simple arity 1 functions.