### PR TITLE
compiler: Rename package keyword to module

### DIFF
--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -75,7 +75,7 @@ version(_Args) ->
 
 compile(_Args) ->
     RufusText ="
-    package example
+    module example
 
     func Number() int {
         42
@@ -103,7 +103,7 @@ scan(_, Res) ->
 
 debug_parse(_Args) ->
     RufusText = "
-    package rand
+    module rand
 
     func Int() int {
         42
@@ -128,7 +128,7 @@ debug_parse(_Args) ->
 
 debug_scan(_Args) ->
     RufusText = "
-    package example
+    module example
 
     func Greet(name string) string {
         \"Hello \" + name

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -42,7 +42,7 @@ forms(Acc, [{func, Line, Name, Args, _ReturnType, Exprs}|T]) ->
     ExportForms = {attribute, Line, export, [{list_to_atom(Name), length(Args)}]},
     Forms = {function, Line, list_to_atom(Name), length(Args), FunctionForms},
     forms([Forms|[ExportForms|Acc]], T);
-forms(Acc, [{package, Line, Name}|T]) ->
+forms(Acc, [{module, Line, Name}|T]) ->
     Form = {attribute, Line, module, list_to_atom(Name)},
     forms([Form|Acc], T);
 forms(Acc, []) ->

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -17,7 +17,7 @@ forms(RufusForms) ->
 %% Private API
 
 forms(Acc, [{arg, Line, Name, Type}|T]) ->
-    Form = {tuple, Line, [{atom, Line, Type}, {var, Line, list_to_atom("_" ++ Name)}]},
+    Form = {tuple, Line, [{atom, Line, Type}, {var, Line, Name}]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, Line, {bool, Value}}|T]) ->
     Form = box({bool, Line, Value}),
@@ -31,6 +31,9 @@ forms(Acc, [{expr, Line, {int, Value}}|T]) ->
 forms(Acc, [{expr, Line, {string, Value}}|T]) ->
     StringExpr = {bin_element, Line, {string, Line, Value}, default, default},
     Form = box({bin, Line, [StringExpr]}),
+    forms([Form|Acc], T);
+forms(Acc, [{expr, Line, {identifier, Name}}|T]) ->
+    Form = {var, Line, Name},
     forms([Form|Acc], T);
 forms(Acc, [{func, Line, Name, Args, _ReturnType, Exprs}|T]) ->
     ArgsForms = forms([], Args),

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,7 +1,9 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 30).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 34).
 
+token_atom({_TokenType, _TokenLine, TokenChars}) ->
+    list_to_atom(TokenChars).
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
 
