### PR TITLE
compiler: Add functions to create and access Rufus forms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+rf/src/rufus_parse.erl linguist-generated=true
+rf/src/rufus_scan.erl linguist-generated=true

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -1,0 +1,55 @@
+-module(rufus_form).
+
+-include_lib("rufus_type.hrl").
+
+-export([
+    line/1,
+    make_literal/3,
+    make_inferred_type/2,
+    make_user_specified_type/2,
+    source/1,
+    spec/1
+]).
+
+%% Form API
+
+%% line returns the line number from the specified form. A line number is
+%% expected with every single form, so lack of one will result in a
+%% function_clause exception at runtime.
+line({_, #{line := Line}}) ->
+    Line.
+
+%% source user_specified, inferred stored for the form.
+-spec source({any(), #{source => inferred | speculation | user_specified}}) -> inferred | speculation | user_specified.
+source({_, #{source := Source}}) ->
+    Source.
+
+%% spec returns the human-readable name for the form.
+-spec spec({any(), #{spec => atom()}}) -> atom().
+spec({_, #{spec := Spec}}) ->
+    Spec.
+
+%% Literal form builder API
+
+%% make_literal returns a form for a literal value.
+-spec make_literal(bool | float | int | string, atom(), term()) -> bool_lit_form() | float_lit_form() | int_lit_form() | string_lit_form().
+make_literal(TypeSpec, Spec, Line) ->
+    FormType = list_to_atom(unicode:characters_to_list([atom_to_list(TypeSpec), "_lit"])),
+    {FormType, #{line => Line,
+                 spec => Spec,
+                 type => {type, #{line => Line,
+                                  spec => TypeSpec}}}}.
+
+%% Type form builder API
+
+-spec make_user_specified_type(atom(), integer()) -> {type, #{line => integer(), spec => atom()}}.
+make_user_specified_type(Spec, Line) ->
+    make_type(Spec, Line, user_specified).
+
+-spec make_inferred_type(type_spec(), integer()) -> {type, #{line => integer(), spec => atom()}}.
+make_inferred_type(Spec, Line) ->
+    make_type(Spec, Line, inferred).
+
+-spec make_type(type_spec(), integer(), inferred | user_specified) -> type_form().
+make_type(Spec, Line, _Source) ->
+    {type, #{spec => Spec, line => Line}}.%, source => Source}}.

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -22,6 +22,7 @@
 %% line returns the line number from the specified form. A line number is
 %% expected with every single form, so lack of one will result in a
 %% function_clause exception at runtime.
+-spec line({any(), #{line => integer()}}) -> integer().
 line({_, #{line := Line}}) ->
     Line.
 

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -27,8 +27,8 @@ line({_, #{line := Line}}) ->
     Line.
 
 %% source returns information about where the type information is from.
--spec source({any(), #{source => inferred | rufus_text}}) -> inferred | rufus_text.
-source({_, #{source := Source}}) ->
+-spec source({type, #{source => inferred | rufus_text}}) -> inferred | rufus_text.
+source({type, #{source := Source}}) ->
     Source.
 
 %% spec returns the human-readable name for the form.
@@ -87,16 +87,16 @@ make_arg(Spec, Type, Line) ->
 
 %% make_inferred_type creates a type form with 'inferred' as the 'source' value,
 %% to indicate that the type has been inferred by the compiler.
--spec make_inferred_type(type_spec(), integer()) -> {type, #{spec => atom(), line => integer()}}.
+-spec make_inferred_type(type_spec(), integer()) -> {type, #{spec => atom(), source => inferred | rufus_text, line => integer()}}.
 make_inferred_type(Spec, Line) ->
-    make_type(Spec, Line, inferred).
+    make_type(Spec, inferred, Line).
 
 %% make_type returns a type form with 'rufus_text' as the 'source' value, to
 %% indicate that the type came from source code.
--spec make_type(atom(), integer()) -> {type, #{spec => atom(), line => integer()}}.
+-spec make_type(atom(), integer()) -> {type, #{spec => atom(), source => inferred | rufus_text, line => integer()}}.
 make_type(Spec, Line) ->
-    make_type(Spec, Line, rufus_text).
+    make_type(Spec, rufus_text, Line).
 
--spec make_type(type_spec(), integer(), inferred | rufus_text) -> type_form().
-make_type(Spec, Line, _Source) ->
-    {type, #{spec => Spec, line => Line}}.%, source => Source}}.
+-spec make_type(type_spec(), inferred | rufus_text, integer()) -> type_form().
+make_type(Spec, Source, Line) ->
+    {type, #{spec => Spec, source => Source, line => Line}}.

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -4,18 +4,17 @@
 
 -export([
     line/1,
-    source/1,
-    spec/1,
-
-    make_module/2,
-    make_import/2,
-    make_identifier/2,
-    make_literal/3,
+    make_arg/3,
     make_binary_op/4,
     make_func/5,
-    make_arg/3,
+    make_identifier/2,
+    make_import/2,
     make_inferred_type/2,
-    make_type/2
+    make_literal/3,
+    make_module/2,
+    make_type/2,
+    source/1,
+    spec/1
 ]).
 
 %% Form API
@@ -26,8 +25,8 @@
 line({_, #{line := Line}}) ->
     Line.
 
-%% source user_specified, inferred stored for the form.
--spec source({any(), #{source => inferred | speculation | user_specified}}) -> inferred | speculation | user_specified.
+%% source returns information about where the type information is from.
+-spec source({any(), #{source => inferred | rufus_text}}) -> inferred | rufus_text.
 source({_, #{source := Source}}) ->
     Source.
 
@@ -38,17 +37,19 @@ spec({_, #{spec := Spec}}) ->
 
 %% Module form builder API
 
-%% make_module returns a form value for a module declaration.
+%% make_module returns a form for a module declaration.
 -spec make_module(atom(), integer()) -> {module, #{spec => atom(), line => integer()}}.
 make_module(Spec, Line) ->
     {module, #{spec => Spec, line => Line}}.
 
+%% make_import returns a form for an import statement.
 -spec make_import(list(), integer()) -> {import, #{spec => list(), line => integer()}}.
 make_import(Spec, Line) ->
     {import, #{spec => Spec, line => Line}}.
 
 %% Identifier form builder API
 
+%% make_identifier returns a form for an identifier.
 -spec make_identifier(atom(), integer()) -> {identifier, #{spec => atom(), line => integer()}}.
 make_identifier(Spec, Line) ->
     {identifier, #{spec => Spec, line => Line}}.

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 81).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
 
 token_chars({_TokenType, _Line, Chars}) ->
     Chars.
@@ -512,95 +512,85 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 13).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 12).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { module , # { line => token_line ( __2 ) ,
-    spec => list_to_atom ( token_chars ( __2 ) ) }
-    }
+   rufus_form : make_module ( list_to_atom ( token_chars ( __2 ) ) , token_line ( __2 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 17).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 13).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { import , # { line => token_line ( __2 ) ,
-    spec => token_chars ( __2 ) }
-    }
+   rufus_form : make_import ( token_chars ( __2 ) , token_line ( __2 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 65).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 41).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 65).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 41).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 72).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 43).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , # { line => token_line ( __1 ) ,
-    spec => list_to_atom ( token_chars ( __1 ) ) ,
-    type => __2 }
-    }
+   rufus_form : make_arg ( list_to_atom ( token_chars ( __1 ) ) , __2 , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 25).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 18).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_user_specified_type ( bool , token_line ( __1 ) )
+   rufus_form : make_type ( bool , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 19).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_user_specified_type ( float , token_line ( __1 ) )
+   rufus_form : make_type ( float , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 27).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 20).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_user_specified_type ( int , token_line ( __1 ) )
+   rufus_form : make_type ( int , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 21).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_user_specified_type ( string , token_line ( __1 ) )
+   rufus_form : make_type ( string , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 67).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 42).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { arg , # { line => token_line ( __1 ) ,
-    spec => list_to_atom ( token_chars ( __1 ) ) ,
-    type => __2 }
-    }
+   rufus_form : make_arg ( list_to_atom ( token_chars ( __1 ) ) , __2 , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 63).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 40).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -608,7 +598,7 @@ yeccpars2_20_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 43).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
 yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -616,7 +606,7 @@ yeccpars2_25_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 32).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 25).
 yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -624,7 +614,7 @@ yeccpars2_26_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
 yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -632,17 +622,15 @@ yeccpars2_27_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 38).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { identifier , # { line => token_line ( __1 ) ,
-    spec => list_to_atom ( token_chars ( __1 ) ) }
-    } ]
+   [ rufus_form : make_identifier ( list_to_atom ( token_chars ( __1 ) ) , token_line ( __1 ) ) ]
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 27).
 yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -650,7 +638,7 @@ yeccpars2_29_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 35).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
 yeccpars2_30_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -658,27 +646,19 @@ yeccpars2_30_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_32_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 56).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 38).
 yeccpars2_32_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { func , # { line => token_line ( __1 ) ,
-    spec => list_to_atom ( token_chars ( __2 ) ) ,
-    args => __4 ,
-    return_type => __6 ,
-    exprs => __8 }
-    }
+   rufus_form : make_func ( list_to_atom ( token_chars ( __2 ) ) , __4 , __6 , __8 , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_33_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 48).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
 yeccpars2_33_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   { binary_op , # { line => token_line ( __2 ) ,
-    op => '+' ,
-    left => __1 ,
-    right => __3 } }
+   rufus_form : make_binary_op ( '+' , __1 , __3 , token_line ( __2 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_34_/1}).
@@ -690,4 +670,4 @@ yeccpars2_34_(__Stack0) ->
   end | __Stack].
 
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 90).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 58).

--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 108).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 81).
 
 token_chars({_TokenType, _Line, Chars}) ->
     Chars.
@@ -532,21 +532,21 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 92).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 65).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 92).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 65).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 99).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 72).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -557,46 +557,39 @@ yeccpars2_14_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 25).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { type , # { line => token_line ( __1 ) ,
-    spec => bool } }
+   rufus_form : make_user_specified_type ( bool , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { type , # { line => token_line ( __1 ) ,
-    spec => float }
-    }
+   rufus_form : make_user_specified_type ( float , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 27).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { type , # { line => token_line ( __1 ) ,
-    spec => int }
-    }
+   rufus_form : make_user_specified_type ( int , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 37).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   { type , # { line => token_line ( __1 ) ,
-    spec => string }
-    }
+   rufus_form : make_user_specified_type ( string , token_line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 94).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 67).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -607,7 +600,7 @@ yeccpars2_19_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 90).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 63).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -615,7 +608,7 @@ yeccpars2_20_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 70).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 43).
 yeccpars2_25_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -623,29 +616,23 @@ yeccpars2_25_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_26_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 44).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 32).
 yeccpars2_26_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { bool_lit , # { line => token_line ( __1 ) ,
-    spec => token_chars ( __1 ) ,
-    type => { type , # { line => token_line ( __1 ) , spec => bool } } }
-    } ]
+   [ rufus_form : make_literal ( bool , token_chars ( __1 ) , token_line ( __1 ) ) ]
   end | __Stack].
 
 -compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
 yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { float_lit , # { line => token_line ( __1 ) ,
-    spec => token_chars ( __1 ) ,
-    type => { type , # { line => token_line ( __1 ) , spec => float } } }
-    } ]
+   [ rufus_form : make_literal ( float , token_chars ( __1 ) , token_line ( __1 ) ) ]
   end | __Stack].
 
 -compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 65).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 38).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -655,29 +642,23 @@ yeccpars2_28_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 54).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
 yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { int_lit , # { line => token_line ( __1 ) ,
-    spec => token_chars ( __1 ) ,
-    type => { type , # { line => token_line ( __1 ) , spec => int } } }
-    } ]
+   [ rufus_form : make_literal ( int , token_chars ( __1 ) , token_line ( __1 ) ) ]
   end | __Stack].
 
 -compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 59).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 35).
 yeccpars2_30_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   [ { string_lit , # { line => token_line ( __1 ) ,
-    spec => list_to_binary ( token_chars ( __1 ) ) ,
-    type => { type , # { line => token_line ( __1 ) , spec => string } } }
-    } ]
+   [ rufus_form : make_literal ( string , list_to_binary ( token_chars ( __1 ) ) , token_line ( __1 ) ) ]
   end | __Stack].
 
 -compile({inline,yeccpars2_32_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 83).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 56).
 yeccpars2_32_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -690,7 +671,7 @@ yeccpars2_32_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_33_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 75).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 48).
 yeccpars2_33_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -709,4 +690,4 @@ yeccpars2_34_(__Stack0) ->
   end | __Stack].
 
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 117).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 90).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -13,70 +13,38 @@ root -> decl root :
 
 %% Module-level declarations
 
