### PR TITLE
compiler: Refactor parse forms to use maps for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ Generic types:
 
 ```rufus
 func Map(n list[T?], f func(T?) T?) list[T?] {
-    map(list[T?]{}, n, f)
+    mapAccumulate(list[T?]{}, n, f)
 }
 
-func map(acc list[T?], [h|t] list[T?], f func(T?) T?) list[T?] {
-    map([f(h)|acc], t, f)
+func mapAccumulate(acc list[T?], [h|t] list[T?], f func(T?) T?) list[T?] {
+    mapAccumulate([f(h)|acc], t, f)
 }
-func map(acc list[T?], [] list[T?], func(T?) T?) list[T?] {
+func mapAccumulate(acc list[T?], [] list[T?], func(T?) T?) list[T?] {
     lists.Reverse(acc)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ const Pi = 3.14159265359
 Collection types:
 
 ```rufus
-tuple[string, int]
 list[int]
-map[atom]float
+numbers = list[int]{1, 2, 3, 4, 5}
+
+map[atom]string
+alice = map[atom]string{:name: "Alice", :age: "34"}
+
+tuple[string, int]
+alice = tuple[string, int]{"Alice", 34}
 ```
 
 Function types:
@@ -49,13 +54,13 @@ Higher order functions:
 
 ```rufus
 func Map(n list[int], f func(int) int) list[int] {
-    map(list[int]{}, n, f)
+    mapAccumulate(list[int]{}, n, f)
 }
 
