### PR TITLE
doc: Update Exported Identifiers RDR

### DIFF
--- a/doc/rdr/nnnn-exported-identifiers.md
+++ b/doc/rdr/nnnn-exported-identifiers.md
@@ -1,4 +1,4 @@
-# Exported names
+# Exported identifiers
 
 * Status: Drafting
 * Deciders: Jamu Kakar <<jkakar@kakar.ca>>
@@ -8,12 +8,12 @@
 
 A package should only export public modules, and a module should only export
 public types, constants and functions. It should not be possible for a user to
-access private names in a package they're using. What facilities should Rufus
-provide for users to manage encapsulation?
+access private identifiers in a package they're using. What facilities should
+Rufus provide for users to manage encapsulation?
 
 ## Decision drivers
 
-* A user can tell whether a name is public or private at a glance.
+* A user can tell whether an identifier is public or private at a glance.
 * It's not possible to access private modules from outside their package.
 * It's not possible to access private types, constants, or functions from
   outside their module.
@@ -22,9 +22,9 @@ provide for users to manage encapsulation?
 
 ### Option 1
 
-Names that start with an `_` or a lowercase letter in the range `a-z` are
-private. All other names are public. Privacy rules apply to the types,
-constants, and functions defined in modules.
+Idenifiers for types, constants, and functions defined in the module block that
+start with an `_` or a Unicode lower case letter (Unicode class "Ll") are
+private. All other identifiers for types, constants, and functions are exported.
 
 A public module called `math` with a public `Pi` constant and a private `float`
 constant:
@@ -38,10 +38,10 @@ const quarter float = 0.25
 
 It would be used exterally like:
 
-```
+```rufus
 module example
 
-import "package/path/math"
+import "rufus/math"
 
 func Area(radius tuple{:radius, int}) float {
     math.Pow(math.Pi * radius, 2)
@@ -53,10 +53,10 @@ accessible within the package.
 
 ### Option 2
 
-Extend the approach in Option 1 to include module names. Modules that start with
-an `_` or a lowercase letter are only accessible within the package. All other
-modules are externally accessible. This makes the privacy mechanism uniform and
-eliminates the need to special-case `internal` directories.
+Extend the approach in Option 1 to include module identifiers. Modules that
+start with an `_` or a lowercase letter are only accessible within the package.
+All other modules are externally accessible. This makes the privacy mechanism
+uniform and eliminates the need to special-case `internal` directories.
 
 A public module called `Math` with a public `Pi` constant and a private `float`
 constant:
@@ -70,10 +70,10 @@ const quarter float = 0.25
 
 It would be used externally like:
 
-```
+```rufus
 module example
 
-import "package/path/Math"
+import "rufus/Math"
 
 func Area(:radius, radius float) float {
     Math.Pow(Math.Pi * radius, 2)
@@ -87,12 +87,13 @@ func Area(:square, side float) float {
 ```
 
 An issue with this approach is that there can be problems with case-insensitive
-file systems. A private `math` module in `math.rf` could conflict with a public
+filesystems. A private `math` module in `math.rf` could conflict with a public
 `Math` module in `Math.rf`, for example.
 
 ## Decision outcome
 
-Chosen option: option 2, because it uses one unified pattern instead of
-introducing two patterns with case-sensitive names, and special-case handling of
-the `internal` directory. It also has the benefit of making private modules more
-obvious when reading code.
+Chosen option: option 2, because it uses one unified pattern instead of two
+different patterns. It also has the benefit of making private modules more
+obvious when reading code. We will fail a build if two or more Rufus source
+files in the same directory have names that differ only by case. This will
+prevent collision issues on case-insensitive filesystems.

--- a/doc/rdr/nnnn-exported-names.md
+++ b/doc/rdr/nnnn-exported-names.md
@@ -68,7 +68,7 @@ const Pi float = 3.14159265359
 const quarter float = 0.25
 ```
 
-It would be used exterally like:
+It would be used externally like:
 
 ```
 module example
@@ -85,6 +85,10 @@ func Area(:square, side float) float {
     Math.Pow(side, 2)
 }
 ```
+
+An issue with this approach is that there can be problems with case-insensitive
+file systems. A private `math` module in `math.rf` could conflict with a public
+`Math` module in `Math.rf`, for example.
 
 ## Decision outcome
 

--- a/doc/rdr/nnnn-exported-names.md
+++ b/doc/rdr/nnnn-exported-names.md
@@ -1,7 +1,7 @@
 # Exported names
 
-* Status: Accepted
-* Deciders: jkakar@kakar.ca <<jkakar@kakar.ca>>
+* Status: Drafting
+* Deciders: Jamu Kakar <<jkakar@kakar.ca>>
 * Date: 2019-05-03
 
 ## Context and problem statement
@@ -75,8 +75,14 @@ module example
 
 import "package/path/Math"
 
-func Area(radius tuple{:radius, int}) float {
-    Math.Pow(math.Pi * radius, 2)
+func Area(:radius, radius float) float {
+    Math.Pow(Math.Pi * radius, 2)
+}
+func Area(:rectangle, tuple{length, width float}) float {
+    length * width
+}
+func Area(:square, side float) float {
+    Math.Pow(side, 2)
 }
 ```
 


### PR DESCRIPTION
The _Exported Names_ RDR has been renamed to _Exported Identifiers_ and the status has been set back to `Drafting` status. We'll move RDR's into `Accepted` status when we make a release. The examples in the document have been improved, as well as calling out an important issue with the chosen design.