-decl -> module identifier :
-    {module, #{line => token_line('$2'),
-               spec => list_to_atom(token_chars('$2'))}
-    }.
-decl -> import string_lit :
-    {import, #{line => token_line('$2'),
-               spec => token_chars('$2')}
-    }.
-decl -> function :
-    '$1'.
+decl -> module identifier : rufus_form:make_module(list_to_atom(token_chars('$2')), token_line('$2')).
+decl -> import string_lit : rufus_form:make_import(token_chars('$2'), token_line('$2')).
+decl -> function          : '$1'.
 
 %% Scalar types
 
-type -> bool : rufus_form:make_user_specified_type(bool, token_line('$1')).
-type -> float : rufus_form:make_user_specified_type(float, token_line('$1')).
-type -> int : rufus_form:make_user_specified_type(int, token_line('$1')).
-type -> string : rufus_form:make_user_specified_type(string, token_line('$1')).
+type -> bool   : rufus_form:make_type(bool, token_line('$1')).
+type -> float  : rufus_form:make_type(float, token_line('$1')).
+type -> int    : rufus_form:make_type(int, token_line('$1')).
+type -> string : rufus_form:make_type(string, token_line('$1')).
 
-%% Type literals
+%% Expressions
 
-expr -> bool_lit : [rufus_form:make_literal(bool, token_chars('$1'), token_line('$1'))].
-expr -> float_lit : [rufus_form:make_literal(float, token_chars('$1'), token_line('$1'))].
-expr -> int_lit : [rufus_form:make_literal(int, token_chars('$1'), token_line('$1'))].
+expr -> bool_lit   : [rufus_form:make_literal(bool, token_chars('$1'), token_line('$1'))].
+expr -> float_lit  : [rufus_form:make_literal(float, token_chars('$1'), token_line('$1'))].
+expr -> int_lit    : [rufus_form:make_literal(int, token_chars('$1'), token_line('$1'))].
 expr -> string_lit : [rufus_form:make_literal(string, list_to_binary(token_chars('$1')), token_line('$1'))].
