### PR TITLE
compiler: Add basic support for the binary / operator

### DIFF
--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 55).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 57).
 
 token_chars({_TokenType, _Line, Chars}) ->
     Chars.
@@ -257,16 +257,20 @@ yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(35=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_36(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(37=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_37(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(38=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_38(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(40=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_40(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(41=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_41(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(42=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_42(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -420,7 +424,7 @@ yeccpars2_23(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 -dialyzer({nowarn_function, yeccpars2_24/7}).
 yeccpars2_24(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 41, Ss, Stack, T, Ts, Tzr);
 yeccpars2_24(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -430,6 +434,8 @@ yeccpars2_25(S, '+', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
 yeccpars2_25(S, '-', Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_25(S, '/', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
 yeccpars2_25(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
 yeccpars2_25(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
@@ -490,10 +496,7 @@ yeccpars2_33(_, _, _, _, T, _, _) ->
 
 %% yeccpars2_35: see yeccpars2_33
 
-yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_36_(Stack),
- yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_36: see yeccpars2_33
 
 yeccpars2_37(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
@@ -506,13 +509,23 @@ yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_39_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_40_(Stack),
+ yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_41_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_42_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_arg/7}).
@@ -537,6 +550,8 @@ yeccgoto_binary_op(33=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_binary_op(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_binary_op(35=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(36=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_decl/7}).
@@ -551,11 +566,13 @@ yeccgoto_expr(23, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_expr(25, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_25(25, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(33=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_37(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(35=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_36(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(36=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_37(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_exprs/7}).
 yeccgoto_exprs(23, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -573,7 +590,7 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(13, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -582,7 +599,7 @@ yeccgoto_type(21, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 8).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 9).
 yeccpars2_3_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -590,7 +607,7 @@ yeccpars2_3_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_7_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 14).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 15).
 yeccpars2_7_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -598,7 +615,7 @@ yeccpars2_7_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_8_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 15).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 16).
 yeccpars2_8_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -606,21 +623,21 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 47).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 47).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 51).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -628,7 +645,7 @@ yeccpars2_14_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_15_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 20).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 21).
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -636,7 +653,7 @@ yeccpars2_15_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 21).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 22).
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -644,7 +661,7 @@ yeccpars2_16_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 22).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 23).
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -652,7 +669,7 @@ yeccpars2_17_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 23).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 24).
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -660,7 +677,7 @@ yeccpars2_18_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 48).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 50).
 yeccpars2_19_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
@@ -668,7 +685,7 @@ yeccpars2_19_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 46).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 48).
 yeccpars2_20_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -676,21 +693,21 @@ yeccpars2_20_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_23_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
 yeccpars2_23_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
 yeccpars2_25_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_27_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
 yeccpars2_27_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -698,7 +715,7 @@ yeccpars2_27_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_28_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 31).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -706,7 +723,7 @@ yeccpars2_28_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
 yeccpars2_29_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -714,7 +731,7 @@ yeccpars2_29_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 31).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 32).
 yeccpars2_30_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -722,7 +739,7 @@ yeccpars2_30_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_31_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 32).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
 yeccpars2_31_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
@@ -730,27 +747,19 @@ yeccpars2_31_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_32_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 27).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 28).
 yeccpars2_32_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_36_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 39).
-yeccpars2_36_(__Stack0) ->
- [__3,__2,__1 | __Stack] = __Stack0,
- [begin
-   rufus_form : make_binary_op ( '-' , __1 , __3 , token_line ( __2 ) )
-  end | __Stack].
-
 -compile({inline,yeccpars2_37_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 38).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 42).
 yeccpars2_37_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_binary_op ( '+' , __1 , __3 , token_line ( __2 ) )
+   rufus_form : make_binary_op ( '/' , __1 , __3 , token_line ( __2 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_38_/1}).
@@ -758,24 +767,40 @@ yeccpars2_37_(__Stack0) ->
 yeccpars2_38_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_binary_op ( '*' , __1 , __3 , token_line ( __2 ) )
+   rufus_form : make_binary_op ( '-' , __1 , __3 , token_line ( __2 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_39_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 44).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 39).
 yeccpars2_39_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   rufus_form : make_binary_op ( '+' , __1 , __3 , token_line ( __2 ) )
+  end | __Stack].
+
+-compile({inline,yeccpars2_40_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 41).
+yeccpars2_40_(__Stack0) ->
+ [__3,__2,__1 | __Stack] = __Stack0,
+ [begin
+   rufus_form : make_binary_op ( '*' , __1 , __3 , token_line ( __2 ) )
+  end | __Stack].
+
+-compile({inline,yeccpars2_41_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 46).
+yeccpars2_41_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_func ( list_to_atom ( token_chars ( __2 ) ) , __4 , __6 , __8 , token_line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_40_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 10).
-yeccpars2_40_(__Stack0) ->
+-compile({inline,yeccpars2_42_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 11).
+yeccpars2_42_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 64).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 66).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,12 +1,13 @@
 Nonterminals root decl expr exprs function type arg args binary_op.
 
-Terminals '(' ')' '{' '}' ',' '+' '-' '*' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' ',' '+' '-' '*' '/' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
 Left 100 '+'.
 Left 100 '-'.
 Left 100 '*'.
+Left 100 '/'.
 
 root -> decl :
     ['$1'].
@@ -42,6 +43,7 @@ expr  -> binary_op  : '$1'.
 binary_op -> expr '+' expr : rufus_form:make_binary_op('+', '$1', '$3', token_line('$2')).
 binary_op -> expr '-' expr : rufus_form:make_binary_op('-', '$1', '$3', token_line('$2')).
 binary_op -> expr '*' expr : rufus_form:make_binary_op('*', '$1', '$3', token_line('$2')).
+binary_op -> expr '/' expr : rufus_form:make_binary_op('/', '$1', '$3', token_line('$2')).
 
 %% Function declarations
 

--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -12,7 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 69).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 71).
 
 strip(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
@@ -309,758 +309,762 @@ adjust_line(T, A, [_|Cs], L) ->
 %% input.
 
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.erl", 310).
-yystate() -> 58.
+yystate() -> 59.
 
-yystate(65, [46|Ics], Line, Tlen, _, _) ->
-    yystate(57, Ics, Line, Tlen+1, 12, Tlen);
+yystate(66, [117|Ics], Line, Tlen, _, _) ->
+    yystate(58, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(66, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,66};
+yystate(65, [97|Ics], Line, Tlen, _, _) ->
+    yystate(57, Ics, Line, Tlen+1, 24, Tlen);
+yystate(65, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(65, Ics, Line, Tlen+1, 12, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(65, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line,65};
-yystate(64, [111|Ics], Line, Tlen, _, _) ->
-    yystate(60, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(64, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,64};
-yystate(63, [117|Ics], Line, Tlen, _, _) ->
-    yystate(55, Ics, Line, Tlen+1, 23, Tlen);
-yystate(63, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,65};
+yystate(64, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(48, Ics, Line, Tlen+1, Action, Alen);
+yystate(64, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,64};
+yystate(63, [32|Ics], Line, Tlen, _, _) ->
+    yystate(63, Ics, Line, Tlen+1, 0, Tlen);
+yystate(63, [9|Ics], Line, Tlen, _, _) ->
+    yystate(63, Ics, Line, Tlen+1, 0, Tlen);
 yystate(63, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,63};
-yystate(62, [32|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
-yystate(62, [9|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 0, Tlen);
+    {0,Tlen,Ics,Line,63};
+yystate(62, [46|Ics], Line, Tlen, _, _) ->
+    yystate(64, Ics, Line, Tlen+1, 12, Tlen);
+yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(62, Ics, Line, Tlen+1, 12, Tlen);
 yystate(62, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,62};
-yystate(61, [100|Ics], Line, Tlen, _, _) ->
-    yystate(63, Ics, Line, Tlen+1, 23, Tlen);
+    {12,Tlen,Ics,Line,62};
+yystate(61, [111|Ics], Line, Tlen, _, _) ->
+    yystate(65, Ics, Line, Tlen+1, 24, Tlen);
 yystate(61, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(61, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,61};
-yystate(60, [97|Ics], Line, Tlen, _, _) ->
-    yystate(52, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,61};
+yystate(60, [100|Ics], Line, Tlen, _, _) ->
+    yystate(66, Ics, Line, Tlen+1, 24, Tlen);
 yystate(60, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(60, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,60};
-yystate(59, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line};
-yystate(58, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(50, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(42, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [116|Ics], Line, Tlen, Action, Alen) ->
+    {24,Tlen,Ics,Line,60};
+yystate(59, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(51, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [123|Ics], Line, Tlen, Action, Alen) ->
+    yystate(43, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(35, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(4, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [109|Ics], Line, Tlen, Action, Alen) ->
+    yystate(52, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [105|Ics], Line, Tlen, Action, Alen) ->
     yystate(34, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [115|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [109|Ics], Line, Tlen, Action, Alen) ->
-    yystate(53, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [105|Ics], Line, Tlen, Action, Alen) ->
+yystate(59, [103|Ics], Line, Tlen, Action, Alen) ->
     yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [103|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(27, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(59, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(25, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [44|Ics], Line, Tlen, Action, Alen) ->
+yystate(59, [104|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [100|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [99|Ics], Line, Tlen, Action, Alen) ->
     yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [43|Ics], Line, Tlen, Action, Alen) ->
-    yystate(9, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [42|Ics], Line, Tlen, Action, Alen) ->
-    yystate(1, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [41|Ics], Line, Tlen, Action, Alen) ->
-    yystate(2, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(10, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(18, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [32|Ics], Line, Tlen, Action, Alen) ->
+yystate(59, [98|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(54, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [47|Ics], Line, Tlen, Action, Alen) ->
+    yystate(32, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(24, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(16, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(8, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [42|Ics], Line, Tlen, Action, Alen) ->
+    yystate(0, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(3, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(19, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(63, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(55, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(59, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(63, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
     yystate(62, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(54, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(58, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(62, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(65, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 108 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 110, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(58, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,58};
-yystate(57, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(41, Ics, Line, Tlen+1, Action, Alen);
-yystate(57, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,57};
-yystate(56, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 9, Tlen);
+yystate(59, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 108 ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [C|Ics], Line, Tlen, Action, Alen) when C >= 110, C =< 114 ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(59, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,59};
+yystate(58, [108|Ics], Line, Tlen, _, _) ->
+    yystate(50, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(58, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,58};
+yystate(57, [116|Ics], Line, Tlen, _, _) ->
+    yystate(49, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(57, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,57};
+yystate(56, [45|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
+yystate(56, [43|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
 yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
-yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 9, Tlen);
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
 yystate(56, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,56};
-yystate(55, [108|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 23, Tlen);
-yystate(55, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {11,Tlen,Ics,Line,56};
+yystate(55, [10|Ics], Line, Tlen, _, _) ->
+    yystate(55, Ics, Line+1, Tlen+1, 1, Tlen);
 yystate(55, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,55};
-yystate(54, [10|Ics], Line, Tlen, _, _) ->
-    yystate(54, Ics, Line+1, Tlen+1, 1, Tlen);
+    {1,Tlen,Ics,Line,55};
 yystate(54, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,54};
-yystate(53, [111|Ics], Line, Tlen, _, _) ->
-    yystate(61, Ics, Line, Tlen+1, 23, Tlen);
+    {19,Tlen,Ics,Line};
 yystate(53, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 9, Tlen);
 yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 9, Tlen);
 yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 9, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 9, Tlen);
 yystate(53, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,53};
-yystate(52, [116|Ics], Line, Tlen, _, _) ->
-    yystate(44, Ics, Line, Tlen+1, 23, Tlen);
+    {9,Tlen,Ics,Line,53};
+yystate(52, [111|Ics], Line, Tlen, _, _) ->
+    yystate(60, Ics, Line, Tlen+1, 24, Tlen);
 yystate(52, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(52, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,52};
-yystate(51, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 2, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 2, Tlen);
+    {24,Tlen,Ics,Line,52};
 yystate(51, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line,51};
-yystate(50, Ics, Line, Tlen, _, _) ->
     {17,Tlen,Ics,Line};
-yystate(49, [45|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
-yystate(49, [43|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
+yystate(50, [101|Ics], Line, Tlen, _, _) ->
+    yystate(42, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(50, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,50};
+yystate(49, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 4, Tlen);
 yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 4, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 4, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 4, Tlen);
 yystate(49, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,49};
-yystate(48, [99|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line, Tlen+1, 23, Tlen);
-yystate(48, [97|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(48, [98|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(48, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    {4,Tlen,Ics,Line,49};
+yystate(48, [101|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 11, Tlen);
+yystate(48, [69|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 11, Tlen);
+yystate(48, [45|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
+yystate(48, [43|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
 yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(48, Ics, Line, Tlen+1, 11, Tlen);
 yystate(48, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,48};
-yystate(47, [101|Ics], Line, Tlen, _, _) ->
-    yystate(39, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(47, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,47};
-yystate(46, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(38, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(46, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,46};
+    {11,Tlen,Ics,Line,48};
+yystate(47, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(39, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,47};
+yystate(46, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 2, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 2, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 2, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 2, Tlen);
+yystate(46, Ics, Line, Tlen, _, _) ->
+    {2,Tlen,Ics,Line,46};
+yystate(45, [99|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line, Tlen+1, 24, Tlen);
+yystate(45, [97|Ics], Line, Tlen, _, _) ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(45, [98|Ics], Line, Tlen, _, _) ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(45, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 6, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 6, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(45, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,45};
+    {24,Tlen,Ics,Line,45};
 yystate(44, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 6, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 6, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 6, Tlen);
 yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 4, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 6, Tlen);
 yystate(44, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,44};
-yystate(43, [108|Ics], Line, Tlen, _, _) ->
-    yystate(51, Ics, Line, Tlen+1, 23, Tlen);
-yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {6,Tlen,Ics,Line,44};
 yystate(43, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,43};
-yystate(42, Ics, Line, Tlen, _, _) ->
     {16,Tlen,Ics,Line};
-yystate(41, [101|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 11, Tlen);
-yystate(41, [69|Ics], Line, Tlen, _, _) ->
-    yystate(49, Ics, Line, Tlen+1, 11, Tlen);
-yystate(41, [45|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
-yystate(41, [43|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
+yystate(42, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 7, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 7, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 7, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 7, Tlen);
+yystate(42, Ics, Line, Tlen, _, _) ->
+    {7,Tlen,Ics,Line,42};
+yystate(41, [108|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 24, Tlen);
+yystate(41, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(41, Ics, Line, Tlen+1, 11, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(41, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,41};
-yystate(40, [110|Ics], Line, Tlen, _, _) ->
-    yystate(48, Ics, Line, Tlen+1, 23, Tlen);
-yystate(40, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,41};
 yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(40, Ics, Line, Tlen+1, 11, Tlen);
 yystate(40, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,40};
-yystate(39, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 7, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
-yystate(39, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 7, Tlen);
+    {11,Tlen,Ics,Line,40};
 yystate(39, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,39};
-yystate(38, Ics, Line, Tlen, _, _) ->
     {13,Tlen,Ics,Line};
-yystate(37, [103|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 23, Tlen);
+yystate(38, [108|Ics], Line, Tlen, _, _) ->
+    yystate(46, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(38, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,38};
+yystate(37, [110|Ics], Line, Tlen, _, _) ->
+    yystate(45, Ics, Line, Tlen+1, 24, Tlen);
 yystate(37, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(37, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,37};
-yystate(36, [108|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,37};
+yystate(36, [103|Ics], Line, Tlen, _, _) ->
+    yystate(44, Ics, Line, Tlen+1, 24, Tlen);
 yystate(36, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(36, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,36};
-yystate(35, [111|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,36};
+yystate(35, [114|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 24, Tlen);
 yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(35, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,35};
-yystate(34, [114|Ics], Line, Tlen, _, _) ->
-    yystate(26, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,35};
+yystate(34, [110|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 24, Tlen);
+yystate(34, [109|Ics], Line, Tlen, _, _) ->
+    yystate(10, Ics, Line, Tlen+1, 24, Tlen);
 yystate(34, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(34, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,34};
+    {24,Tlen,Ics,Line,34};
+yystate(33, [115|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 24, Tlen);
+yystate(33, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(33, Ics, Line, Tlen+1, 11, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(33, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,33};
-yystate(32, [117|Ics], Line, Tlen, _, _) ->
-    yystate(40, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [108|Ics], Line, Tlen, _, _) ->
-    yystate(64, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [97|Ics], Line, Tlen, _, _) ->
-    yystate(36, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,33};
 yystate(32, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,32};
-yystate(31, [110|Ics], Line, Tlen, _, _) ->
-    yystate(23, Ics, Line, Tlen+1, 23, Tlen);
-yystate(31, [109|Ics], Line, Tlen, _, _) ->
-    yystate(7, Ics, Line, Tlen+1, 23, Tlen);
+    {23,Tlen,Ics,Line};
 yystate(31, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(31, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,31};
+    {24,Tlen,Ics,Line,31};
+yystate(30, [111|Ics], Line, Tlen, _, _) ->
+    yystate(38, Ics, Line, Tlen+1, 24, Tlen);
 yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(30, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,30};
-yystate(29, [110|Ics], Line, Tlen, _, _) ->
-    yystate(37, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,30};
+yystate(29, [117|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 24, Tlen);
+yystate(29, [108|Ics], Line, Tlen, _, _) ->
+    yystate(61, Ics, Line, Tlen+1, 24, Tlen);
+yystate(29, [97|Ics], Line, Tlen, _, _) ->
+    yystate(41, Ics, Line, Tlen+1, 24, Tlen);
 yystate(29, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(29, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,29};
-yystate(28, [115|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,29};
+yystate(28, [110|Ics], Line, Tlen, _, _) ->
+    yystate(36, Ics, Line, Tlen+1, 24, Tlen);
 yystate(28, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(28, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,28};
-yystate(27, [111|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,28};
+yystate(27, [117|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 24, Tlen);
 yystate(27, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(27, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,27};
-yystate(26, [117|Ics], Line, Tlen, _, _) ->
-    yystate(20, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,27};
+yystate(26, [116|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 24, Tlen);
 yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(26, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,26};
+    {24,Tlen,Ics,Line,26};
+yystate(25, [101|Ics], Line, Tlen, _, _) ->
+    yystate(15, Ics, Line, Tlen+1, 24, Tlen);
+yystate(25, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(65, Ics, Line, Tlen+1, 21, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(25, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,25};
-yystate(24, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 8, Tlen);
+    {24,Tlen,Ics,Line,25};
 yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
-yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 8, Tlen);
+    yystate(62, Ics, Line, Tlen+1, 21, Tlen);
 yystate(24, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line,24};
-yystate(23, [116|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(23, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,23};
-yystate(22, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(22, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,22};
-yystate(21, [105|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 23, Tlen);
+    {21,Tlen,Ics,Line,24};
+yystate(23, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(23, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,23};
+yystate(22, [111|Ics], Line, Tlen, _, _) ->
+    yystate(30, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(22, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,22};
 yystate(21, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 8, Tlen);
 yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 8, Tlen);
 yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 8, Tlen);
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 8, Tlen);
 yystate(21, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,21};
-yystate(20, [101|Ics], Line, Tlen, _, _) ->
-    yystate(14, Ics, Line, Tlen+1, 23, Tlen);
+    {8,Tlen,Ics,Line,21};
+yystate(20, [105|Ics], Line, Tlen, _, _) ->
+    yystate(28, Ics, Line, Tlen+1, 24, Tlen);
 yystate(20, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(20, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,20};
-yystate(19, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 3, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 3, Tlen);
-yystate(19, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line,19};
-yystate(18, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(22, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(46, Ics, Line, Tlen+1, Action, Alen);
-yystate(18, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,18};
+    {24,Tlen,Ics,Line,20};
+yystate(19, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(23, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(19, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,19};
+yystate(18, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 5, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 5, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 5, Tlen);
+yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 5, Tlen);
+yystate(18, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,18};
+yystate(17, [111|Ics], Line, Tlen, _, _) ->
+    yystate(9, Ics, Line, Tlen+1, 24, Tlen);
+yystate(17, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(17, Ics, Line, Tlen, _, _) ->
-    {18,Tlen,Ics,Line};
-yystate(16, [116|Ics], Line, Tlen, _, _) ->
-    yystate(24, Ics, Line, Tlen+1, 23, Tlen);
-yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,17};
 yystate(16, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,16};
+    {18,Tlen,Ics,Line};
 yystate(15, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 10, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 10, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 10, Tlen);
 yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 5, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 10, Tlen);
 yystate(15, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,15};
+    {10,Tlen,Ics,Line,15};
 yystate(14, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 3, Tlen);
 yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 3, Tlen);
 yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 3, Tlen);
 yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 10, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 3, Tlen);
 yystate(14, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,14};
-yystate(13, [114|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 23, Tlen);
+    {3,Tlen,Ics,Line,14};
+yystate(13, [116|Ics], Line, Tlen, _, _) ->
+    yystate(21, Ics, Line, Tlen+1, 24, Tlen);
 yystate(13, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(13, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,13};
-yystate(12, [111|Ics], Line, Tlen, _, _) ->
-    yystate(4, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,13};
+yystate(12, [114|Ics], Line, Tlen, _, _) ->
+    yystate(20, Ics, Line, Tlen+1, 24, Tlen);
 yystate(12, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(12, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,12};
-yystate(11, [116|Ics], Line, Tlen, _, _) ->
-    yystate(19, Ics, Line, Tlen+1, 23, Tlen);
-yystate(11, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,12};
 yystate(11, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,11};
-yystate(10, Ics, Line, Tlen, _, _) ->
     {14,Tlen,Ics,Line};
+yystate(10, [112|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(10, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,10};
+yystate(9, [110|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 24, Tlen);
+yystate(9, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(65, Ics, Line, Tlen+1, 20, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(9, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,9};
-yystate(8, [114|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 23, Tlen);
-yystate(8, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,9};
 yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(62, Ics, Line, Tlen+1, 20, Tlen);
 yystate(8, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,8};
-yystate(7, [112|Ics], Line, Tlen, _, _) ->
-    yystate(0, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(7, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,7};
-yystate(6, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(22, Ics, Line, Tlen+1, Action, Alen);
-yystate(6, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,6};
-yystate(5, [116|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 23, Tlen);
+    {20,Tlen,Ics,Line,8};
+yystate(7, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(23, Ics, Line, Tlen+1, Action, Alen);
+yystate(7, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,7};
+yystate(6, [116|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(6, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,6};
+yystate(5, [114|Ics], Line, Tlen, _, _) ->
+    yystate(13, Ics, Line, Tlen+1, 24, Tlen);
 yystate(5, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(5, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,5};
-yystate(4, [110|Ics], Line, Tlen, _, _) ->
-    yystate(3, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,5};
+yystate(4, [116|Ics], Line, Tlen, _, _) ->
+    yystate(12, Ics, Line, Tlen+1, 24, Tlen);
 yystate(4, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(4, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,4};
-yystate(3, [115|Ics], Line, Tlen, _, _) ->
-    yystate(11, Ics, Line, Tlen+1, 23, Tlen);
-yystate(3, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,4};
 yystate(3, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,3};
-yystate(2, Ics, Line, Tlen, _, _) ->
     {15,Tlen,Ics,Line};
+yystate(2, [111|Ics], Line, Tlen, _, _) ->
+    yystate(5, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(2, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line,2};
+yystate(1, [115|Ics], Line, Tlen, _, _) ->
+    yystate(6, Ics, Line, Tlen+1, 24, Tlen);
+yystate(1, [34|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 24, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(31, Ics, Line, Tlen+1, 24, Tlen);
 yystate(1, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line};
-yystate(0, [111|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 23, Tlen);
-yystate(0, [34|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 23, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
-yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(30, Ics, Line, Tlen+1, 23, Tlen);
+    {24,Tlen,Ics,Line,1};
 yystate(0, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line,0};
+    {22,Tlen,Ics,Line};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -1118,130 +1122,137 @@ yyaction(21, _, _, TokenLine) ->
     yyaction_21(TokenLine);
 yyaction(22, _, _, TokenLine) ->
     yyaction_22(TokenLine);
-yyaction(23, TokenLen, YYtcs, TokenLine) ->
+yyaction(23, _, _, TokenLine) ->
+    yyaction_23(TokenLine);
+yyaction(24, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_23(TokenChars, TokenLine);
+    yyaction_24(TokenChars, TokenLine);
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/0}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 37).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 38).
 yyaction_0() ->
      skip_token .
 
 -compile({inline,yyaction_1/0}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 38).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 39).
 yyaction_1() ->
      skip_token .
 
 -compile({inline,yyaction_2/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 40).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 41).
 yyaction_2(TokenLine) ->
      { token, { bool, TokenLine } } .
 
 -compile({inline,yyaction_3/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 41).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 42).
 yyaction_3(TokenLine) ->
      { token, { const, TokenLine } } .
 
 -compile({inline,yyaction_4/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 42).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 43).
 yyaction_4(TokenLine) ->
      { token, { float, TokenLine } } .
 
 -compile({inline,yyaction_5/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 43).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 44).
 yyaction_5(TokenLine) ->
      { token, { int, TokenLine } } .
 
 -compile({inline,yyaction_6/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 44).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 45).
 yyaction_6(TokenLine) ->
      { token, { string, TokenLine } } .
 
 -compile({inline,yyaction_7/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 46).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 47).
 yyaction_7(TokenLine) ->
      { token, { module, TokenLine } } .
 
 -compile({inline,yyaction_8/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 47).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 48).
 yyaction_8(TokenLine) ->
      { token, { import, TokenLine } } .
 
 -compile({inline,yyaction_9/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 48).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 49).
 yyaction_9(TokenLine) ->
      { token, { func, TokenLine } } .
 
 -compile({inline,yyaction_10/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 50).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 51).
 yyaction_10(TokenChars, TokenLine) ->
      { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
 
 -compile({inline,yyaction_11/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 51).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 52).
 yyaction_11(TokenChars, TokenLine) ->
      { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
 
 -compile({inline,yyaction_12/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 52).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 53).
 yyaction_12(TokenChars, TokenLine) ->
      { token, { int_lit, TokenLine, list_to_integer (TokenChars) } } .
 
 -compile({inline,yyaction_13/3}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 53).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 54).
 yyaction_13(TokenChars, TokenLen, TokenLine) ->
      S = strip (TokenChars, TokenLen),
      { token, { string_lit, TokenLine, S } } .
 
 -compile({inline,yyaction_14/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 56).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 57).
 yyaction_14(TokenLine) ->
      { token, { '(', TokenLine } } .
 
 -compile({inline,yyaction_15/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 57).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 58).
 yyaction_15(TokenLine) ->
      { token, { ')', TokenLine } } .
 
 -compile({inline,yyaction_16/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 58).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 59).
 yyaction_16(TokenLine) ->
      { token, { '{', TokenLine } } .
 
 -compile({inline,yyaction_17/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 59).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 60).
 yyaction_17(TokenLine) ->
      { token, { '}', TokenLine } } .
 
 -compile({inline,yyaction_18/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 60).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 61).
 yyaction_18(TokenLine) ->
      { token, { ',', TokenLine } } .
 
 -compile({inline,yyaction_19/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 61).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 62).
 yyaction_19(TokenLine) ->
      { token, { '=', TokenLine } } .
 
 -compile({inline,yyaction_20/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 62).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 63).
 yyaction_20(TokenLine) ->
      { token, { '+', TokenLine } } .
 
 -compile({inline,yyaction_21/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 63).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 64).
 yyaction_21(TokenLine) ->
      { token, { '-', TokenLine } } .
 
 -compile({inline,yyaction_22/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 64).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 65).
 yyaction_22(TokenLine) ->
      { token, { '*', TokenLine } } .
 
--compile({inline,yyaction_23/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 65).
-yyaction_23(TokenChars, TokenLine) ->
+-compile({inline,yyaction_23/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 66).
+yyaction_23(TokenLine) ->
+     { token, { '/', TokenLine } } .
+
+-compile({inline,yyaction_24/2}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 67).
+yyaction_24(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
 -file("/usr/local/Cellar/erlang/22.0.1/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/src/rufus_scan.xrl
+++ b/rf/src/rufus_scan.xrl
@@ -33,6 +33,7 @@ Match         = =
 Plus          = \+
 Minus         = \-
 Multiply      = \*
+Divide        = \/
 
 Rules.
 
@@ -64,6 +65,7 @@ Rules.
 {Plus}          : {token, {'+', TokenLine}}.
 {Minus}         : {token, {'-', TokenLine}}.
 {Multiply}      : {token, {'*', TokenLine}}.
+{Divide}        : {token, {'/', TokenLine}}.
 {Identifier}    : {token, {identifier, TokenLine, TokenChars}}.
 
 Erlang code.

--- a/rf/test/rufus_compile_erlang_test.erl
+++ b/rf/test/rufus_compile_erlang_test.erl
@@ -238,7 +238,8 @@ forms_for_function_returning_a_sum_of_three_int_literals_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_typecheck_binary_op:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(AnnotatedForms),
     LeftExpr = {op, 3, '+', {integer, 3, 19}, {integer, 3, 23}},
     BinaryOpExpr = {op, 3, '+', LeftExpr, {integer, 3, 17}},
     Expected = [
@@ -289,7 +290,8 @@ forms_for_function_returning_a_difference_of_three_int_literals_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_typecheck_binary_op:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(AnnotatedForms),
     LeftExpr = {op, 3, '-', {integer, 3, 1500}, {integer, 3, 150}},
     BinaryOpExpr = {op, 3, '-', LeftExpr, {integer, 3, 15}},
     Expected = [
@@ -340,7 +342,8 @@ forms_for_function_returning_a_product_of_three_int_literals_test() ->
     ",
     {ok, Tokens, _} = rufus_scan:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_typecheck_binary_op:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(AnnotatedForms),
     LeftExpr = {op, 3, '*', {integer, 3, 3}, {integer, 3, 5}},
     BinaryOpExpr = {op, 3, '*', LeftExpr, {integer, 3, 89}},
     Expected = [
@@ -363,5 +366,57 @@ forms_for_function_returning_a_product_of_float_literals_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Pi', 0}]},
         {function, 3, 'Pi', 0, [{clause, 3, [], [], [BinaryOpExpr]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+%% Arity-0 functions returning a division of literal values for scalar types
+
+forms_for_function_returning_a_division_of_int_literals_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int { 84 / 2 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    BinaryOpExpr = {op, 3, 'div', {integer, 3, 84}, {integer, 3, 2}},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'FortyTwo', 0}]},
+        {function, 3, 'FortyTwo', 0, [{clause, 3, [], [], [BinaryOpExpr]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_division_of_three_int_literals_test() ->
+    RufusText = "
+    module example
+    func Five() int { 100 / 10 / 2 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_typecheck_binary_op:forms(Forms),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(AnnotatedForms),
+    LeftExpr = {op, 3, 'div', {integer, 3, 100}, {integer, 3, 10}},
+    BinaryOpExpr = {op, 3, 'div', LeftExpr, {integer, 3, 2}},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Five', 0}]},
+        {function, 3, 'Five', 0, [{clause, 3, [], [], [BinaryOpExpr]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_division_of_float_literals_test() ->
+    RufusText = "
+    module example
+    func TwoPointSevenFive() float { 5.5 / 2.0 }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_compile_erlang:forms(Forms),
+    BinaryOpExpr = {op, 3, '/', {float, 3, 5.5}, {float, 3, 2.0}},
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'TwoPointSevenFive', 0}]},
+        {function, 3, 'TwoPointSevenFive', 0, [{clause, 3, [], [], [BinaryOpExpr]}]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -233,3 +233,32 @@ eval_with_function_returning_a_product_of_float_literals_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'Pi'()).
+
+%% Arity-0 functions returning a division of literal values for scalar types
+
+eval_with_function_returning_a_division_of_int_literals_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int { 84 / 2 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(42, example:'FortyTwo'()).
+
+eval_with_function_returning_a_division_of_three_int_literals_test() ->
+    RufusText = "
+    module example
+    func Five() int { 100 / 10 / 2 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(5, example:'Five'()).
+
+eval_with_function_returning_a_division_of_float_literals_test() ->
+    RufusText = "
+    module example
+    func TwoPointSevenFive() float { 5.5 / 2.0 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(2.75, example:'TwoPointSevenFive'()).

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -309,6 +309,14 @@ string_with_binary_op_expression_using_multiplication_operator_test() ->
      {int_lit, 1, 5}
     ], Tokens).
 
+string_with_binary_op_expression_using_division_operator_test() ->
+    {ok, Tokens, _} = rufus_scan:string("3 / 5"),
+    ?assertEqual([
+     {int_lit, 1, 3},
+     {'/', 1},
+     {int_lit, 1, 5}
+    ], Tokens).
+
 %% string_with_function_takes_an_unused_argument_test() ->
 %%     {ok, Tokens, _} = rufus_scan:string("func unused(_ int) int { 0 }")
 


### PR DESCRIPTION
The scanner can now parse `/` division operator tokens. The parser has been extended to parse `binary_op` expressions of the form `A / B`. The `rufus_typecheck_binary_op` module enforces the invariant that a binary operation may only be performed exclusively with ints or exclusively with floats, not both at the same time. No other types are supported with binary operators. The `rufus_compile_erlang` module translates `binary_op` expressions into Erlang abstract forms.