@@ -185,7 +187,7 @@ yecctoken2string(Other) ->
 
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.erl", 188).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.erl", 190).
 
 -dialyzer({nowarn_function, yeccpars2/7}).
 yeccpars2(0=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -226,18 +228,18 @@ yeccpars2(17=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_17(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -246,8 +248,12 @@ yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_27(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(28=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_28(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(29=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_29(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(29=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_29(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(30=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_30(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(31=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_31(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -268,7 +274,7 @@ yeccpars2_1(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_2(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccgoto_declaration(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ yeccgoto_decl(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_3(S, func, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 4, Ss, Stack, T, Ts, Tzr);
@@ -301,12 +307,12 @@ yeccpars2_6(_, _, _, _, T, _, _) ->
 yeccpars2_7(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_7_(Stack),
- yeccgoto_declaration(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_decl(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_8(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_8_(Stack),
- yeccgoto_declaration(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_decl(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_9/7}).
 yeccpars2_9(S, '(', Ss, Stack, T, Ts, Tzr) ->
@@ -322,7 +328,7 @@ yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
 yeccpars2_11(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 21, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -330,7 +336,7 @@ yeccpars2_12(S, identifier, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
 yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_12_(Stack),
- yeccpars2_19(_S, Cat, [12 | Ss], NewStack, T, Ts, Tzr).
+ yeccpars2_20(_S, Cat, [12 | Ss], NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_13/7}).
 yeccpars2_13(S, bool, Ss, Stack, T, Ts, Tzr) ->
@@ -344,10 +350,12 @@ yeccpars2_13(S, string, Ss, Stack, T, Ts, Tzr) ->
 yeccpars2_13(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
+yeccpars2_14(S, ',', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
 yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_14_(Stack),
- yeccgoto_argument(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_arg(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_15(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_15_(Stack),
@@ -366,83 +374,94 @@ yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_19_(Stack),
- yeccgoto_arguments(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_arg(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_20: see yeccpars2_13
+yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_20_(Stack),
+ yeccgoto_args(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_21/7}).
-yeccpars2_21(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 22, Ss, Stack, T, Ts, Tzr);
-yeccpars2_21(_, _, _, _, T, _, _) ->
- yeccerror(T).
+%% yeccpars2_21: see yeccpars2_13
 
 -dialyzer({nowarn_function, yeccpars2_22/7}).
-yeccpars2_22(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 24, Ss, Stack, T, Ts, Tzr);
-yeccpars2_22(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 25, Ss, Stack, T, Ts, Tzr);
-yeccpars2_22(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_22(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
+yeccpars2_22(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 23, Ss, Stack, T, Ts, Tzr);
 yeccpars2_22(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_23/7}).
-yeccpars2_23(S, '}', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_23(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 25, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
 yeccpars2_23(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_24_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccpars2_24/7}).
+yeccpars2_24(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
+yeccpars2_24(_, _, _, _, T, _, _) ->
+ yeccerror(T).
 
 yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_25_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_26_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_27_(Stack),
- yeccgoto_expression(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_28_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_29_(Stack),
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_30_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_31_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccgoto_argument/7}).
-yeccgoto_argument(10, Cat, Ss, Stack, T, Ts, Tzr) ->
+-dialyzer({nowarn_function, yeccgoto_arg/7}).
+yeccgoto_arg(10, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_argument(12, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccgoto_arg(12, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_12(12, Cat, Ss, Stack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccgoto_arguments/7}).
-yeccgoto_arguments(10, Cat, Ss, Stack, T, Ts, Tzr) ->
+-dialyzer({nowarn_function, yeccgoto_args/7}).
+yeccgoto_args(10, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(11, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_arguments(12=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_args(12=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccgoto_declaration/7}).
-yeccgoto_declaration(0, Cat, Ss, Stack, T, Ts, Tzr) ->
+-dialyzer({nowarn_function, yeccgoto_decl/7}).
+yeccgoto_decl(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_declaration(3, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccgoto_decl(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccgoto_expression/7}).
-yeccgoto_expression(22, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_23(23, Cat, Ss, Stack, T, Ts, Tzr).
+-dialyzer({nowarn_function, yeccgoto_expr/7}).
+yeccgoto_expr(23, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_24(24, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -454,16 +473,16 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
-yeccgoto_type(13=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_type(20, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_21(21, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_type(13, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_14(14, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_type(21, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 3).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 5).
 yeccpars2_3_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -471,7 +490,7 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 7).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 9).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -479,7 +498,7 @@ yeccpars2_7_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 6).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 8).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -487,29 +506,29 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 18).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , token_line ( __1 ) , token_chars ( __1 ) , token_type ( __2 ) }
+   { arg , token_line ( __1 ) , token_atom ( __1 ) , token_type ( __2 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 12).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -517,7 +536,7 @@ yeccpars2_15_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 13).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -525,7 +544,7 @@ yeccpars2_16_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 16).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -533,7 +552,7 @@ yeccpars2_17_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -541,60 +560,76 @@ yeccpars2_18_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 21).
 yeccpars2_19_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { arg , token_line ( __1 ) , token_atom ( __1 ) , token_type ( __2 ) }
+  end | __Stack].
+
+-compile({inline,yeccpars2_20_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
+yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_24_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 21).
-yeccpars2_24_(__Stack0) ->
+-compile({inline,yeccpars2_25_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
+yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { bool , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
-yeccpars2_25_(__Stack0) ->
+-compile({inline,yeccpars2_26_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 25).
+yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 23).
-yeccpars2_26_(__Stack0) ->
+-compile({inline,yeccpars2_27_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 28).
+yeccpars2_27_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   [ { expr , token_line ( __1 ) , { identifier , token_atom ( __1 ) } } ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_28_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 26).
+yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
-yeccpars2_27_(__Stack0) ->
+-compile({inline,yeccpars2_29_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 27).
+yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
   end | __Stack].
 
--compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 10).
-yeccpars2_28_(__Stack0) ->
+-compile({inline,yeccpars2_30_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 12).
+yeccpars2_30_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { func , token_line ( __1 ) , token_chars ( __2 ) , __4 , token_type ( __6 ) , __8 }
   end | __Stack].
 
--compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 4).
-yeccpars2_29_(__Stack0) ->
+-compile({inline,yeccpars2_31_/1}).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 6).
+yeccpars2_31_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 42).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -262,7 +262,7 @@ yeccpars2_0(S, func, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 4, Ss, Stack, T, Ts, Tzr);
 yeccpars2_0(S, import, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 5, Ss, Stack, T, Ts, Tzr);
-yeccpars2_0(S, package, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_0(S, module, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 6, Ss, Stack, T, Ts, Tzr);
 yeccpars2_0(_, _, _, _, T, _, _) ->
  yeccerror(T).
@@ -280,7 +280,7 @@ yeccpars2_3(S, func, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 4, Ss, Stack, T, Ts, Tzr);
 yeccpars2_3(S, import, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 5, Ss, Stack, T, Ts, Tzr);
-yeccpars2_3(S, package, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_3(S, module, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 6, Ss, Stack, T, Ts, Tzr);
 yeccpars2_3(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_3_(Stack),
@@ -494,7 +494,7 @@ yeccpars2_3_(__Stack0) ->
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { package , token_line ( __2 ) , token_chars ( __2 ) }
+   { module , token_line ( __2 ) , token_chars ( __2 ) }
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,34 +1,40 @@
-Nonterminals declaration expression function root type argument arguments.
+Nonterminals
+  root decl expr function type arg args
+  .
 
-Terminals '(' ')' '{' '}' func identifier import package bool bool_lit float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' ',' func identifier import package bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
-root -> declaration : ['$1'].
-root -> declaration root : ['$1'] ++ '$2'.
+root -> decl : ['$1'].
+root -> decl root : ['$1'] ++ '$2'.
 
-declaration -> import string_lit : {import, token_line('$2'), token_chars('$2')}.
-declaration -> package identifier : {package, token_line('$2'), token_chars('$2')}.
-declaration -> function : '$1'.
+decl -> import string_lit : {import, token_line('$2'), token_chars('$2')}.
+decl -> package identifier : {package, token_line('$2'), token_chars('$2')}.
+decl -> function : '$1'.
 
-function -> func identifier '(' arguments ')' type '{' expression '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.
+function -> func identifier '(' args ')' type '{' expr '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.
 
 type -> bool : {bool, token_line('$1')}.
 type -> float : {float, token_line('$1')}.
 type -> int : {int, token_line('$1')}.
 type -> string : {string, token_line('$1')}.
 
-arguments -> argument arguments : ['$1'|'$2'].
-arguments -> '$empty' : [].
-argument -> identifier type : {arg, token_line('$1'), token_chars('$1'), token_type('$2')}.
+args -> arg args : ['$1'|'$2'].
+args -> '$empty' : [].
+arg -> identifier type ',' : {arg, token_line('$1'), token_atom('$1'), token_type('$2')}.
+arg -> identifier type : {arg, token_line('$1'), token_atom('$1'), token_type('$2')}.
 
-expression -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
-expression -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
-expression -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
-expression -> string_lit : [{expr, token_line('$1'), {string, token_chars('$1')}}].
+expr -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
+expr -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
+expr -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
+expr -> string_lit : [{expr, token_line('$1'), {string, token_chars('$1')}}].
+expr -> identifier : [{expr, token_line('$1'), {identifier, token_atom('$1')}}].
 
 Erlang code.
 
+token_atom({_TokenType, _TokenLine, TokenChars}) ->
+    list_to_atom(TokenChars).
 token_chars({_TokenType, _TokenLine, TokenChars}) ->
     TokenChars.
 

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -2,7 +2,7 @@ Nonterminals
   root decl expr function type arg args
   .
 
-Terminals '(' ')' '{' '}' ',' func identifier import package bool bool_lit float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' ',' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
@@ -10,7 +10,7 @@ root -> decl : ['$1'].
 root -> decl root : ['$1'] ++ '$2'.
 
 decl -> import string_lit : {import, token_line('$2'), token_chars('$2')}.
-decl -> package identifier : {package, token_line('$2'), token_chars('$2')}.
+decl -> module identifier : {module, token_line('$2'), token_chars('$2')}.
 decl -> function : '$1'.
 
 function -> func identifier '(' args ')' type '{' expr '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.

--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -309,766 +309,752 @@ adjust_line(T, A, [_|Cs], L) ->
 %% input.
 
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.erl", 310).
-yystate() -> 58.
+yystate() -> 57.
 
-yystate(65, [99|Ics], Line, Tlen, _, _) ->
-    yystate(59, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [97|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [98|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(65, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,65};
+yystate(64, [100|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 22, Tlen);
 yystate(64, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(64, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,64};
+    {22,Tlen,Ics,Line,64};
+yystate(63, [111|Ics], Line, Tlen, _, _) ->
+    yystate(55, Ics, Line, Tlen+1, 22, Tlen);
+yystate(63, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(63, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line};
-yystate(62, [32|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
-yystate(62, [9|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
+    {22,Tlen,Ics,Line,63};
+yystate(62, [46|Ics], Line, Tlen, _, _) ->
+    yystate(54, Ics, Line, Tlen+1, 12, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(62, Ics, Line, Tlen+1, 12, Tlen);
 yystate(62, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,62};
-yystate(61, [46|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 12, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(61, Ics, Line, Tlen+1, 12, Tlen);
+    {12,Tlen,Ics,Line,62};
+yystate(61, [32|Ics], Line, Tlen, _, _) ->
+    yystate(61, Ics, Line, Tlen+1, 0, Tlen);
+yystate(61, [9|Ics], Line, Tlen, _, _) ->
+    yystate(61, Ics, Line, Tlen+1, 0, Tlen);
 yystate(61, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line,61};
-yystate(60, [111|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 22, Tlen);
-yystate(60, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    {0,Tlen,Ics,Line,61};
 yystate(60, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,60};
-yystate(59, [107|Ics], Line, Tlen, _, _) ->
-    yystate(51, Ics, Line, Tlen+1, 22, Tlen);
+    {19,Tlen,Ics,Line};
 yystate(59, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 9, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 9, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 106 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 108, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 9, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 9, Tlen);
 yystate(59, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,59};
-yystate(58, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(50, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(34, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(9, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [113|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [114|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [112|Ics], Line, Tlen, Action, Alen) ->
-    yystate(57, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [105|Ics], Line, Tlen, Action, Alen) ->
-    yystate(19, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [103|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(40, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(8, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(63, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(21, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [44|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [43|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(1, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(14, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(62, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(54, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(58, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(62, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(61, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 111 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,58};
-yystate(57, [97|Ics], Line, Tlen, _, _) ->
-    yystate(65, Ics, Line, Tlen+1, 22, Tlen);
-yystate(57, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
-yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(57, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,57};
-yystate(56, [99|Ics], Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,59};
+yystate(58, [111|Ics], Line, Tlen, _, _) ->
     yystate(64, Ics, Line, Tlen+1, 22, Tlen);
-yystate(56, [97|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(56, [98|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(58, Ics, Line, Tlen, _, _) ->
+    {22,Tlen,Ics,Line,58};
+yystate(57, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(49, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [123|Ics], Line, Tlen, Action, Alen) ->
+    yystate(41, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(33, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [109|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [105|Ics], Line, Tlen, Action, Alen) ->
+    yystate(24, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [103|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [104|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(35, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [100|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [99|Ics], Line, Tlen, Action, Alen) ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [98|Ics], Line, Tlen, Action, Alen) ->
+    yystate(28, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(60, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(14, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(6, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(2, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(61, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(53, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(57, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(61, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(62, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 108 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 110, C =< 114 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(57, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,57};
+yystate(56, [117|Ics], Line, Tlen, _, _) ->
+    yystate(48, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(56, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,56};
+yystate(55, [97|Ics], Line, Tlen, _, _) ->
+    yystate(47, Ics, Line, Tlen+1, 22, Tlen);
 yystate(55, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 2, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(55, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line,55};
-yystate(54, [10|Ics], Line, Tlen, _, _) ->
-    yystate(54, Ics, Line+1, Tlen+1, 1, Tlen);
-yystate(54, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,54};
-yystate(53, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(37, Ics, Line, Tlen+1, Action, Alen);
-yystate(53, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,53};
-yystate(52, [97|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,55};
+yystate(54, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(38, Ics, Line, Tlen+1, Action, Alen);
+yystate(54, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,54};
+yystate(53, [10|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line+1, Tlen+1, 1, Tlen);
+yystate(53, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,53};
 yystate(52, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 2, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 2, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 2, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 2, Tlen);
 yystate(52, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,52};
+    {2,Tlen,Ics,Line,52};
+yystate(51, [99|Ics], Line, Tlen, _, _) ->
+    yystate(59, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [97|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(51, [98|Ics], Line, Tlen, _, _) ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(51, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,51};
+yystate(50, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 6, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 6, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, 6, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 6, Tlen);
 yystate(50, Ics, Line, Tlen, _, _) ->
-    {17,Tlen,Ics,Line};
-yystate(49, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 6, Tlen);
-yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
-yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
-yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+    {6,Tlen,Ics,Line,50};
 yystate(49, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,49};
-yystate(48, [110|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line, Tlen+1, 22, Tlen);
+    {17,Tlen,Ics,Line};
+yystate(48, [108|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(48, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,48};
-yystate(47, [108|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 22, Tlen);
+yystate(47, [116|Ics], Line, Tlen, _, _) ->
+    yystate(39, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(47, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,47};
-yystate(46, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(38, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,46};
-yystate(45, [45|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
-yystate(45, [43|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
-yystate(45, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,45};
-yystate(44, [116|Ics], Line, Tlen, _, _) ->
-    yystate(36, Ics, Line, Tlen+1, 22, Tlen);
+yystate(46, [45|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
+yystate(46, [43|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
+yystate(46, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line,46};
+yystate(45, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(37, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(45, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,45};
+yystate(44, [108|Ics], Line, Tlen, _, _) ->
+    yystate(52, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(44, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,44};
-yystate(43, [103|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 22, Tlen);
+yystate(43, [110|Ics], Line, Tlen, _, _) ->
+    yystate(51, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(43, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,43};
+yystate(42, [103|Ics], Line, Tlen, _, _) ->
+    yystate(50, Ics, Line, Tlen+1, 22, Tlen);
+yystate(42, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(42, Ics, Line, Tlen, _, _) ->
-    {16,Tlen,Ics,Line};
-yystate(41, [103|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 22, Tlen);
-yystate(41, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,42};
 yystate(41, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,41};
-yystate(40, [117|Ics], Line, Tlen, _, _) ->
-    yystate(48, Ics, Line, Tlen+1, 22, Tlen);
-yystate(40, [108|Ics], Line, Tlen, _, _) ->
-    yystate(60, Ics, Line, Tlen+1, 22, Tlen);
-yystate(40, [97|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line, Tlen+1, 22, Tlen);
+    {16,Tlen,Ics,Line};
+yystate(40, [101|Ics], Line, Tlen, _, _) ->
+    yystate(32, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(40, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,40};
-yystate(39, [111|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 22, Tlen);
 yystate(39, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 4, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 4, Tlen);
 yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 4, Tlen);
+yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 4, Tlen);
 yystate(39, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,39};
+    {4,Tlen,Ics,Line,39};
+yystate(38, [101|Ics], Line, Tlen, _, _) ->
+    yystate(46, Ics, Line, Tlen+1, 11, Tlen);
+yystate(38, [69|Ics], Line, Tlen, _, _) ->
+    yystate(46, Ics, Line, Tlen+1, 11, Tlen);
+yystate(38, [45|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
+yystate(38, [43|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(38, Ics, Line, Tlen+1, 11, Tlen);
 yystate(38, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line};
-yystate(37, [101|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 11, Tlen);
-yystate(37, [69|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 11, Tlen);
-yystate(37, [45|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
-yystate(37, [43|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(37, Ics, Line, Tlen+1, 11, Tlen);
+    {11,Tlen,Ics,Line,38};
 yystate(37, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,37};
+    {13,Tlen,Ics,Line};
+yystate(36, [111|Ics], Line, Tlen, _, _) ->
+    yystate(44, Ics, Line, Tlen+1, 22, Tlen);
 yystate(36, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(36, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,36};
-yystate(35, [101|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,36};
+yystate(35, [117|Ics], Line, Tlen, _, _) ->
+    yystate(43, Ics, Line, Tlen+1, 22, Tlen);
+yystate(35, [108|Ics], Line, Tlen, _, _) ->
+    yystate(63, Ics, Line, Tlen+1, 22, Tlen);
+yystate(35, [97|Ics], Line, Tlen, _, _) ->
+    yystate(31, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(35, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,35};
-yystate(34, [114|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 22, Tlen);
+yystate(34, [110|Ics], Line, Tlen, _, _) ->
+    yystate(42, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(34, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,34};
-yystate(33, [110|Ics], Line, Tlen, _, _) ->
-    yystate(41, Ics, Line, Tlen+1, 22, Tlen);
+yystate(33, [114|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(33, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,33};
 yystate(32, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 8, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 7, Tlen);
 yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 7, Tlen);
 yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 7, Tlen);
 yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 7, Tlen);
 yystate(32, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line,32};
-yystate(31, [111|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 22, Tlen);
+    {7,Tlen,Ics,Line,32};
+yystate(31, [108|Ics], Line, Tlen, _, _) ->
+    yystate(23, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(31, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,31};
-yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(30, Ics, Line, Tlen+1, 11, Tlen);
 yystate(30, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,30};
+    {11,Tlen,Ics,Line,30};
+yystate(29, [34|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(29, Ics, Line, Tlen+1, 11, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(29, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,29};
-yystate(28, [108|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,29};
+yystate(28, [111|Ics], Line, Tlen, _, _) ->
+    yystate(36, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(28, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,28};
 yystate(27, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 7, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 8, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 8, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 8, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 8, Tlen);
 yystate(27, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,27};
-yystate(26, [117|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 22, Tlen);
+    {8,Tlen,Ics,Line,27};
+yystate(26, [105|Ics], Line, Tlen, _, _) ->
+    yystate(34, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(26, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,26};
-yystate(25, [105|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 22, Tlen);
+yystate(25, [117|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(25, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,25};
-yystate(24, [116|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 22, Tlen);
+yystate(24, [110|Ics], Line, Tlen, _, _) ->
+    yystate(16, Ics, Line, Tlen+1, 22, Tlen);
+yystate(24, [109|Ics], Line, Tlen, _, _) ->
+    yystate(0, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(24, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,24};
+yystate(23, [115|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 22, Tlen);
 yystate(23, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 3, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(23, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line,23};
-yystate(22, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(22, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,22};
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(61, Ics, Line, Tlen+1, 21, Tlen);
-yystate(21, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,21};
-yystate(20, [115|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,23};
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(62, Ics, Line, Tlen+1, 21, Tlen);
+yystate(22, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line,22};
+yystate(21, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(21, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,21};
 yystate(20, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 3, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 3, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 3, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 3, Tlen);
 yystate(20, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,20};
-yystate(19, [110|Ics], Line, Tlen, _, _) ->
-    yystate(11, Ics, Line, Tlen+1, 22, Tlen);
-yystate(19, [109|Ics], Line, Tlen, _, _) ->
-    yystate(4, Ics, Line, Tlen+1, 22, Tlen);
+    {3,Tlen,Ics,Line,20};
+yystate(19, [116|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(19, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,19};
-yystate(18, [101|Ics], Line, Tlen, _, _) ->
-    yystate(10, Ics, Line, Tlen+1, 22, Tlen);
+yystate(18, [114|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(18, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,18};
-yystate(17, [114|Ics], Line, Tlen, _, _) ->
-    yystate(25, Ics, Line, Tlen+1, 22, Tlen);
+yystate(17, [101|Ics], Line, Tlen, _, _) ->
+    yystate(9, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(17, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,17};
-yystate(16, [114|Ics], Line, Tlen, _, _) ->
-    yystate(24, Ics, Line, Tlen+1, 22, Tlen);
+yystate(16, [116|Ics], Line, Tlen, _, _) ->
+    yystate(8, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(16, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,16};
-yystate(15, [116|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 22, Tlen);
+yystate(15, [114|Ics], Line, Tlen, _, _) ->
+    yystate(19, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(15, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,15};
-yystate(14, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(22, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,14};
-yystate(13, Ics, Line, Tlen, _, _) ->
+yystate(14, Ics, Line, Tlen, _, _) ->
     {18,Tlen,Ics,Line};
-yystate(12, [111|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 22, Tlen);
+yystate(13, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(13, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,13};
+yystate(12, [116|Ics], Line, Tlen, _, _) ->
+    yystate(20, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(12, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,12};
-yystate(11, [116|Ics], Line, Tlen, _, _) ->
+yystate(11, [111|Ics], Line, Tlen, _, _) ->
     yystate(3, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(11, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,11};
+yystate(10, [116|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 22, Tlen);
 yystate(10, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(10, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,10};
-yystate(9, [116|Ics], Line, Tlen, _, _) ->
-    yystate(17, Ics, Line, Tlen+1, 22, Tlen);
+    {22,Tlen,Ics,Line,10};
 yystate(9, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 10, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 10, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 10, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 10, Tlen);
 yystate(9, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,9};
-yystate(8, [111|Ics], Line, Tlen, _, _) ->
-    yystate(0, Ics, Line, Tlen+1, 22, Tlen);
+    {10,Tlen,Ics,Line,9};
 yystate(8, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 5, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 5, Tlen);
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 5, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 5, Tlen);
 yystate(8, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line,8};
-yystate(7, [115|Ics], Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,8};
+yystate(7, [111|Ics], Line, Tlen, _, _) ->
     yystate(15, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(7, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,7};
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(62, Ics, Line, Tlen+1, 20, Tlen);
 yystate(6, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line};
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(61, Ics, Line, Tlen+1, 20, Tlen);
+    {20,Tlen,Ics,Line,6};
 yystate(5, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,5};
-yystate(4, [112|Ics], Line, Tlen, _, _) ->
+    {14,Tlen,Ics,Line};
+yystate(4, [115|Ics], Line, Tlen, _, _) ->
     yystate(12, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(4, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,4};
+yystate(3, [110|Ics], Line, Tlen, _, _) ->
+    yystate(4, Ics, Line, Tlen+1, 22, Tlen);
 yystate(3, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(3, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,3};
-yystate(2, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(22, Ics, Line, Tlen+1, Action, Alen);
-yystate(2, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,2};
-yystate(1, Ics, Line, Tlen, _, _) ->
+    {22,Tlen,Ics,Line,3};
+yystate(2, Ics, Line, Tlen, _, _) ->
     {15,Tlen,Ics,Line};
-yystate(0, [110|Ics], Line, Tlen, _, _) ->
+yystate(1, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(1, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,1};
+yystate(0, [112|Ics], Line, Tlen, _, _) ->
     yystate(7, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [34|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(1, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 22, Tlen);
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
+    yystate(29, Ics, Line, Tlen+1, 22, Tlen);
 yystate(0, Ics, Line, Tlen, _, _) ->
     {22,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
@@ -1169,7 +1155,7 @@ yyaction_6(TokenLine) ->
 -compile({inline,yyaction_7/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 45).
 yyaction_7(TokenLine) ->
-     { token, { package, TokenLine } } .
+     { token, { module, TokenLine } } .
 
 -compile({inline,yyaction_8/1}).
 -file("/Users/jkakar/rufus/rf/src/rufus_scan.xrl", 46).

--- a/rf/src/rufus_scan.xrl
+++ b/rf/src/rufus_scan.xrl
@@ -18,7 +18,7 @@ FloatType     = float
 IntType       = int
 StringType    = string
 
-Package       = package
+Module        = module
 Import        = import
 Func          = func
 
@@ -44,7 +44,7 @@ Rules.
 {IntType}       : {token, {int, TokenLine}}.
 {StringType}    : {token, {string, TokenLine}}.
 
-{Package}       : {token, {package, TokenLine}}.
+{Module}        : {token, {module, TokenLine}}.
 {Import}        : {token, {import, TokenLine}}.
 {Func}          : {token, {func, TokenLine}}.
 

--- a/rf/test/rufus_check_types_test.erl
+++ b/rf/test/rufus_check_types_test.erl
@@ -26,3 +26,13 @@ forms_with_function_having_unmatched_return_types_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     {error, unmatched_return_type, Data} = rufus_check_types:forms(Forms),
     ?assertEqual(#{actual => float, expected => int}, Data).
+
+forms_with_function_returning_a_variable_test() ->
+    RufusText = "
+    package example
+    func Echo(s string) string { s }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    io:format("Forms => ~n~n~p~n", [Forms]),
+    ?assertEqual({ok, Forms}, rufus_check_types:forms(Forms)).

--- a/rf/test/rufus_check_types_test.erl
+++ b/rf/test/rufus_check_types_test.erl
@@ -26,13 +26,3 @@ forms_with_function_having_unmatched_return_types_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     {error, unmatched_return_type, Data} = rufus_check_types:forms(Forms),
     ?assertEqual(#{actual => float, expected => int}, Data).
-
-forms_with_function_returning_a_variable_test() ->
-    RufusText = "
-    module example
-    func Echo(s string) string { s }
-    ",
-    {ok, Tokens, _} = rufus_scan:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    io:format("Forms => ~n~n~p~n", [Forms]),
-    ?assertEqual({ok, Forms}, rufus_check_types:forms(Forms)).

--- a/rf/test/rufus_check_types_test.erl
+++ b/rf/test/rufus_check_types_test.erl
@@ -2,15 +2,15 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-forms_with_empty_package_test() ->
-    RufusText = "package empty",
+forms_with_empty_module_test() ->
+    RufusText = "module empty",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual({ok, Forms}, rufus_check_types:forms(Forms)).
 
 forms_test() ->
     RufusText = "
-    package example
+    module example
     func Number() int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -19,7 +19,7 @@ forms_test() ->
 
 forms_with_function_having_unmatched_return_types_test() ->
     RufusText = "
-    package example
+    module example
     func Number() int { 42.0 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -29,7 +29,7 @@ forms_with_function_having_unmatched_return_types_test() ->
 
 forms_with_function_returning_a_variable_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(s string) string { s }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -6,7 +6,7 @@
 
 forms_for_function_returning_a_bool_literal_test() ->
     RufusText = "
-    package example
+    module example
     func False() bool { false }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -23,7 +23,7 @@ forms_for_function_returning_a_bool_literal_test() ->
 
 forms_for_function_returning_a_float_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Pi() float { 3.14159265359 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -40,7 +40,7 @@ forms_for_function_returning_a_float_literal_test() ->
 
 forms_for_function_returning_an_int_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Number() int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -57,7 +57,7 @@ forms_for_function_returning_an_int_literal_test() ->
 
 forms_for_function_returning_a_string_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Greeting() string { \"Hello\" }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -76,7 +76,7 @@ forms_for_function_returning_a_string_literal_test() ->
 
 forms_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(b bool) bool { true }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -93,7 +93,7 @@ forms_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
 
 forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n float) float { 3.14159265359 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -110,7 +110,7 @@ forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
 
 forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n int) int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -127,7 +127,7 @@ forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
 
 forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(s string) string { \"Hello\" }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
@@ -147,7 +147,7 @@ forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
 
 forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(b bool) bool { b }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -4,7 +4,7 @@
 
 %% Arity-0 functions returning a literal value for primitive types
 
-forms_for_function_returning_a_bool_test() ->
+forms_for_function_returning_a_bool_literal_test() ->
     RufusText = "
     package example
     func False() bool { false }
@@ -21,7 +21,7 @@ forms_for_function_returning_a_bool_test() ->
     ],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_returning_a_float_test() ->
+forms_for_function_returning_a_float_literal_test() ->
     RufusText = "
     package example
     func Pi() float { 3.14159265359 }
@@ -38,7 +38,7 @@ forms_for_function_returning_a_float_test() ->
     ],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_returning_an_int_test() ->
+forms_for_function_returning_an_int_literal_test() ->
     RufusText = "
     package example
     func Number() int { 42 }
@@ -55,7 +55,7 @@ forms_for_function_returning_an_int_test() ->
     ],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_returning_a_string_test() ->
+forms_for_function_returning_a_string_literal_test() ->
     RufusText = "
     package example
     func Greeting() string { \"Hello\" }
@@ -72,12 +72,12 @@ forms_for_function_returning_a_string_test() ->
     ],
     ?assertEqual(Expected, ErlangForms).
 
-%% Arity-1 functions using an argument
+%% Arity-1 functions taking an unused argument
 
-forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
+forms_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
     package example
-    func MaybeEcho(n bool) bool { true }
+    func MaybeEcho(b bool) bool { true }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
@@ -86,12 +86,12 @@ forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, bool}, {var, 3, '_n'}]}],
+                           [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}],
                            [],
                            [{tuple, 3, [{atom, 3, bool}, {atom, 3, true}]}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_taking_a_float_and_returning_a_float_test() ->
+forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n float) float { 3.14159265359 }
@@ -103,12 +103,12 @@ forms_for_function_taking_a_float_and_returning_a_float_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, float}, {var, 3, '_n'}]}],
+                           [{tuple, 3, [{atom, 3, float}, {var, 3, n}]}],
                            [],
                            [{tuple, 3, [{atom, 3, float}, {float, 3, 3.14159265359}]}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_taking_an_int_and_returning_an_int_test() ->
+forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n int) int { 42 }
@@ -120,15 +120,15 @@ forms_for_function_taking_an_int_and_returning_an_int_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, int}, {var, 3, '_n'}]}],
+                           [{tuple, 3, [{atom, 3, int}, {var, 3, n}]}],
                            [],
                            [{tuple, 3, [{atom, 3, int}, {integer, 3, 42}]}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_taking_a_string_and_returning_a_string_test() ->
+forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
     RufusText = "
     package example
-    func MaybeEcho(n string) string { \"Hello\" }
+    func MaybeEcho(s string) string { \"Hello\" }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
@@ -138,7 +138,26 @@ forms_for_function_taking_a_string_and_returning_a_string_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, string}, {var, 3, '_n'}]}],
+                           [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
                            [],
                            [{tuple, 3, [{atom, 3, string}, {bin,3, [StringExpr]}]}]}]}],
+    ?assertEqual(Expected, ErlangForms).
+
+%% Arity-1 functions taking and using an argument
+
+forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func Echo(b bool) bool { b }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    Expected = [{attribute, 2, module, example},
+                  {attribute, 3, export, [{'Echo', 1}]},
+                  {function, 3, 'Echo', 1,
+                      [{clause, 3,
+                           [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}],
+                           [],
+                           [{var, 3, b}]}]}],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -88,17 +88,6 @@ eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
 
-%% Arity-1 functions taking and using an argument
-
-eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
-    RufusText = "
-    module example
-    func Echo(n bool) bool { n }
-    ",
-    Result = rufus_compile:eval(RufusText),
-    ?assertEqual({ok, example}, Result),
-    ?assertEqual({bool, true}, example:'Echo'({bool, false})).
-
 %% Type checking return values
 
 eval_with_function_having_unmatched_return_types_test() ->

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -18,7 +18,7 @@ eval_chain_with_error_handler_test() ->
 
 %% Arity-0 functions returning a literal value for primitive types
 
-eval_with_function_returning_a_bool_test() ->
+eval_with_function_returning_a_bool_literal_test() ->
     RufusText = "
     package example
     func True() bool { true }
@@ -26,7 +26,7 @@ eval_with_function_returning_a_bool_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({bool, true}, example:'True'()).
 
-eval_with_function_returning_a_float_test() ->
+eval_with_function_returning_a_float_literal_test() ->
     RufusText = "
     package example
     func Pi() float { 3.14159265359 }
@@ -34,7 +34,7 @@ eval_with_function_returning_a_float_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({float, 3.14159265359}, example:'Pi'()).
 
-eval_with_function_returning_an_int_test() ->
+eval_with_function_returning_an_int_literal_test() ->
     RufusText = "
     package example
     func Number() int { 42 }
@@ -42,7 +42,7 @@ eval_with_function_returning_an_int_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({int, 42}, example:'Number'()).
 
-eval_with_function_returning_a_string_test() ->
+eval_with_function_returning_a_string_literal_test() ->
     RufusText = "
     package example
     func Greeting() string { \"Hello\" }
@@ -50,9 +50,9 @@ eval_with_function_returning_a_string_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
-%% Arity-1 functions using an argument
+%% Arity-1 functions taking an unused argument
 
-eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
+eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n bool) bool { true }
@@ -61,7 +61,7 @@ eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual({bool, true}, example:'MaybeEcho'({bool, false})).
 
-eval_with_function_taking_a_float_and_returning_a_float_test() ->
+eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n float) float { 3.14159265359 }
@@ -70,7 +70,7 @@ eval_with_function_taking_a_float_and_returning_a_float_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual({float, 3.14159265359}, example:'MaybeEcho'({float, 3.14})).
 
-eval_with_function_taking_an_int_and_returning_an_int_test() ->
+eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n int) int { 42 }
@@ -79,7 +79,7 @@ eval_with_function_taking_an_int_and_returning_an_int_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual({int, 42}, example:'MaybeEcho'({int, 42})).
 
-eval_with_function_taking_a_string_and_returning_a_string_test() ->
+eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     RufusText = "
     package example
     func MaybeEcho(n string) string { \"Hello\" }
@@ -87,6 +87,17 @@ eval_with_function_taking_a_string_and_returning_a_string_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
+
+%% Arity-1 functions taking and using an argument
+
+eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
+    RufusText = "
+    package example
+    func Echo(n bool) bool { n }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual({bool, true}, example:'Echo'({bool, false})).
 
 %% Type checking return values
 

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -20,7 +20,7 @@ eval_chain_with_error_handler_test() ->
 
 eval_with_function_returning_a_bool_literal_test() ->
     RufusText = "
-    package example
+    module example
     func True() bool { true }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
@@ -28,7 +28,7 @@ eval_with_function_returning_a_bool_literal_test() ->
 
 eval_with_function_returning_a_float_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Pi() float { 3.14159265359 }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
@@ -36,7 +36,7 @@ eval_with_function_returning_a_float_literal_test() ->
 
 eval_with_function_returning_an_int_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Number() int { 42 }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
@@ -44,7 +44,7 @@ eval_with_function_returning_an_int_literal_test() ->
 
 eval_with_function_returning_a_string_literal_test() ->
     RufusText = "
-    package example
+    module example
     func Greeting() string { \"Hello\" }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
@@ -54,7 +54,7 @@ eval_with_function_returning_a_string_literal_test() ->
 
 eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n bool) bool { true }
     ",
     Result = rufus_compile:eval(RufusText),
@@ -63,7 +63,7 @@ eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
 
 eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n float) float { 3.14159265359 }
     ",
     Result = rufus_compile:eval(RufusText),
@@ -72,7 +72,7 @@ eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
 
 eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n int) int { 42 }
     ",
     Result = rufus_compile:eval(RufusText),
@@ -81,7 +81,7 @@ eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
 
 eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     RufusText = "
-    package example
+    module example
     func MaybeEcho(n string) string { \"Hello\" }
     ",
     Result = rufus_compile:eval(RufusText),
@@ -92,7 +92,7 @@ eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
 
 eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(n bool) bool { n }
     ",
     Result = rufus_compile:eval(RufusText),
@@ -103,7 +103,7 @@ eval_with_function_taking_a_bool_and_returning_a_bool_test() ->
 
 eval_with_function_having_unmatched_return_types_test() ->
     RufusText = "
-    package example
+    module example
     func Number() float { 42 }
     ",
     {error, unmatched_return_type, _Data} = rufus_compile:eval(RufusText).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -2,26 +2,26 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% Packages
+%% Modules
 
-parse_empty_package_test() ->
-    {ok, Tokens, _} = rufus_scan:string("package empty"),
+parse_empty_module_test() ->
+    {ok, Tokens, _} = rufus_scan:string("module empty"),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 1, "empty"}
+     {module, 1, "empty"}
     ], Forms).
 
 %% Import
 
 parse_import_test() ->
     RufusText = "
-    package foo
+    module foo
     import \"bar\"
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "foo"},
+     {module, 2, "foo"},
      {import, 3, "bar"}
     ], Forms).
 
@@ -29,49 +29,49 @@ parse_import_test() ->
 
 parse_function_returning_a_bool_test() ->
     RufusText = "
-    package example
+    module example
     func True() bool { true }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
 parse_function_returning_a_float_test() ->
     RufusText = "
-    package math
+    module math
     func Pi() float { 3.14159265359 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "math"},
+     {module, 2, "math"},
      {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
 parse_function_returning_an_int_test() ->
     RufusText = "
-    package rand
+    module rand
     func Number() int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "rand"},
+     {module, 2, "rand"},
      {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
 parse_function_returning_a_string_test() ->
     RufusText = "
-    package example
+    module example
     func Greeting() string { \"Hello\" }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).
 
@@ -79,48 +79,48 @@ parse_function_returning_a_string_test() ->
 
 parse_function_taking_an_bool_and_returning_an_bool_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(n bool) bool { true }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "Echo", [{arg, 3, n, bool}], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
 parse_function_taking_an_float_and_returning_an_float_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(n float) float { 3.14159265359 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "Echo", [{arg, 3, n, float}], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
 parse_function_taking_an_int_and_returning_an_int_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(n int) int { 42 }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "Echo", [{arg, 3, n, int}], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
 parse_function_taking_an_string_and_returning_an_string_test() ->
     RufusText = "
-    package example
+    module example
     func Echo(n string) string { \"Hello\" }
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {package, 2, "example"},
+     {module, 2, "example"},
      {func, 3, "Echo", [{arg, 3, n, string}], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -86,7 +86,7 @@ parse_function_taking_an_bool_and_returning_an_bool_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 2, "example"},
-     {func, 3, "Echo", [{arg, 3, "n", bool}], bool, [{expr, 3, {bool, true}}]}
+     {func, 3, "Echo", [{arg, 3, n, bool}], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
 parse_function_taking_an_float_and_returning_an_float_test() ->
@@ -98,7 +98,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 2, "example"},
-     {func, 3, "Echo", [{arg, 3, "n", float}], float, [{expr, 3, {float, 3.14159265359}}]}
+     {func, 3, "Echo", [{arg, 3, n, float}], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
 parse_function_taking_an_int_and_returning_an_int_test() ->
@@ -110,7 +110,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 2, "example"},
-     {func, 3, "Echo", [{arg, 3, "n", int}], int, [{expr, 3, {int, 42}}]}
+     {func, 3, "Echo", [{arg, 3, n, int}], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
 parse_function_taking_an_string_and_returning_an_string_test() ->
@@ -122,5 +122,5 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {package, 2, "example"},
-     {func, 3, "Echo", [{arg, 3, "n", string}], string, [{expr, 3, {string, "Hello"}}]}
+     {func, 3, "Echo", [{arg, 3, n, string}], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -2,22 +2,22 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% Packages
+%% Modules
 
-string_with_empty_package_test() ->
-    {ok, Tokens, _} = rufus_scan:string("package empty"),
+string_with_empty_module_test() ->
+    {ok, Tokens, _} = rufus_scan:string("module empty"),
     ?assertEqual([
-     {package, 1},
+     {module, 1},
      {identifier, 1, "empty"}
     ], Tokens).
 
 string_with_import_test() ->
     {ok, Tokens, _} = rufus_scan:string("
-     package foo
+     module foo
      import \"bar\"
     "),
     ?assertEqual([
-     {package, 2},
+     {module, 2},
      {identifier, 2, "foo"},
      {import, 3},
      {string_lit, 3, "bar"}


### PR DESCRIPTION
The `package` keyword is renamed to `module`. A collection of modules is now referred to as a package. A package is the unit of distribution for modules.