### PR TITLE
compiler: Add basic support for the binary + operator

### DIFF
--- a/rf/src/rufus_check_types.erl
+++ b/rf/src/rufus_check_types.erl
@@ -53,6 +53,6 @@ check_return_expr({type, #{spec := ReturnType}}, {identifier, #{locals := Locals
     end;
 check_return_expr({type, #{spec := _ReturnType}}, {_FormType, #{type := {type, #{spec := _ReturnType}}}}) ->
     ok;
-check_return_expr({type, #{spec := ReturnType}}, {_FormType, #{type := {type, #{spec := ActualReturnType}}}}) ->
-    Data = #{expected => ReturnType, actual => ActualReturnType},
+check_return_expr({type, #{spec := ExpectedReturnType}}, {_FormType, #{type := {type, #{spec := ActualReturnType}}}}) ->
+    Data = #{expected => ExpectedReturnType, actual => ActualReturnType},
     {error, unmatched_return_type, Data}.

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -20,6 +20,7 @@ eval(RufusText) ->
                 fun rufus_parse:parse/1,
                 fun rufus_scope_locals:forms/1,
                 fun rufus_check_types:forms/1,
+                fun rufus_typecheck_binary_op:forms/1,
                 fun rufus_compile_erlang:forms/1,
                 fun compile/1
                ],

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -45,7 +45,15 @@ forms(Acc, [{func, #{line := Line, spec := Name, args := Args, exprs := Exprs}}|
 forms(Acc, [{arg, #{line := Line, spec := Name, type := Type}}|T]) ->
     Form = {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]},
     forms([Form|Acc], T);
+forms(Acc, [{binary_op, #{line := Line, op := Op, left := Left, right := Right}}|T]) ->
+    [LeftExpr] = forms([], Left),
+    [RightExpr] = forms([], Right),
+    Form = {op, Line, Op, LeftExpr, RightExpr},
+    forms([Form|Acc], T);
 forms(Acc, []) ->
+    Acc;
+forms(Acc, _Unhandled) ->
+    io:format("unhandled form ->~n~p~n", [_Unhandled]),
     Acc.
 
 %% box converts Rufus types into Erlang `{<type>, <value>}` 2-tuples, such as

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 97).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 106).
 
 token_chars({_TokenType, _Line, Chars}) ->
     Chars.
@@ -235,8 +235,8 @@ yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -247,8 +247,14 @@ yeccpars2(29=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_29(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(30=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_30(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(31=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_31(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(31=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(32=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_32(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(33=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -388,21 +394,23 @@ yeccpars2_22(_, _, _, _, T, _, _) ->
 
 -dialyzer({nowarn_function, yeccpars2_23/7}).
 yeccpars2_23(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 25, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 26, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_23(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_23(S, identifier, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_23(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
 yeccpars2_23(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 -dialyzer({nowarn_function, yeccpars2_24/7}).
+yeccpars2_24(S, '+', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
 yeccpars2_24(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 32, Ss, Stack, T, Ts, Tzr);
 yeccpars2_24(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -427,13 +435,26 @@ yeccpars2_29(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_30(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_,_|Nss] = Ss,
  NewStack = yeccpars2_30_(Stack),
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+%% yeccpars2_31: see yeccpars2_23
+
+yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_32_(Stack),
  yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_33(S, '+', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
+yeccpars2_33(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_|Nss] = Ss,
+ NewStack = yeccpars2_33_(Stack),
+ yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_34(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
- NewStack = yeccpars2_31_(Stack),
+ NewStack = yeccpars2_34_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_arg/7}).
@@ -448,6 +469,12 @@ yeccgoto_args(10, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_args(12=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
+-dialyzer({nowarn_function, yeccgoto_binary_op/7}).
+yeccgoto_binary_op(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(31=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr).
+
 -dialyzer({nowarn_function, yeccgoto_decl/7}).
 yeccgoto_decl(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr);
@@ -456,7 +483,9 @@ yeccgoto_decl(3, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 -dialyzer({nowarn_function, yeccgoto_expr/7}).
 yeccgoto_expr(23, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_24(24, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_24(24, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(31, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_33(33, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -468,7 +497,7 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_34(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(13, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -477,7 +506,7 @@ yeccgoto_type(21, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 6).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 4).
 yeccpars2_3_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -485,7 +514,7 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 13).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 11).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -495,7 +524,7 @@ yeccpars2_7_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 17).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 15).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -505,21 +534,21 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 53).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 90).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 53).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 90).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 60).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 97).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -530,7 +559,7 @@ yeccpars2_14_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 24).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -539,7 +568,7 @@ yeccpars2_15_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 27).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -549,7 +578,7 @@ yeccpars2_16_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 31).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -559,7 +588,7 @@ yeccpars2_17_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 37).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 35).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -569,7 +598,7 @@ yeccpars2_18_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 55).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 92).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -580,7 +609,7 @@ yeccpars2_19_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 51).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 88).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -592,15 +621,23 @@ yeccpars2_20_(__Stack0) ->
 yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
+   [ __1 ]
+  end | __Stack].
+
+-compile({inline,yeccpars2_26_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 42).
+yeccpars2_26_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
    [ { bool_lit , # { line => token_line ( __1 ) ,
     spec => token_chars ( __1 ) ,
     type => { type , # { line => token_line ( __1 ) , spec => bool } } }
     } ]
   end | __Stack].
 
--compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 73).
-yeccpars2_26_(__Stack0) ->
+-compile({inline,yeccpars2_27_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 47).
+yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { float_lit , # { line => token_line ( __1 ) ,
@@ -609,9 +646,9 @@ yeccpars2_26_(__Stack0) ->
     } ]
   end | __Stack].
 
--compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 89).
-yeccpars2_27_(__Stack0) ->
+-compile({inline,yeccpars2_28_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 63).
+yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { identifier , # { line => token_line ( __1 ) ,
@@ -619,9 +656,9 @@ yeccpars2_27_(__Stack0) ->
     } ]
   end | __Stack].
 
--compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 78).
-yeccpars2_28_(__Stack0) ->
+-compile({inline,yeccpars2_29_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 52).
+yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { int_lit , # { line => token_line ( __1 ) ,
@@ -630,9 +667,9 @@ yeccpars2_28_(__Stack0) ->
     } ]
   end | __Stack].
 
--compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 83).
-yeccpars2_29_(__Stack0) ->
+-compile({inline,yeccpars2_30_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 57).
+yeccpars2_30_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    [ { string_lit , # { line => token_line ( __1 ) ,
@@ -641,9 +678,9 @@ yeccpars2_29_(__Stack0) ->
     } ]
   end | __Stack].
 
--compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 44).
-yeccpars2_30_(__Stack0) ->
+-compile({inline,yeccpars2_32_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 81).
+yeccpars2_32_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    { func , # { line => token_line ( __1 ) ,
@@ -654,13 +691,24 @@ yeccpars2_30_(__Stack0) ->
     }
   end | __Stack].
 
--compile({inline,yeccpars2_31_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 8).
-yeccpars2_31_(__Stack0) ->
+-compile({inline,yeccpars2_33_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 73).
+yeccpars2_33_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   { binary_op , # { line => token_line ( __2 ) ,
+    op => '+' ,
+    left => __1 ,
+    right => __3 } }
+  end | __Stack].
+
+-compile({inline,yeccpars2_34_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 6).
+yeccpars2_34_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 106).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 115).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,8 +1,6 @@
-Nonterminals
-  root decl expr function type arg args
-  .
+Nonterminals root decl expr exprs function type arg args binary_op.
 
-Terminals '(' ')' '{' '}' ',' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' ',' '+' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
@@ -11,7 +9,7 @@ root -> decl :
 root -> decl root :
     ['$1'] ++ '$2'.
 
-%% Declarations
+%% Module-level declarations
 
 decl -> module identifier :
     {module, #{line => token_line('$2'),
@@ -24,7 +22,7 @@ decl -> import string_lit :
 decl -> function :
     '$1'.
 
-%% Primitive types
+%% Scalar types
 
 type -> bool :
     {type, #{line => token_line('$1'),
@@ -42,31 +40,7 @@ type -> string :
              spec => string}
     }.
 
-%% Functions
-
-function -> func identifier '(' args ')' type '{' expr '}' :
-    {func, #{line => token_line('$1'),
-             spec => list_to_atom(token_chars('$2')),
-             args => '$4',
-             return_type => '$6',
-             exprs => '$8'}
-    }.
-args -> arg args :
-    ['$1'|'$2'].
-args -> '$empty' :
-    [].
-arg -> identifier type ',' :
-    {arg, #{line => token_line('$1'),
-            spec => list_to_atom(token_chars('$1')),
-            type => '$2'}
-    }.
-arg -> identifier type :
-    {arg, #{line => token_line('$1'),
-            spec => list_to_atom(token_chars('$1')),
-            type => '$2'}
-    }.
-
-%% Literal values
+%% Type literals
 
 expr -> bool_lit :
     [{bool_lit, #{line => token_line('$1'),
@@ -93,6 +67,41 @@ expr -> identifier :
     [{identifier, #{line => token_line('$1'),
                     spec => list_to_atom(token_chars('$1'))}
     }].
+
+expr -> binary_op :
+    ['$1'].
+
+%% Binary operations
+
+binary_op -> expr '+' expr :
+    {binary_op, #{line => token_line('$2'),
+                  op => '+',
+                  left => '$1',
+                  right => '$3'}}.
+
+%% Function declarations
+
+function -> func identifier '(' args ')' type '{' expr '}' :
+    {func, #{line => token_line('$1'),
+             spec => list_to_atom(token_chars('$2')),
+             args => '$4',
+             return_type => '$6',
+             exprs => '$8'}
+    }.
+args -> arg args :
+    ['$1'|'$2'].
+args -> '$empty' :
+    [].
+arg -> identifier type ',' :
+    {arg, #{line => token_line('$1'),
+            spec => list_to_atom(token_chars('$1')),
+            type => '$2'}
+    }.
+arg -> identifier type :
+    {arg, #{line => token_line('$1'),
+            spec => list_to_atom(token_chars('$1')),
+            type => '$2'}
+    }.
 
 Erlang code.
 

--- a/rf/src/rufus_typecheck_binary_op.erl
+++ b/rf/src/rufus_typecheck_binary_op.erl
@@ -1,6 +1,6 @@
 %% rufus_typecheck_binary_op enforces the invariant that a binary operation may
 %% only be performed exclusively with ints or exclusively with floats, not both
-%% at the same time.
+%% at the same time. No other types are supported with binary operators.
 -module(rufus_typecheck_binary_op).
 
 %% API exports

--- a/rf/src/rufus_typecheck_binary_op.erl
+++ b/rf/src/rufus_typecheck_binary_op.erl
@@ -1,0 +1,80 @@
+%% rufus_typecheck_binary_op enforces the invariant that a binary operation may
+%% only be performed exclusively with ints or exclusively with floats, not both
+%% at the same time.
+-module(rufus_typecheck_binary_op).
+
+%% API exports
+
+-export([forms/1]).
+
+%% API
+
+%% forms iterates over RufusForms and typechecks binary operations to ensure
+%% that the operands are exclusively ints or exclusively floats. Iteration stops
+%% at the first error. Returns values:
+%% - `{ok, RufusForms}` if no issues are found.
+%% - `{error, unmatched_operand_type, Data}` if an `int` operand is mixed with a
+%%   `float` operand. `Data` contains `left` and `right` atom keys pointing to
+%%   the illegal operands.
+%% - `{error, unsupported_operand_type, Data}` if a type other than an int is
+%%   used as an operand. `Data` contains `left` and `right` atom keys pointing
+%%   to the illegal operands.
+forms(RufusForms) ->
+    forms(RufusForms, RufusForms).
+
+%% Private API
+
+forms([H|T], Forms) ->
+    case check_expr(H) of
+        ok ->
+            forms(T, Forms);
+        Error ->
+            Error
+    end;
+forms([], Forms) ->
+    {ok, Forms}.
+
+check_expr({func, #{exprs := Exprs}}) ->
+    check_binary_op_exprs(Exprs);
+check_expr(_) ->
+    ok.
+
+check_binary_op_exprs([{binary_op, #{op := Op, left := [Left], right := [Right]}}|T]) ->
+    {_, #{type := {type, #{spec := LeftType}}}} = Left,
+    {_, #{type := {type, #{spec := RightType}}}} = Right,
+
+    LeftTypeSupported = check_operand_type_supported(LeftType),
+    RightTypeSupported = check_operand_type_supported(RightType),
+    OperandTypesMatch = check_operand_types_match(LeftType, RightType),
+    Data = #{op => Op, left => Left, right => Right},
+    case check_outcomes(Data, LeftTypeSupported, RightTypeSupported, OperandTypesMatch) of
+        ok ->
+            check_binary_op_exprs(T);
+        Error ->
+            Error
+    end;
+check_binary_op_exprs([_|T]) ->
+    check_binary_op_exprs(T);
+check_binary_op_exprs([]) ->
+    ok.
+
+check_operand_types_match(_Type, _Type) ->
+    ok;
+check_operand_types_match(_LeftType, _RightType) ->
+    error.
+
+check_operand_type_supported(float) ->
+    ok;
+check_operand_type_supported(int) ->
+    ok;
+check_operand_type_supported(_) ->
+    error.
+
+check_outcomes(Data, error, _RightTypeSupported, _OperandTypesMatch) ->
+    {error, unsupported_operand_type, Data};
+check_outcomes(Data, _LeftTypeSupported, error, _OperandTypesMatch) ->
+    {error, unsupported_operand_type, Data};
+check_outcomes(Data, _LeftTypeSupported, _RightTypeSupported, error) ->
+    {error, unmatched_operand_type, Data};
+check_outcomes(_Data, _LeftTypeSupported, _RightTypeSupported, _OperandTypesMatch) ->
+    ok.

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% Arity-0 functions returning a literal value for primitive types
+%% Arity-0 functions returning a literal value for scalar types
 
 forms_for_function_returning_a_bool_literal_test() ->
     RufusText = "
@@ -215,4 +215,40 @@ forms_for_function_taking_a_string_and_returning_a_string_test() ->
                            [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
                            [],
                            [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}],
+    ?assertEqual(Expected, ErlangForms).
+
+%% Arity-0 functions returning a sum of literal values for scalar types
+
+forms_for_function_returning_a_sum_of_int_literals_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int { 19 + 23 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    LeftExpr = {tuple, 3, [{atom, 3, int}, {integer, 3, 19}]},
+    RightExpr = {tuple, 3, [{atom, 3, int}, {integer, 3, 23}]},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'FortyTwo', 0}]},
+        {function, 3, 'FortyTwo', 0, [{clause, 3, [], [], [{op, 3, '+', LeftExpr, RightExpr}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_sum_of_float_literals_test() ->
+    RufusText = "
+    module example
+    func Pi() float { 1.0 + 2.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    LeftExpr = {tuple, 3, [{atom, 3, float}, {float, 3, 1.0}]},
+    RightExpr = {tuple, 3, [{atom, 3, float}, {float, 3, 2.14159265359}]},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Pi', 0}]},
+        {function, 3, 'Pi', 0, [{clause, 3, [], [], [{op, 3, '+', LeftExpr, RightExpr}]}]}
+    ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -16,7 +16,7 @@ eval_chain_with_error_handler_test() ->
     %% it encounters a failure from Error.
     ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
 
-%% Arity-0 functions returning a literal value for primitive types
+%% Arity-0 functions returning a literal value for scalar types
 
 eval_with_function_returning_a_bool_literal_test() ->
     RufusText = "
@@ -50,7 +50,7 @@ eval_with_function_returning_a_string_literal_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
-%% Arity-1 functions taking an unused parameter for primitive types
+%% Arity-1 functions taking an unused parameter for scalar types
 
 eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
@@ -88,7 +88,7 @@ eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
 
-%% Arity-1 functions taking an argument and returning it for primitive types
+%% Arity-1 functions taking an argument and returning it for scalar types
 
 eval_with_function_taking_a_bool_and_returning_it_test() ->
     RufusText = "

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -180,3 +180,59 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
               return_type => {type, #{line => 3, spec => string}},
               spec => 'Echo'}}
     ], Forms).
+
+%% Binary operations
+
+parse_function_adding_two_ints_test() ->
+    RufusText = "
+    module math
+    func Three() int { 1 + 2 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {module, #{line => 2, spec => math}},
+     {func, #{args => [],
+              exprs => [{binary_op, #{line => 3,
+                                      op => '+',
+                                      left => [{int_lit, #{line => 3,
+                                                           spec => 1,
+                                                           type => {type, #{line => 3, spec => int}}}}],
+                                      right => [{int_lit, #{line => 3,
+                                                            spec => 2,
+                                                            type => {type, #{line => 3, spec => int}}}}]}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => int}},
+              spec => 'Three'}}
+    ], Forms).
+
+parse_function_adding_three_ints_test() ->
+    RufusText = "
+    module math
+    func Six() int { 1 + 2 + 3 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+      {module,#{line => 2,spec => math}},
+      {func, #{args => [],
+               exprs => [{binary_op, #{left => [{int_lit, #{line => 3,
+                                                            spec => 1,
+                                                            type => {type, #{line => 3,
+                                                                             spec => int}}}}],
+                                       line => 3,
+                                       op => '+',
+                                       right => [{binary_op, #{left => [{int_lit, #{line => 3,
+                                                                                    spec => 2,
+                                                                                    type => {type, #{line => 3,
+                                                                                                     spec => int}}}}],
+                                                               line => 3,
+                                                               op => '+',
+                                                               right => [{int_lit, #{line => 3,
+                                                                                     spec => 3,
+                                                                                     type => {type, #{line => 3,
+                                                                                                      spec => int}}}}]}}]}}],
+               line => 3,
+               return_type => {type, #{line => 3, spec => int}},
+               spec => 'Six'}}
+    ], Forms).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -25,7 +25,7 @@ parse_import_test() ->
      {import, #{line => 3, spec => "bar"}}
     ], Forms).
 
-%% Arity-0 functions returning a literal value for primitive types
+%% Arity-0 functions returning a literal value for scalar types
 
 parse_function_returning_a_bool_test() ->
     RufusText = "

--- a/rf/test/rufus_typecheck_binary_op_test.erl
+++ b/rf/test/rufus_typecheck_binary_op_test.erl
@@ -1,0 +1,74 @@
+-module(rufus_typecheck_binary_op_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+forms_typecheck_for_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int { 19 + 23 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, TypecheckedForms} = rufus_typecheck_binary_op:forms(Forms),
+    ?assertEqual(Forms, TypecheckedForms).
+
+forms_typecheck_for_binary_op_with_floats_test() ->
+    RufusText = "
+    module example
+    func Pi() float { 1.0 + 2.14159265359 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, TypecheckedForms} = rufus_typecheck_binary_op:forms(Forms),
+    ?assertEqual(Forms, TypecheckedForms).
+
+forms_typecheck_for_binary_op_with_float_and_int_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int { 19.0 + 23 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = #{op => '+',
+                 left => {float_lit, #{line => 3,
+                                       spec => 19.0,
+                                       type => {type, #{line => 3, spec => float}}}},
+                 right => {int_lit, #{line => 3,
+                                      spec => 23,
+                                      type => {type, #{line => 3, spec => int}}}}},
+    {error, unmatched_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
+    ?assertEqual(Expected, Data).
+
+forms_typecheck_for_binary_op_with_bools_test() ->
+    RufusText = "
+    module example
+    func Concat() bool { true + false }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = #{op => '+',
+                 left => {bool_lit, #{line => 3,
+                                      spec => true,
+                                      type => {type, #{line => 3, spec => bool}}}},
+                 right => {bool_lit, #{line => 3,
+                                       spec => false,
+                                       type => {type, #{line => 3, spec => bool}}}}},
+    {error, unsupported_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
+    ?assertEqual(Expected, Data).
+
+forms_typecheck_for_binary_op_with_strings_test() ->
+    RufusText = "
+    module example
+    func Concat() string { \"port\" + \"manteau\" }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = #{op => '+',
+                 left => {string_lit, #{line => 3,
+                                        spec => <<"port">>,
+                                        type => {type, #{line => 3, spec => string}}}},
+                 right => {string_lit, #{line => 3,
+                                         spec => <<"manteau">>,
+                                         type => {type, #{line => 3, spec => string}}}}},
+    {error, unsupported_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
+    ?assertEqual(Expected, Data).


### PR DESCRIPTION
The parser has been extended to parse `binary_op` expressions of the form `A + B`. A new `rufus_typecheck_binary_op` module enforces the invariant that a binary operation may only be performed exclusively with ints or exclusively with floats, not both at the same time. No other types are supported with binary operators. The `rufus_compile_erlang` module translates `binary_op` expressions in Erlang abstract forms. Type checking for `binary_op` return values is not supported yet.