-
-expr -> identifier :
-    [{identifier, #{line => token_line('$1'),
-                    spec => list_to_atom(token_chars('$1'))}
-    }].
-
-expr -> binary_op :
-    ['$1'].
+expr -> identifier : [rufus_form:make_identifier(list_to_atom(token_chars('$1')), token_line('$1'))].
+expr -> binary_op  : ['$1'].
 
 %% Binary operations
 
-binary_op -> expr '+' expr :
-    {binary_op, #{line => token_line('$2'),
-                  op => '+',
-                  left => '$1',
-                  right => '$3'}}.
+binary_op -> expr '+' expr : rufus_form:make_binary_op('+', '$1', '$3', token_line('$2')).
 
 %% Function declarations
 
-function -> func identifier '(' args ')' type '{' expr '}' :
-    {func, #{line => token_line('$1'),
-             spec => list_to_atom(token_chars('$2')),
-             args => '$4',
-             return_type => '$6',
-             exprs => '$8'}
-    }.
-args -> arg args :
-    ['$1'|'$2'].
-args -> '$empty' :
-    [].
-arg -> identifier type ',' :
-    {arg, #{line => token_line('$1'),
-            spec => list_to_atom(token_chars('$1')),
-            type => '$2'}
-    }.
-arg -> identifier type :
-    {arg, #{line => token_line('$1'),
-            spec => list_to_atom(token_chars('$1')),
-            type => '$2'}
-    }.
+function -> func identifier '(' args ')' type '{' expr '}' : rufus_form:make_func(list_to_atom(token_chars('$2')), '$4', '$6', '$8', token_line('$1')).
+
+args -> arg args           : ['$1'|'$2'].
+args -> '$empty'           : [].
+arg -> identifier type ',' : rufus_form:make_arg(list_to_atom(token_chars('$1')), '$2', token_line('$1')).
+arg -> identifier type     : rufus_form:make_arg(list_to_atom(token_chars('$1')), '$2', token_line('$1')).
 
 Erlang code.
 

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -26,44 +26,17 @@ decl -> function :
 
 %% Scalar types
 
