### PR TITLE
compiler: Use bare int and float values with function guards instead of boxed values

### DIFF
--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -73,13 +73,13 @@ forms(Acc, _Unhandled) ->
     Acc.
 
 % guards generates function guards for floats and integers.
-guards(Acc, [{arg, #{line := Line, spec := Name, type := {float, _}}}|T]) ->
-    GuardExpr = {call, Line, {remote, Line, erlang, is_float, [{float, Line, Name}]}},
+guards(Acc, [{arg, #{line := Line, spec := Name, type := {type, #{spec := float}}}}|T]) ->
+    GuardExpr = [{call, Line, {remote, Line, {atom, Line, erlang}, {atom, Line, is_float}}, [{var, Line, Name}]}],
     guards([GuardExpr|Acc], T);
-guards(Acc, [{arg, #{line := Line, spec := Name, type := {int, _}}}|T]) ->
-    GuardExpr = {call, Line, {remote, Line, erlang, is_integer, [{integer, Line, Name}]}},
+guards(Acc, [{arg, #{line := Line, spec := Name, type := {type, #{spec := int}}}}|T]) ->
+    GuardExpr = [{call, Line, {remote, Line, {atom, Line, erlang}, {atom, Line, is_integer}}, [{var, Line, Name}]}],
     guards([GuardExpr|Acc], T);
-guards(Acc, [_|T]) ->
+guards(Acc, [F|T]) ->
     guards(Acc, T);
 guards(Acc, []) ->
     Acc.

--- a/rf/src/rufus_compile_erlang.erl
+++ b/rf/src/rufus_compile_erlang.erl
@@ -33,17 +33,33 @@ forms(Acc, [{string_lit, _Context} = StringLit|T]) ->
     forms([Form|Acc], T);
 forms(Acc, [{identifier, #{line := Line, spec := Name, locals := Locals}}|T]) ->
     Type = maps:get(Name, Locals),
-    Form = {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]},
+    Form = case type_spec(Type) of
+        float ->
+            {var, Line, Name};
+        int ->
+            {var, Line, Name};
+        _ ->
+            {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]}
+    end,
     forms([Form|Acc], T);
 forms(Acc, [{func, #{line := Line, spec := Name, args := Args, exprs := Exprs}}|T]) ->
     ArgsForms = forms([], Args),
+    GuardForms = guards([], Args),
     ExprForms = lists:reverse(forms([], Exprs)),
-    FunctionForms = [{clause, Line, ArgsForms, [], ExprForms}],
+    FunctionForms = [{clause, Line, ArgsForms, GuardForms, ExprForms}],
     ExportForms = {attribute, Line, export, [{Name, length(Args)}]},
     Forms = {function, Line, Name, length(Args), FunctionForms},
     forms([Forms|[ExportForms|Acc]], T);
 forms(Acc, [{arg, #{line := Line, spec := Name, type := Type}}|T]) ->
-    Form = {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]},
+    Form = case type_spec(Type) of
+        float ->
+            {var, Line, Name};
+        int ->
+            {var, Line, Name};
+        _ ->
+            {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]}
+    end,
+    %% Form = {tuple, Line, [{atom, Line, type_spec(Type)}, {var, Line, Name}]},
     forms([Form|Acc], T);
 forms(Acc, [{binary_op, #{line := Line, op := Op, left := Left, right := Right}}|T]) ->
     [LeftExpr] = forms([], Left),
@@ -56,14 +72,25 @@ forms(Acc, _Unhandled) ->
     io:format("unhandled form ->~n~p~n", [_Unhandled]),
     Acc.
 
-%% box converts Rufus types into Erlang `{<type>, <value>}` 2-tuples, such as
-%% turning `3.14159265359` into `{float, 3.14159265359}`, for example.
+% guards generates function guards for floats and integers.
+guards(Acc, [{arg, #{line := Line, spec := Name, type := {float, _}}}|T]) ->
+    GuardExpr = {call, Line, {remote, Line, erlang, is_float, [{float, Line, Name}]}},
+    guards([GuardExpr|Acc], T);
+guards(Acc, [{arg, #{line := Line, spec := Name, type := {int, _}}}|T]) ->
+    GuardExpr = {call, Line, {remote, Line, erlang, is_integer, [{integer, Line, Name}]}},
+    guards([GuardExpr|Acc], T);
+guards(Acc, [_|T]) ->
+    guards(Acc, T);
+guards(Acc, []) ->
+    Acc.
+
+%% box converts Rufus forms for primitive values into Erlang forms.
 box({bool_lit, #{line := Line, spec := Value}}) ->
     {tuple, Line, [{atom, Line, bool}, {atom, Line, Value}]};
 box({float_lit, #{line := Line, spec := Value}}) ->
-    {tuple, Line, [{atom, Line, float}, {float, Line, Value}]};
+    {float, Line, Value};
 box({int_lit, #{line := Line, spec := Value}}) ->
-    {tuple, Line, [{atom, Line, int}, {integer, Line, Value}]};
+    {integer, Line, Value};
 box({string_lit, #{line := Line, spec := Value}}) ->
     StringExpr = {bin_element, Line, {string, Line, binary_to_list(Value)}, default, default},
     {tuple, Line, [{atom, Line, string}, {bin, Line, [StringExpr]}]}.

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -100,7 +100,7 @@ forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
                            [{var, 3, n}],
-                           [],
+                           [[{call,3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]],
                            [{float, 3, 3.14159265359}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
@@ -117,7 +117,7 @@ forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
                            [{var, 3, n}],
-                           [],
+                           [[{call,3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
                            [{integer, 3, 42}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
@@ -173,7 +173,7 @@ forms_for_function_taking_a_float_and_returning_a_float_test() ->
                   {function, 3, 'Echo', 1,
                       [{clause, 3,
                            [{var, 3, n}],
-                           [],
+                           [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]],
                            [{var, 3, n}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
@@ -191,7 +191,7 @@ forms_for_function_taking_an_int_and_returning_an_int_test() ->
                   {function, 3, 'Echo', 1,
                       [{clause, 3,
                            [{var, 3, n}],
-                           [],
+                           [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
                            [{var, 3, n}]}]}],
     ?assertEqual(Expected, ErlangForms).
 

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -29,12 +29,10 @@ forms_for_function_returning_a_float_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
-    FloatExpr = {float, 3, 3.14159265359},
-    BoxedFloatExpr = {tuple, 3, [{atom, 3, float}, FloatExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Pi', 0}]},
-        {function, 3, 'Pi', 0, [{clause, 3, [], [], [BoxedFloatExpr]}]}
+        {function, 3, 'Pi', 0, [{clause, 3, [], [], [{float, 3, 3.14159265359}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -46,12 +44,10 @@ forms_for_function_returning_an_int_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
-    IntegerExpr = {integer, 3, 42},
-    BoxedIntegerExpr = {tuple, 3, [{atom, 3, int}, IntegerExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Number', 0}]},
-        {function, 3, 'Number', 0, [{clause, 3, [], [], [BoxedIntegerExpr]}]}
+        {function, 3, 'Number', 0, [{clause, 3, [], [], [{integer, 3, 42}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -103,9 +99,9 @@ forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, float}, {var, 3, n}]}],
+                           [{var, 3, n}],
                            [],
-                           [{tuple, 3, [{atom, 3, float}, {float, 3, 3.14159265359}]}]}]}],
+                           [{float, 3, 3.14159265359}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
@@ -120,9 +116,9 @@ forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
                   {attribute, 3, export, [{'MaybeEcho', 1}]},
                   {function, 3, 'MaybeEcho', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, int}, {var, 3, n}]}],
+                           [{var, 3, n}],
                            [],
-                           [{tuple, 3, [{atom, 3, int}, {integer, 3, 42}]}]}]}],
+                           [{integer, 3, 42}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
@@ -140,7 +136,7 @@ forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
                       [{clause, 3,
                            [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
                            [],
-                           [{tuple, 3, [{atom, 3, string}, {bin,3, [StringExpr]}]}]}]}],
+                           [{tuple, 3, [{atom, 3, string}, {bin, 3, [StringExpr]}]}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 %% Arity-1 functions taking and using an argument
@@ -176,9 +172,9 @@ forms_for_function_taking_a_float_and_returning_a_float_test() ->
                   {attribute, 3, export, [{'Echo', 1}]},
                   {function, 3, 'Echo', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, float}, {var, 3, n}]}],
+                           [{var, 3, n}],
                            [],
-                           [{tuple, 3, [{atom, 3, float}, {var, 3, n}]}]}]}],
+                           [{var, 3, n}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_int_and_returning_an_int_test() ->
@@ -194,9 +190,9 @@ forms_for_function_taking_an_int_and_returning_an_int_test() ->
                   {attribute, 3, export, [{'Echo', 1}]},
                   {function, 3, 'Echo', 1,
                       [{clause, 3,
-                           [{tuple, 3, [{atom, 3, int}, {var, 3, n}]}],
+                           [{var, 3, n}],
                            [],
-                           [{tuple, 3, [{atom, 3, int}, {var, 3, n}]}]}]}],
+                           [{var, 3, n}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_string_and_returning_a_string_test() ->
@@ -227,8 +223,8 @@ forms_for_function_returning_a_sum_of_int_literals_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
-    LeftExpr = {tuple, 3, [{atom, 3, int}, {integer, 3, 19}]},
-    RightExpr = {tuple, 3, [{atom, 3, int}, {integer, 3, 23}]},
+    LeftExpr = {integer, 3, 19},
+    RightExpr = {integer, 3, 23},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'FortyTwo', 0}]},
@@ -244,8 +240,8 @@ forms_for_function_returning_a_sum_of_float_literals_test() ->
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
-    LeftExpr = {tuple, 3, [{atom, 3, float}, {float, 3, 1.0}]},
-    RightExpr = {tuple, 3, [{atom, 3, float}, {float, 3, 2.14159265359}]},
+    LeftExpr = {float, 3, 1.0},
+    RightExpr = {float, 3, 2.14159265359},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Pi', 0}]},

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -32,7 +32,7 @@ eval_with_function_returning_a_float_literal_test() ->
     func Pi() float { 3.14159265359 }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
-    ?assertEqual({float, 3.14159265359}, example:'Pi'()).
+    ?assertEqual(3.14159265359, example:'Pi'()).
 
 eval_with_function_returning_an_int_literal_test() ->
     RufusText = "
@@ -40,7 +40,7 @@ eval_with_function_returning_an_int_literal_test() ->
     func Number() int { 42 }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
-    ?assertEqual({int, 42}, example:'Number'()).
+    ?assertEqual(42, example:'Number'()).
 
 eval_with_function_returning_a_string_literal_test() ->
     RufusText = "
@@ -68,7 +68,7 @@ eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({float, 3.14159265359}, example:'MaybeEcho'({float, 3.14})).
+    ?assertEqual(3.14159265359, example:'MaybeEcho'(3.14)).
 
 eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
     RufusText = "
@@ -77,7 +77,7 @@ eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({int, 42}, example:'MaybeEcho'({int, 42})).
+    ?assertEqual(42, example:'MaybeEcho'(42)).
 
 eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     RufusText = "
@@ -106,7 +106,7 @@ eval_with_function_taking_a_float_and_returning_it_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({float, 3.14159265359}, example:'Echo'({float, 3.14159265359})).
+    ?assertEqual(3.14159265359, example:'Echo'(3.14159265359)).
 
 eval_with_function_taking_an_int_and_returning_it_test() ->
     RufusText = "
@@ -115,7 +115,7 @@ eval_with_function_taking_an_int_and_returning_it_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({int, 42}, example:'Echo'({int, 42})).
+    ?assertEqual(42, example:'Echo'(42)).
 
 eval_with_function_taking_a_string_and_returning_it_test() ->
     RufusText = "


### PR DESCRIPTION
`float` and `int` values are now represented as plain values like `1.4` and `42`, instead of being boxed as `{float, 1.4}` and `{int, 42}`. Functions are now generated with guards to match these types. This will make generating binary expressions for `+`, `-` and other operators easier and result in optimal performance for these operations.