-func map(acc list[int], [h|t] list[int], f func(int) int) list[int] {
+func mapAccumulate(acc list[int], [h|t] list[int], f func(int) int) list[int] {
     map([f(h)|acc], t, f)
 }
-func map(acc list[int], [] list[int], func(int) int) list[int] {
+func mapAccumulate(acc list[int], [] list[int], func(int) int) list[int] {
     lists.Reverse(acc)
 }
 ```
@@ -73,13 +78,13 @@ Union type:
 
 ```rufus
 // Inline method allows shorthand syntax to help reduce boilerplate
-func Teleport(Point{Y=5}) :ok | tuple[:error, Reason string] {
+func Teleport(point Point) :ok | tuple[:error, string] {
     // ...
 }
 
-type Result union[:ok | tuple[:error, Reason string]]
+type Outcome :ok | tuple[:error, string]
 
-func Teleport(Point{Y=5}) Result {
+func Teleport(point Point) Outcome {
     // ...
 }
 ```

--- a/rf/src/rufus_check_types.erl
+++ b/rf/src/rufus_check_types.erl
@@ -30,13 +30,15 @@ forms(Forms, [H|T]) ->
 forms(Forms, []) ->
     {ok, Forms}.
 
-check_expr({func, _Line, _Name, _Arguments, ReturnType, Exprs}) ->
-    check_expr(ReturnType, lists:last(Exprs));
+check_expr({func, #{return_type := ReturnType, exprs := Exprs}}) ->
+    check_return_expr(ReturnType, lists:last(Exprs));
 check_expr(_) ->
     ok.
 
-check_expr(ReturnType, {expr, _Line, {ReturnType, _Literal}}) ->
+check_return_expr({type, #{spec := ReturnType}}, {FormType, #{type := {type, #{spec := ReturnType}}}}) ->
+    io:format("ReturnType => ~p  FormType => ~p~n", [ReturnType, FormType]),
     ok;
-check_expr(ReturnType, {expr, _Line, {ActualReturnType, _Literal}}) ->
+check_return_expr({type, #{spec := ReturnType}}, {FormType, #{type := {type, #{spec := ActualReturnType}}}}) ->
+    io:format("ReturnType => ~p  ActualReturnType => ~p  FormType => ~p~n", [ReturnType, ActualReturnType, FormType]),
     Data = #{expected => ReturnType, actual => ActualReturnType},
     {error, unmatched_return_type, Data}.

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -16,7 +16,7 @@ forms(RufusForms) ->
 
 %% Private API
 
-forms(Acc, [{arg, Line, Name, Type}|T]) ->
+forms(Acc, [{arg, #{line := Line, spec := Name, type := Type}}|T]) ->
     Form = {tuple, Line, [{atom, Line, Type}, {var, Line, Name}]},
     forms([Form|Acc], T);
 forms(Acc, [{expr, Line, {bool, Value}}|T]) ->

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -42,8 +42,8 @@ forms(Acc, [{func, Line, Name, Args, _ReturnType, Exprs}|T]) ->
     ExportForms = {attribute, Line, export, [{list_to_atom(Name), length(Args)}]},
     Forms = {function, Line, list_to_atom(Name), length(Args), FunctionForms},
     forms([Forms|[ExportForms|Acc]], T);
-forms(Acc, [{module, Line, Name}|T]) ->
-    Form = {attribute, Line, module, list_to_atom(Name)},
+forms(Acc, [{module, #{line := Line, spec := Name}}|T]) ->
+    Form = {attribute, Line, module, Name},
     forms([Form|Acc], T);
 forms(Acc, []) ->
     Acc.

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -502,7 +502,7 @@ yeccpars2_7_(__Stack0) ->
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { import , token_line ( __2 ) , token_chars ( __2 ) }
+   { import , # { line => token_line ( __2 ) , import_spec => token_chars ( __2 ) } }
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 89).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 97).
 
 token_chars({_TokenType, _Line, Chars}) ->
     Chars.
@@ -485,7 +485,7 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 13).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -495,7 +495,7 @@ yeccpars2_7_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 11).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -505,21 +505,21 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 53).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 53).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 55).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 60).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -530,7 +530,7 @@ yeccpars2_14_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 30).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 26).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -539,7 +539,7 @@ yeccpars2_15_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 33).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 29).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -549,7 +549,7 @@ yeccpars2_16_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 37).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 33).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -559,7 +559,7 @@ yeccpars2_17_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 41).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 37).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -569,7 +569,7 @@ yeccpars2_18_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 50).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 55).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -580,7 +580,7 @@ yeccpars2_19_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 46).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 51).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -588,7 +588,7 @@ yeccpars2_20_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 61).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 68).
 yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -599,7 +599,7 @@ yeccpars2_25_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 66).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 73).
 yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -610,7 +610,7 @@ yeccpars2_26_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 81).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 89).
 yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -620,7 +620,7 @@ yeccpars2_27_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 71).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 78).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -631,7 +631,7 @@ yeccpars2_28_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 76).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 83).
 yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -642,7 +642,7 @@ yeccpars2_29_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 44).
 yeccpars2_30_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -663,4 +663,4 @@ yeccpars2_31_(__Stack0) ->
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 98).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 106).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -524,7 +524,7 @@ yeccpars2_12_(__Stack0) ->
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , token_line ( __1 ) , token_atom ( __1 ) , token_type ( __2 ) }
+   { arg , # { line => token_line ( __1 ) , spec => token_atom ( __1 ) , type => token_type ( __2 ) } }
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
@@ -564,7 +564,7 @@ yeccpars2_18_(__Stack0) ->
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , token_line ( __1 ) , token_atom ( __1 ) , token_type ( __2 ) }
+   { arg , # { line => token_line ( __1 ) , spec => token_atom ( __1 ) , type => token_type ( __2 ) } }
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -494,7 +494,7 @@ yeccpars2_3_(__Stack0) ->
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { module , token_line ( __2 ) , token_chars ( __2 ) }
+   { module , # { line => token_line ( __2 ) , spec => token_atom ( __2 ) } }
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
@@ -502,7 +502,7 @@ yeccpars2_7_(__Stack0) ->
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { import , # { line => token_line ( __2 ) , import_spec => token_chars ( __2 ) } }
+   { import , # { line => token_line ( __2 ) , spec => token_chars ( __2 ) } }
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,19 +1,14 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 34).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 89).
 
-token_atom({_TokenType, _TokenLine, TokenChars}) ->
-    list_to_atom(TokenChars).
-token_chars({_TokenType, _TokenLine, TokenChars}) ->
-    TokenChars.
+token_chars({_TokenType, _Line, Chars}) ->
+    Chars.
 
-token_line({_TokenType, TokenLine}) ->
-    TokenLine;
-token_line({_TokenType, TokenLine, _TokenChars}) ->
-    TokenLine.
-
-token_type({TokenType, _TokenLine}) ->
-    TokenType.
+token_line({_TokenType, Line}) ->
+    Line;
+token_line({_TokenType, Line, _Chars}) ->
+    Line.
 
 -file("/usr/local/Cellar/erlang/21.2/lib/erlang/lib/parsetools-2.1.8/include/yeccpre.hrl", 0).
 %%
@@ -187,7 +182,7 @@ yecctoken2string(Other) ->
 
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.erl", 190).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.erl", 185).
 
 -dialyzer({nowarn_function, yeccpars2/7}).
 yeccpars2(0=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -482,7 +477,7 @@ yeccgoto_type(21, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 5).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 6).
 yeccpars2_3_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -490,85 +485,102 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 9).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { module , # { line => token_line ( __2 ) , spec => token_atom ( __2 ) } }
+   { module , # { line => token_line ( __2 ) ,
+    spec => list_to_atom ( token_chars ( __2 ) ) }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 8).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 11).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { import , # { line => token_line ( __2 ) , spec => token_chars ( __2 ) } }
+   { import , # { line => token_line ( __2 ) ,
+    spec => token_chars ( __2 ) }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 20).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 55).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , # { line => token_line ( __1 ) , spec => token_atom ( __1 ) , type => token_type ( __2 ) } }
+   { arg , # { line => token_line ( __1 ) ,
+    spec => list_to_atom ( token_chars ( __1 ) ) ,
+    type => __2 }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 14).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 30).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { bool , token_line ( __1 ) }
+   { type , # { line => token_line ( __1 ) ,
+    spec => bool } }
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 15).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 33).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { float , token_line ( __1 ) }
+   { type , # { line => token_line ( __1 ) ,
+    spec => float }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 16).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 37).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { int , token_line ( __1 ) }
+   { type , # { line => token_line ( __1 ) ,
+    spec => int }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 17).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 41).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { string , token_line ( __1 ) }
+   { type , # { line => token_line ( __1 ) ,
+    spec => string }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 21).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 50).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , # { line => token_line ( __1 ) , spec => token_atom ( __1 ) , type => token_type ( __2 ) } }
+   { arg , # { line => token_line ( __1 ) ,
+    spec => list_to_atom ( token_chars ( __1 ) ) ,
+    type => __2 }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 19).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 46).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -576,55 +588,74 @@ yeccpars2_20_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 24).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 61).
 yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { bool , token_chars ( __1 ) } } ]
+   [ { bool_lit , # { line => token_line ( __1 ) ,
+    spec => token_chars ( __1 ) ,
+    type => { type , # { line => token_line ( __1 ) , spec => bool } } }
+    } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 25).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 66).
 yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { float , token_chars ( __1 ) } } ]
+   [ { float_lit , # { line => token_line ( __1 ) ,
+    spec => token_chars ( __1 ) ,
+    type => { type , # { line => token_line ( __1 ) , spec => float } } }
+    } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 28).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 81).
 yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { identifier , token_atom ( __1 ) } } ]
+   [ { identifier , # { line => token_line ( __1 ) ,
+    spec => list_to_atom ( token_chars ( __1 ) ) }
+    } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 26).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 71).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { int , token_chars ( __1 ) } } ]
+   [ { int_lit , # { line => token_line ( __1 ) ,
+    spec => token_chars ( __1 ) ,
+    type => { type , # { line => token_line ( __1 ) , spec => int } } }
+    } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 27).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 76).
 yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { expr , token_line ( __1 ) , { string , token_chars ( __1 ) } } ]
+   [ { string_lit , # { line => token_line ( __1 ) ,
+    spec => list_to_binary ( token_chars ( __1 ) ) ,
+    type => { type , # { line => token_line ( __1 ) , spec => string } } }
+    } ]
   end | __Stack].
 
 -compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 12).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 22).
 yeccpars2_30_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { func , token_line ( __1 ) , token_chars ( __2 ) , __4 , token_type ( __6 ) , __8 }
+   { func , # { line => token_line ( __1 ) ,
+    spec => list_to_atom ( token_chars ( __2 ) ) ,
+    args => __4 ,
+    return_type => __6 ,
+    exprs => __8 }
+    }
   end | __Stack].
 
 -compile({inline,yeccpars2_31_/1}).
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 6).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 8).
 yeccpars2_31_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -632,4 +663,4 @@ yeccpars2_31_(__Stack0) ->
   end | __Stack].
 
 
--file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 48).
+-file("/Users/jkakar/rufus/rf/src/rufus_parse.yrl", 98).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -6,42 +6,92 @@ Terminals '(' ')' '{' '}' ',' func identifier import module bool bool_lit float 
 
 Rootsymbol root.
 
-root -> decl : ['$1'].
-root -> decl root : ['$1'] ++ '$2'.
+root -> decl :
+    ['$1'].
+root -> decl root :
+    ['$1'] ++ '$2'.
 
-decl -> import string_lit : {import, #{line => token_line('$2'), spec => token_chars('$2')}}.
-decl -> module identifier : {module, #{line => token_line('$2'), spec => token_atom('$2')}}.
-decl -> function : '$1'.
+decl -> import string_lit :
+    {import, #{line => token_line('$2'),
+               spec => token_chars('$2')}
+    }.
+decl -> module identifier :
+    {module, #{line => token_line('$2'),
+               spec => list_to_atom(token_chars('$2'))}
+    }.
+decl -> function :
+    '$1'.
 
-function -> func identifier '(' args ')' type '{' expr '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.
+function -> func identifier '(' args ')' type '{' expr '}' :
+    {func, #{line => token_line('$1'),
+             spec => list_to_atom(token_chars('$2')),
+             args => '$4',
+             return_type => '$6',
+             exprs => '$8'}
+    }.
 
-type -> bool : {bool, token_line('$1')}.
-type -> float : {float, token_line('$1')}.
-type -> int : {int, token_line('$1')}.
-type -> string : {string, token_line('$1')}.
+type -> bool :
+    {type, #{line => token_line('$1'),
+             spec => bool}}.
+type -> float :
+    {type, #{line => token_line('$1'),
+             spec => float}
+    }.
+type -> int :
+    {type, #{line => token_line('$1'),
+             spec => int}
+    }.
+type -> string :
+    {type, #{line => token_line('$1'),
+             spec => string}
+    }.
 
-args -> arg args : ['$1'|'$2'].
-args -> '$empty' : [].
-arg -> identifier type ',' : {arg, #{line => token_line('$1'), spec => token_atom('$1'), type => token_type('$2')}}.
-arg -> identifier type : {arg, #{line => token_line('$1'), spec => token_atom('$1'), type => token_type('$2')}}.
+args -> arg args :
+    ['$1'|'$2'].
+args -> '$empty' :
+    [].
+arg -> identifier type ',' :
+    {arg, #{line => token_line('$1'),
+            spec => list_to_atom(token_chars('$1')),
+            type => '$2'}
+    }.
+arg -> identifier type :
+    {arg, #{line => token_line('$1'),
+            spec => list_to_atom(token_chars('$1')),
+            type => '$2'}
+    }.
 
-expr -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
-expr -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].
-expr -> int_lit : [{expr, token_line('$1'), {int, token_chars('$1')}}].
-expr -> string_lit : [{expr, token_line('$1'), {string, token_chars('$1')}}].
-expr -> identifier : [{expr, token_line('$1'), {identifier, token_atom('$1')}}].
+expr -> bool_lit :
+    [{bool_lit, #{line => token_line('$1'),
+                  spec => token_chars('$1'),
+                  type => {type, #{line => token_line('$1'), spec => bool}}}
+    }].
+expr -> float_lit :
+    [{float_lit, #{line => token_line('$1'),
+                   spec => token_chars('$1'),
+                   type => {type, #{line => token_line('$1'), spec => float}}}
+    }].
+expr -> int_lit :
+    [{int_lit, #{line => token_line('$1'),
+                 spec => token_chars('$1'),
+                 type => {type, #{line => token_line('$1'), spec => int}}}
+    }].
+expr -> string_lit :
+    [{string_lit, #{line => token_line('$1'),
+                    spec => list_to_binary(token_chars('$1')),
+                    type => {type, #{line => token_line('$1'), spec => string}}}
+    }].
+expr -> identifier :
+    [{identifier, #{line => token_line('$1'),
+                    spec => list_to_atom(token_chars('$1'))}
+    }].
 
 Erlang code.
 
-token_atom({_TokenType, _TokenLine, TokenChars}) ->
-    list_to_atom(TokenChars).
-token_chars({_TokenType, _TokenLine, TokenChars}) ->
-    TokenChars.
+token_chars({_TokenType, _Line, Chars}) ->
+    Chars.
 
-token_line({_TokenType, TokenLine}) ->
-    TokenLine;
-token_line({_TokenType, TokenLine, _TokenChars}) ->
-    TokenLine.
-
-token_type({TokenType, _TokenLine}) ->
-    TokenType.
+token_line({_TokenType, Line}) ->
+    Line;
+token_line({_TokenType, Line, _Chars}) ->
+    Line.

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -9,8 +9,8 @@ Rootsymbol root.
 root -> decl : ['$1'].
 root -> decl root : ['$1'] ++ '$2'.
 
-decl -> import string_lit : {import, #{line => token_line('$2'), import_spec => token_chars('$2')}}.
-decl -> module identifier : {module, token_line('$2'), token_chars('$2')}.
+decl -> import string_lit : {import, #{line => token_line('$2'), spec => token_chars('$2')}}.
+decl -> module identifier : {module, #{line => token_line('$2'), spec => token_atom('$2')}}.
 decl -> function : '$1'.
 
 function -> func identifier '(' args ')' type '{' expr '}' : {func, token_line('$1'), token_chars('$2'), '$4', token_type('$6'), '$8'}.

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -9,7 +9,7 @@ Rootsymbol root.
 root -> decl : ['$1'].
 root -> decl root : ['$1'] ++ '$2'.
 
-decl -> import string_lit : {import, token_line('$2'), token_chars('$2')}.
+decl -> import string_lit : {import, #{line => token_line('$2'), import_spec => token_chars('$2')}}.
 decl -> module identifier : {module, token_line('$2'), token_chars('$2')}.
 decl -> function : '$1'.
 

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -11,24 +11,20 @@ root -> decl :
 root -> decl root :
     ['$1'] ++ '$2'.
 
-decl -> import string_lit :
-    {import, #{line => token_line('$2'),
-               spec => token_chars('$2')}
-    }.
+%% Declarations
+
 decl -> module identifier :
     {module, #{line => token_line('$2'),
                spec => list_to_atom(token_chars('$2'))}
     }.
+decl -> import string_lit :
+    {import, #{line => token_line('$2'),
+               spec => token_chars('$2')}
+    }.
 decl -> function :
     '$1'.
 
-function -> func identifier '(' args ')' type '{' expr '}' :
-    {func, #{line => token_line('$1'),
-             spec => list_to_atom(token_chars('$2')),
-             args => '$4',
-             return_type => '$6',
-             exprs => '$8'}
-    }.
+%% Primitive types
 
 type -> bool :
     {type, #{line => token_line('$1'),
@@ -46,6 +42,15 @@ type -> string :
              spec => string}
     }.
 
+%% Functions
+
+function -> func identifier '(' args ')' type '{' expr '}' :
+    {func, #{line => token_line('$1'),
+             spec => list_to_atom(token_chars('$2')),
+             args => '$4',
+             return_type => '$6',
+             exprs => '$8'}
+    }.
 args -> arg args :
     ['$1'|'$2'].
 args -> '$empty' :
@@ -60,6 +65,8 @@ arg -> identifier type :
             spec => list_to_atom(token_chars('$1')),
             type => '$2'}
     }.
+
+%% Literal values
 
 expr -> bool_lit :
     [{bool_lit, #{line => token_line('$1'),
@@ -81,6 +88,7 @@ expr -> string_lit :
                     spec => list_to_binary(token_chars('$1')),
                     type => {type, #{line => token_line('$1'), spec => string}}}
     }].
+
 expr -> identifier :
     [{identifier, #{line => token_line('$1'),
                     spec => list_to_atom(token_chars('$1'))}

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -22,8 +22,8 @@ type -> string : {string, token_line('$1')}.
 
 args -> arg args : ['$1'|'$2'].
 args -> '$empty' : [].
-arg -> identifier type ',' : {arg, token_line('$1'), token_atom('$1'), token_type('$2')}.
-arg -> identifier type : {arg, token_line('$1'), token_atom('$1'), token_type('$2')}.
+arg -> identifier type ',' : {arg, #{line => token_line('$1'), spec => token_atom('$1'), type => token_type('$2')}}.
+arg -> identifier type : {arg, #{line => token_line('$1'), spec => token_atom('$1'), type => token_type('$2')}}.
 
 expr -> bool_lit : [{expr, token_line('$1'), {bool, token_chars('$1')}}].
 expr -> float_lit : [{expr, token_line('$1'), {float, token_chars('$1')}}].

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -36,7 +36,13 @@ parse_function_returning_a_bool_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
+     {func, #{args => [],
+              exprs => [{bool_lit, #{line => 3,
+                                     spec => true,
+                                     type => {type, #{line => 3, spec => bool}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => bool}},
+              spec => 'True'}}
     ], Forms).
 
 parse_function_returning_a_float_test() ->
@@ -48,7 +54,13 @@ parse_function_returning_a_float_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => math}},
-     {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
+     {func, #{args => [],
+              exprs => [{float_lit, #{line => 3,
+                                      spec => 3.14159265359,
+                                      type => {type, #{line => 3, spec => float}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => float}},
+              spec => 'Pi'}}
     ], Forms).
 
 parse_function_returning_an_int_test() ->
@@ -60,7 +72,13 @@ parse_function_returning_an_int_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => rand}},
-     {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
+     {func, #{args => [],
+              exprs => [{int_lit, #{line => 3,
+                                    spec => 42,
+                                    type => {type, #{line => 3, spec => int}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => int}},
+              spec => 'Number'}}
     ], Forms).
 
 parse_function_returning_a_string_test() ->
@@ -72,12 +90,18 @@ parse_function_returning_a_string_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
+     {func, #{args => [],
+              exprs => [{string_lit, #{line => 3,
+                                       spec => <<"Hello">>,
+                                       type => {type, #{line => 3, spec => string}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => string}},
+              spec => 'Greeting'}}
     ], Forms).
 
 %% Arity-1 functions using an argument
 
-parse_function_taking_an_bool_and_returning_an_bool_test() ->
+parse_function_taking_a_bool_and_returning_a_bool_test() ->
     RufusText = "
     module example
     func Echo(n bool) bool { true }
@@ -86,7 +110,15 @@ parse_function_taking_an_bool_and_returning_an_bool_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => bool}}], bool, [{expr, 3, {bool, true}}]}
+     {func, #{args => [{arg, #{line => 3,
+                               spec => n,
+                               type => {type, #{line => 3, spec => bool}}}}],
+              exprs => [{bool_lit, #{line => 3,
+                                     spec => true,
+                                     type => {type, #{line => 3, spec => bool}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => bool}},
+              spec => 'Echo'}}
     ], Forms).
 
 parse_function_taking_an_float_and_returning_an_float_test() ->
@@ -98,7 +130,15 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => float}}], float, [{expr, 3, {float, 3.14159265359}}]}
+     {func, #{args => [{arg, #{line => 3,
+                               spec => n,
+                               type => {type, #{line => 3, spec => float}}}}],
+              exprs => [{float_lit, #{line => 3,
+                                      spec => 3.14159265359,
+                                      type => {type, #{line => 3, spec => float}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => float}},
+              spec => 'Echo'}}
     ], Forms).
 
 parse_function_taking_an_int_and_returning_an_int_test() ->
@@ -110,7 +150,15 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => int}}], int, [{expr, 3, {int, 42}}]}
+     {func, #{args => [{arg, #{line => 3,
+                               spec => n,
+                               type => {type, #{line => 3, spec => int}}}}],
+              exprs => [{int_lit, #{line => 3,
+                                    spec => 42,
+                                    type => {type, #{line => 3, spec => int}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => int}},
+              spec => 'Echo'}}
     ], Forms).
 
 parse_function_taking_an_string_and_returning_an_string_test() ->
@@ -121,6 +169,14 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => string}}], string, [{expr, 3, {string, "Hello"}}]}
+     {module,#{line => 2, spec => example}},
+     {func, #{args => [{arg, #{line => 3,
+                               spec => n,
+                               type => {type, #{line => 3, spec => string}}}}],
+              exprs => [{string_lit, #{line => 3,
+                                       spec => <<"Hello">>,
+                                       type => {type, #{line => 3, spec => string}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => string}},
+              spec => 'Echo'}}
     ], Forms).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -22,7 +22,7 @@ parse_import_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, 2, "foo"},
-     {import, 3, "bar"}
+     {import, #{line => 3, import_spec => "bar"}}
     ], Forms).
 
 %% Arity-0 functions returning a literal value for primitive types

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -8,7 +8,7 @@ parse_empty_module_test() ->
     {ok, Tokens, _} = rufus_scan:string("module empty"),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 1, "empty"}
+     {module, #{line => 1, spec => empty}}
     ], Forms).
 
 %% Import
@@ -21,8 +21,8 @@ parse_import_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "foo"},
-     {import, #{line => 3, import_spec => "bar"}}
+     {module, #{line => 2, spec => foo}},
+     {import, #{line => 3, spec => "bar"}}
     ], Forms).
 
 %% Arity-0 functions returning a literal value for primitive types
@@ -35,7 +35,7 @@ parse_function_returning_a_bool_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "True", [], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
@@ -47,7 +47,7 @@ parse_function_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "math"},
+     {module, #{line => 2, spec => math}},
      {func, 3, "Pi", [], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
@@ -59,7 +59,7 @@ parse_function_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "rand"},
+     {module, #{line => 2, spec => rand}},
      {func, 3, "Number", [], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
@@ -71,7 +71,7 @@ parse_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "Greeting", [], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).
 
@@ -85,7 +85,7 @@ parse_function_taking_an_bool_and_returning_an_bool_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "Echo", [{arg, 3, n, bool}], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
@@ -97,7 +97,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "Echo", [{arg, 3, n, float}], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
@@ -109,7 +109,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "Echo", [{arg, 3, n, int}], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
@@ -121,6 +121,6 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
-     {module, 2, "example"},
+     {module, #{line => 2, spec => example}},
      {func, 3, "Echo", [{arg, 3, n, string}], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -86,7 +86,7 @@ parse_function_taking_an_bool_and_returning_an_bool_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, 3, n, bool}], bool, [{expr, 3, {bool, true}}]}
+     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => bool}}], bool, [{expr, 3, {bool, true}}]}
     ], Forms).
 
 parse_function_taking_an_float_and_returning_an_float_test() ->
@@ -98,7 +98,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, 3, n, float}], float, [{expr, 3, {float, 3.14159265359}}]}
+     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => float}}], float, [{expr, 3, {float, 3.14159265359}}]}
     ], Forms).
 
 parse_function_taking_an_int_and_returning_an_int_test() ->
@@ -110,7 +110,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, 3, n, int}], int, [{expr, 3, {int, 42}}]}
+     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => int}}], int, [{expr, 3, {int, 42}}]}
     ], Forms).
 
 parse_function_taking_an_string_and_returning_an_string_test() ->
@@ -122,5 +122,5 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual([
      {module, #{line => 2, spec => example}},
-     {func, 3, "Echo", [{arg, 3, n, string}], string, [{expr, 3, {string, "Hello"}}]}
+     {func, 3, "Echo", [{arg, #{line => 3, spec => n, type => string}}], string, [{expr, 3, {string, "Hello"}}]}
     ], Forms).


### PR DESCRIPTION
Some examples in the README have been improved. The `rufus_parser:parse/1` function now produces forms that match `{Kind, #{...}}`. Using a consistent 2-tuple shape for parse forms, along with a map that we can easily add arbitrary data to, should help when implementing the next set of behaviors in the compiler. The `rufus_check_types`, `rufus_compile` and `rufus_compile_erlang` modules have all been updated to work with the new parse forms.