-type -> bool :
-    {type, #{line => token_line('$1'),
-             spec => bool}}.
-type -> float :
-    {type, #{line => token_line('$1'),
-             spec => float}
-    }.
-type -> int :
-    {type, #{line => token_line('$1'),
-             spec => int}
-    }.
-type -> string :
-    {type, #{line => token_line('$1'),
-             spec => string}
-    }.
+type -> bool : rufus_form:make_user_specified_type(bool, token_line('$1')).
+type -> float : rufus_form:make_user_specified_type(float, token_line('$1')).
+type -> int : rufus_form:make_user_specified_type(int, token_line('$1')).
+type -> string : rufus_form:make_user_specified_type(string, token_line('$1')).
 
 %% Type literals
 
-expr -> bool_lit :
-    [{bool_lit, #{line => token_line('$1'),
-                  spec => token_chars('$1'),
-                  type => {type, #{line => token_line('$1'), spec => bool}}}
-    }].
-expr -> float_lit :
-    [{float_lit, #{line => token_line('$1'),
-                   spec => token_chars('$1'),
-                   type => {type, #{line => token_line('$1'), spec => float}}}
-    }].
-expr -> int_lit :
-    [{int_lit, #{line => token_line('$1'),
-                 spec => token_chars('$1'),
-                 type => {type, #{line => token_line('$1'), spec => int}}}
-    }].
-expr -> string_lit :
-    [{string_lit, #{line => token_line('$1'),
-                    spec => list_to_binary(token_chars('$1')),
-                    type => {type, #{line => token_line('$1'), spec => string}}}
-    }].
+expr -> bool_lit : [rufus_form:make_literal(bool, token_chars('$1'), token_line('$1'))].
+expr -> float_lit : [rufus_form:make_literal(float, token_chars('$1'), token_line('$1'))].
+expr -> int_lit : [rufus_form:make_literal(int, token_chars('$1'), token_line('$1'))].
+expr -> string_lit : [rufus_form:make_literal(string, list_to_binary(token_chars('$1')), token_line('$1'))].
 
 expr -> identifier :
     [{identifier, #{line => token_line('$1'),

--- a/rf/test/rufus_annotate_locals_test.erl
+++ b/rf/test/rufus_annotate_locals_test.erl
@@ -20,9 +20,9 @@ forms_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{args => [],
                  exprs => [{int_lit, #{line => 3, locals => #{}, spec => 42,
-                                       type => {type, #{line => 3, spec => int}}}}],
+                                       type => {type, #{line => 3, spec => int, source => inferred}}}}],
                  line => 3,
-                 return_type => {type, #{line => 3, spec => int}},
+                 return_type => {type, #{line => 3, spec => int, source => rufus_text}},
                  spec => 'Number'}
     }],
     ?assertEqual(Expected, AnnotatedForms).
@@ -42,13 +42,13 @@ forms_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => b,
-                            type => {type, #{line => 3, spec => bool}}}}],
+                            type => {type, #{line => 3, spec => bool, source => rufus_text}}}}],
            exprs => [{bool_lit, #{line => 3,
-                                   locals => #{b => {type, #{line => 3, spec => bool}}},
-                                   spec => true,
-                                   type => {type, #{line => 3, spec => bool}}}}],
+                                  locals => #{b => {type, #{line => 3, spec => bool, source => rufus_text}}},
+                                  spec => true,
+                                  type => {type, #{line => 3, spec => bool, source => inferred}}}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => bool}},
+           return_type => {type, #{line => 3, spec => bool, source => rufus_text}},
            spec => 'MaybeEcho'}
         }
     ],
@@ -67,13 +67,13 @@ forms_for_function_taking_a_float_and_returning_a_float_literal_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => n,
-                            type => {type, #{line => 3, spec => float}}}}],
+                            type => {type, #{line => 3, spec => float, source => rufus_text}}}}],
            exprs => [{float_lit, #{line => 3,
-                                   locals => #{n => {type, #{line => 3, spec => float}}},
+                                   locals => #{n => {type, #{line => 3, spec => float, source => rufus_text}}},
                                    spec => 3.14159265359,
-                                   type => {type, #{line => 3, spec => float}}}}],
+                                   type => {type, #{line => 3, spec => float, source => inferred}}}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => float}},
+           return_type => {type, #{line => 3, spec => float, source => rufus_text}},
            spec => 'MaybeEcho'}
         }
     ],
@@ -92,13 +92,13 @@ forms_for_function_taking_an_int_and_returning_an_int_literal_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => n,
-                            type => {type, #{line => 3, spec => int}}}}],
+                            type => {type, #{line => 3, spec => int, source => rufus_text}}}}],
            exprs => [{int_lit, #{line => 3,
-                                 locals => #{n => {type, #{line => 3, spec => int}}},
+                                 locals => #{n => {type, #{line => 3, spec => int, source => rufus_text}}},
                                  spec => 42,
-                                 type => {type, #{line => 3, spec => int}}}}],
+                                 type => {type, #{line => 3, spec => int, source => inferred}}}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => int}},
+           return_type => {type, #{line => 3, spec => int, source => rufus_text}},
            spec => 'MaybeEcho'}
         }
     ],
@@ -117,13 +117,13 @@ forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => s,
-                            type => {type, #{line => 3, spec => string}}}}],
+                            type => {type, #{line => 3, spec => string, source => rufus_text}}}}],
            exprs => [{string_lit, #{line => 3,
-                                    locals => #{s => {type, #{line => 3, spec => string}}},
+                                    locals => #{s => {type, #{line => 3, spec => string, source => rufus_text}}},
                                     spec => <<"Hello">>,
-                                    type => {type, #{line => 3, spec => string}}}}],
+                                    type => {type, #{line => 3, spec => string, source => inferred}}}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => string}},
+           return_type => {type, #{line => 3, spec => string, source => rufus_text}},
            spec => 'MaybeEcho'}
         }
     ],
@@ -144,13 +144,13 @@ forms_for_function_taking_a_bool_and_returning_it_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => b,
-                            type => {type, #{line => 3, spec => bool}}}}],
+                            type => {type, #{line => 3, spec => bool, source => rufus_text}}}}],
            exprs =>
                     [{identifier, #{line => 3,
-                                    locals => #{b => {type, #{line => 3, spec => bool}}},
+                                    locals => #{b => {type, #{line => 3, spec => bool, source => rufus_text}}},
                                     spec => b}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => bool}},
+           return_type => {type, #{line => 3, spec => bool, source => rufus_text}},
            spec => 'Echo'}
         }
     ],
@@ -169,13 +169,13 @@ forms_for_function_taking_a_float_and_returning_it_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => n,
-                            type => {type, #{line => 3, spec => float}}}}],
+                            type => {type, #{line => 3, spec => float, source => rufus_text}}}}],
            exprs =>
                     [{identifier, #{line => 3,
-                                    locals => #{n => {type, #{line => 3, spec => float}}},
+                                    locals => #{n => {type, #{line => 3, spec => float, source => rufus_text}}},
                                     spec => n}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => float}},
+           return_type => {type, #{line => 3, spec => float, source => rufus_text}},
            spec => 'Echo'}
         }
     ],
@@ -194,13 +194,13 @@ forms_for_function_taking_an_int_and_returning_it_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => n,
-                            type => {type, #{line => 3, spec => int}}}}],
+                            type => {type, #{line => 3, spec => int, source => rufus_text}}}}],
            exprs =>
                     [{identifier, #{line => 3,
-                                    locals => #{n => {type, #{line => 3, spec => int}}},
+                                    locals => #{n => {type, #{line => 3, spec => int, source => rufus_text}}},
                                     spec => n}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => int}},
+           return_type => {type, #{line => 3, spec => int, source => rufus_text}},
            spec => 'Echo'}
         }
     ],
@@ -219,13 +219,13 @@ forms_for_function_taking_a_string_and_returning_it_test() ->
         {func,
          #{args => [{arg, #{line => 3,
                             spec => s,
-                            type => {type, #{line => 3, spec => string}}}}],
+                            type => {type, #{line => 3, spec => string, source => rufus_text}}}}],
            exprs =>
                     [{identifier, #{line => 3,
-                                    locals => #{s => {type, #{line => 3, spec => string}}},
+                                    locals => #{s => {type, #{line => 3, spec => string, source => rufus_text}}},
                                     spec => s}}],
            line => 3,
-           return_type => {type, #{line => 3, spec => string}},
+           return_type => {type, #{line => 3, spec => string, source => rufus_text}},
            spec => 'Echo'}
         }
     ],

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -1,0 +1,9 @@
+-module(rufus_form_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+make_inferred_type_test() ->
+    ?assertEqual({type, #{spec => int, line => 4}}, rufus_form:make_user_specified_type(int, 4)).
+
+make_user_specified_type_test() ->
+    ?assertEqual({type, #{spec => float, line => 37}}, rufus_form:make_user_specified_type(float, 37)).

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -36,7 +36,7 @@ make_arg_test() ->
     ?assertEqual({arg, #{spec => n, type => Type, line => 52}}, rufus_form:make_arg(n, Type, 52)).
 
 make_inferred_type_test() ->
-    ?assertEqual({type, #{spec => int, line => 4}}, rufus_form:make_inferred_type(int, 4)).
+    ?assertEqual({type, #{spec => int, source => inferred, line => 4}}, rufus_form:make_inferred_type(int, 4)).
 
 make_type_test() ->
-    ?assertEqual({type, #{spec => float, line => 37}}, rufus_form:make_type(float, 37)).
+    ?assertEqual({type, #{spec => float, source => rufus_text, line => 37}}, rufus_form:make_type(float, 37)).

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -2,8 +2,41 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-make_inferred_type_test() ->
-    ?assertEqual({type, #{spec => int, line => 4}}, rufus_form:make_user_specified_type(int, 4)).
+make_module_test() ->
+    ?assertEqual({module, #{spec => example, line => 1}}, rufus_form:make_module(example, 1)).
 
-make_user_specified_type_test() ->
-    ?assertEqual({type, #{spec => float, line => 37}}, rufus_form:make_user_specified_type(float, 37)).
+make_import_test() ->
+    ?assertEqual({import, #{spec => "example", line => 3}}, rufus_form:make_import("example", 3)).
+
+make_identifier_test() ->
+    ?assertEqual({identifier, #{spec => n, line => 13}}, rufus_form:make_identifier(n, 13)).
+
+make_literal_test() ->
+    ?assertEqual({bool_lit, #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
+                 rufus_form:make_literal(bool, true, 7)),
+    ?assertEqual({float_lit, #{spec => "37.103", line => 92, type => rufus_form:make_inferred_type(float, 92)}},
+                 rufus_form:make_literal(float, "37.103", 92)),
+    ?assertEqual({int_lit, #{spec => "42", line => 5, type => rufus_form:make_inferred_type(int, 5)}},
+                 rufus_form:make_literal(int, "42", 5)),
+    ?assertEqual({string_lit, #{spec => <<"hello">>, line => 9, type => rufus_form:make_inferred_type(string, 9)}},
+                 rufus_form:make_literal(string, <<"hello">>, 9)).
+
+make_binary_op_test() ->
+    Arg = {int_lit, #{spec => 2, line => 4}},
+    ?assertEqual({binary_op, #{op => '+', left => Arg, right => Arg, line => 4}},
+                 rufus_form:make_binary_op('+', Arg, Arg, 4)).
+
+make_func_test() ->
+    Type = rufus_form:make_type(bool, 81),
+    ?assertEqual({func, #{spec => 'True', args => [], return_type => Type, exprs => [], line => 81}},
+                 rufus_form:make_func('True', [], Type, [], 81)).
+
+make_arg_test() ->
+    Type = rufus_form:make_type(int, 52),
+    ?assertEqual({arg, #{spec => n, type => Type, line => 52}}, rufus_form:make_arg(n, Type, 52)).
+
+make_inferred_type_test() ->
+    ?assertEqual({type, #{spec => int, line => 4}}, rufus_form:make_inferred_type(int, 4)).
+
+make_type_test() ->
+    ?assertEqual({type, #{spec => float, line => 37}}, rufus_form:make_type(float, 37)).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -39,9 +39,9 @@ parse_function_returning_a_bool_test() ->
      {func, #{args => [],
               exprs => [{bool_lit, #{line => 3,
                                      spec => true,
-                                     type => {type, #{line => 3, spec => bool}}}}],
+                                     type => {type, #{line => 3, spec => bool, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => bool}},
+              return_type => {type, #{line => 3, spec => bool, source => rufus_text}},
               spec => 'True'}}
     ], Forms).
 
@@ -57,9 +57,9 @@ parse_function_returning_a_float_test() ->
      {func, #{args => [],
               exprs => [{float_lit, #{line => 3,
                                       spec => 3.14159265359,
-                                      type => {type, #{line => 3, spec => float}}}}],
+                                      type => {type, #{line => 3, spec => float, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => float}},
+              return_type => {type, #{line => 3, spec => float, source => rufus_text}},
               spec => 'Pi'}}
     ], Forms).
 
@@ -75,9 +75,9 @@ parse_function_returning_an_int_test() ->
      {func, #{args => [],
               exprs => [{int_lit, #{line => 3,
                                     spec => 42,
-                                    type => {type, #{line => 3, spec => int}}}}],
+                                    type => {type, #{line => 3, spec => int, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => int}},
+              return_type => {type, #{line => 3, spec => int, source => rufus_text}},
               spec => 'Number'}}
     ], Forms).
 
@@ -93,9 +93,9 @@ parse_function_returning_a_string_test() ->
      {func, #{args => [],
               exprs => [{string_lit, #{line => 3,
                                        spec => <<"Hello">>,
-                                       type => {type, #{line => 3, spec => string}}}}],
+                                       type => {type, #{line => 3, spec => string, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => string}},
+              return_type => {type, #{line => 3, spec => string, source => rufus_text}},
               spec => 'Greeting'}}
     ], Forms).
 
@@ -112,12 +112,12 @@ parse_function_taking_a_bool_and_returning_a_bool_test() ->
      {module, #{line => 2, spec => example}},
      {func, #{args => [{arg, #{line => 3,
                                spec => n,
-                               type => {type, #{line => 3, spec => bool}}}}],
+                               type => {type, #{line => 3, spec => bool, source => rufus_text}}}}],
               exprs => [{bool_lit, #{line => 3,
                                      spec => true,
-                                     type => {type, #{line => 3, spec => bool}}}}],
+                                     type => {type, #{line => 3, spec => bool, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => bool}},
+              return_type => {type, #{line => 3, spec => bool, source => rufus_text}},
               spec => 'Echo'}}
     ], Forms).
 
@@ -132,12 +132,12 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
      {module, #{line => 2, spec => example}},
      {func, #{args => [{arg, #{line => 3,
                                spec => n,
-                               type => {type, #{line => 3, spec => float}}}}],
+                               type => {type, #{line => 3, spec => float, source => rufus_text}}}}],
               exprs => [{float_lit, #{line => 3,
                                       spec => 3.14159265359,
-                                      type => {type, #{line => 3, spec => float}}}}],
+                                      type => {type, #{line => 3, spec => float, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => float}},
+              return_type => {type, #{line => 3, spec => float, source => rufus_text}},
               spec => 'Echo'}}
     ], Forms).
 
@@ -152,12 +152,12 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
      {module, #{line => 2, spec => example}},
      {func, #{args => [{arg, #{line => 3,
                                spec => n,
-                               type => {type, #{line => 3, spec => int}}}}],
+                               type => {type, #{line => 3, spec => int, source => rufus_text}}}}],
               exprs => [{int_lit, #{line => 3,
                                     spec => 42,
-                                    type => {type, #{line => 3, spec => int}}}}],
+                                    type => {type, #{line => 3, spec => int, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => int}},
+              return_type => {type, #{line => 3, spec => int, source => rufus_text}},
               spec => 'Echo'}}
     ], Forms).
 
@@ -172,12 +172,12 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
      {module,#{line => 2, spec => example}},
      {func, #{args => [{arg, #{line => 3,
                                spec => n,
-                               type => {type, #{line => 3, spec => string}}}}],
+                               type => {type, #{line => 3, spec => string, source => rufus_text}}}}],
               exprs => [{string_lit, #{line => 3,
                                        spec => <<"Hello">>,
-                                       type => {type, #{line => 3, spec => string}}}}],
+                                       type => {type, #{line => 3, spec => string, source => inferred}}}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => string}},
+              return_type => {type, #{line => 3, spec => string, source => rufus_text}},
               spec => 'Echo'}}
     ], Forms).
 
@@ -197,12 +197,12 @@ parse_function_adding_two_ints_test() ->
                                       op => '+',
                                       left => [{int_lit, #{line => 3,
                                                            spec => 1,
-                                                           type => {type, #{line => 3, spec => int}}}}],
+                                                           type => {type, #{line => 3, spec => int, source => inferred}}}}],
                                       right => [{int_lit, #{line => 3,
                                                             spec => 2,
-                                                            type => {type, #{line => 3, spec => int}}}}]}}],
+                                                            type => {type, #{line => 3, spec => int, source => inferred}}}}]}}],
               line => 3,
-              return_type => {type, #{line => 3, spec => int}},
+              return_type => {type, #{line => 3, spec => int, source => rufus_text}},
               spec => 'Three'}}
     ], Forms).
 
@@ -220,20 +220,24 @@ parse_function_adding_three_ints_test() ->
                                                               left => [{int_lit, #{line => 3,
                                                                                    spec => 1,
                                                                                    type => {type, #{line => 3,
-                                                                                                    spec => int}}}}],
+                                                                                                    spec => int,
+                                                                                                    source => inferred}}}}],
                                                               right => [{int_lit, #{line => 3,
                                                                                     spec => 2,
                                                                                     type => {type, #{line => 3,
-                                                                                                     spec => int}}}}],
+                                                                                                     spec => int,
+                                                                                                     source => inferred}}}}],
                                                               line => 3}}],
                                        line => 3,
                                        op => '+',
                                        right => [{int_lit, #{line => 3,
                                                              spec => 3,
                                                              type => {type, #{line => 3,
-                                                                              spec => int}}}}]}}],
+                                                                              spec => int,
+                                                                              source => inferred}}}}]}}],
                line => 3,
                return_type => {type, #{line => 3,
-                                       spec => int}},
+                                       spec => int,
+                                       source => rufus_text}},
                spec => 'Six'}}
     ], Forms).

--- a/rf/test/rufus_typecheck_binary_op_test.erl
+++ b/rf/test/rufus_typecheck_binary_op_test.erl
@@ -32,10 +32,10 @@ forms_typecheck_for_binary_op_with_float_and_int_test() ->
     Expected = #{op => '+',
                  left => {float_lit, #{line => 3,
                                        spec => 19.0,
-                                       type => {type, #{line => 3, spec => float}}}},
+                                       type => {type, #{line => 3, spec => float, source => inferred}}}},
                  right => {int_lit, #{line => 3,
                                       spec => 23,
-                                      type => {type, #{line => 3, spec => int}}}}},
+                                      type => {type, #{line => 3, spec => int, source => inferred}}}}},
     {error, unmatched_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
     ?assertEqual(Expected, Data).
 
@@ -49,10 +49,10 @@ forms_typecheck_for_binary_op_with_bools_test() ->
     Expected = #{op => '+',
                  left => {bool_lit, #{line => 3,
                                       spec => true,
-                                      type => {type, #{line => 3, spec => bool}}}},
+                                      type => {type, #{line => 3, spec => bool, source => inferred}}}},
                  right => {bool_lit, #{line => 3,
                                        spec => false,
-                                       type => {type, #{line => 3, spec => bool}}}}},
+                                       type => {type, #{line => 3, spec => bool, source => inferred}}}}},
     {error, unsupported_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
     ?assertEqual(Expected, Data).
 
@@ -66,9 +66,9 @@ forms_typecheck_for_binary_op_with_strings_test() ->
     Expected = #{op => '+',
                  left => {string_lit, #{line => 3,
                                         spec => <<"port">>,
-                                        type => {type, #{line => 3, spec => string}}}},
+                                        type => {type, #{line => 3, spec => string, source => inferred}}}},
                  right => {string_lit, #{line => 3,
                                          spec => <<"manteau">>,
-                                         type => {type, #{line => 3, spec => string}}}}},
+                                         type => {type, #{line => 3, spec => string, source => inferred}}}}},
     {error, unsupported_operand_type, Data} = rufus_typecheck_binary_op:forms(Forms),
     ?assertEqual(Expected, Data).


### PR DESCRIPTION
A new `rufus_form` module contains methods to create Rufus forms, as well as to fetch data from them, such as their line number or spec. The grammar has been updated to use the new module, which has eliminated sources of duplication along with boilerplate that made the grammar hard to read. Type forms have a new `source` key that reveals where the type information came from, one of `rufus_text` and `inferred`.