### PR TITLE
compiler: Add a new atom scalar type

### DIFF
--- a/rf/src/rufus_parse.erl
+++ b/rf/src/rufus_parse.erl
@@ -1,6 +1,6 @@
 -module(rufus_parse).
 -export([parse/1, parse_and_scan/1, format_error/1]).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 60).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 62).
 
 %% chars returns the content from the token.
 chars({_TokenType, _Line, Chars}) ->
@@ -227,22 +227,22 @@ yeccpars2(18=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_18(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(19=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_19(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2(20=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_20(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(21=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_21(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_13(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(22=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_22(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(23=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_23(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(24=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_24(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(25=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_25(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(26=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_26(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_27(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(27=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_27(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(28=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_28(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(29=S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -251,32 +251,36 @@ yeccpars2(30=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_30(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(31=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_31(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(32=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_32(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(32=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_32(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(33=S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(34=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_34(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(35=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(36=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(37=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_33(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(38=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_38(S, Cat, Ss, Stack, T, Ts, Tzr);
-%% yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
-%%  yeccpars2_39(S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(38=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(39=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_35(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(40=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_40(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(41=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_41(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(42=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_42(S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccpars2(43=S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(43=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_43(S, Cat, Ss, Stack, T, Ts, Tzr);
 %% yeccpars2(44=S, Cat, Ss, Stack, T, Ts, Tzr) ->
 %%  yeccpars2_44(S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccpars2(45=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_45(S, Cat, Ss, Stack, T, Ts, Tzr);
+%% yeccpars2(46=S, Cat, Ss, Stack, T, Ts, Tzr) ->
+%%  yeccpars2_46(S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccpars2(Other, _, _, _, _, _, _) ->
  erlang:error({yecc_bug,"1.4",{missing_state_in_action_table, Other}}).
 
@@ -351,7 +355,7 @@ yeccpars2_10(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 
 -dialyzer({nowarn_function, yeccpars2_11/7}).
 yeccpars2_11(S, ')', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 21, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 22, Ss, Stack, T, Ts, Tzr);
 yeccpars2_11(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
@@ -359,22 +363,24 @@ yeccpars2_12(S, identifier, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 13, Ss, Stack, T, Ts, Tzr);
 yeccpars2_12(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_12_(Stack),
- yeccpars2_20(_S, Cat, [12 | Ss], NewStack, T, Ts, Tzr).
+ yeccpars2_21(_S, Cat, [12 | Ss], NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccpars2_13/7}).
-yeccpars2_13(S, bool, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_13(S, atom, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 15, Ss, Stack, T, Ts, Tzr);
-yeccpars2_13(S, float, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_13(S, bool, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 16, Ss, Stack, T, Ts, Tzr);
-yeccpars2_13(S, int, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_13(S, float, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 17, Ss, Stack, T, Ts, Tzr);
-yeccpars2_13(S, string, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_13(S, int, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 18, Ss, Stack, T, Ts, Tzr);
+yeccpars2_13(S, string, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
 yeccpars2_13(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
 yeccpars2_14(S, ',', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 19, Ss, Stack, T, Ts, Tzr);
+ yeccpars1(S, 20, Ss, Stack, T, Ts, Tzr);
 yeccpars2_14(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_|Nss] = Ss,
  NewStack = yeccpars2_14_(Stack),
@@ -397,73 +403,77 @@ yeccpars2_18(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_19(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
  NewStack = yeccpars2_19_(Stack),
- yeccgoto_arg(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_type(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_20_(Stack),
+ yeccgoto_arg(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_21_(Stack),
  yeccgoto_args(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
-%% yeccpars2_21: see yeccpars2_13
+%% yeccpars2_22: see yeccpars2_13
 
--dialyzer({nowarn_function, yeccpars2_22/7}).
-yeccpars2_22(S, '{', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 23, Ss, Stack, T, Ts, Tzr);
-yeccpars2_22(_, _, _, _, T, _, _) ->
+-dialyzer({nowarn_function, yeccpars2_23/7}).
+yeccpars2_23(S, '{', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 24, Ss, Stack, T, Ts, Tzr);
+yeccpars2_23(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-yeccpars2_23(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_24(S, atom_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_24(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_24(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_24(S, identifier, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
-yeccpars2_23(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_23_(Stack),
- yeccpars2_24(24, Cat, [23 | Ss], NewStack, T, Ts, Tzr).
-
--dialyzer({nowarn_function, yeccpars2_24/7}).
-yeccpars2_24(S, '}', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 43, Ss, Stack, T, Ts, Tzr);
-yeccpars2_24(_, _, _, _, T, _, _) ->
- yeccerror(T).
-
-yeccpars2_25(S, '%', Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_24(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 32, Ss, Stack, T, Ts, Tzr);
+yeccpars2_24(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 33, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, '*', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 34, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, '+', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, '-', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, '/', Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, identifier, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
-yeccpars2_25(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_25_(Stack),
- yeccpars2_32(_S, Cat, [25 | Ss], NewStack, T, Ts, Tzr).
+yeccpars2_24(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_24_(Stack),
+ yeccpars2_25(25, Cat, [24 | Ss], NewStack, T, Ts, Tzr).
 
+-dialyzer({nowarn_function, yeccpars2_25/7}).
+yeccpars2_25(S, '}', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 45, Ss, Stack, T, Ts, Tzr);
+yeccpars2_25(_, _, _, _, T, _, _) ->
+ yeccerror(T).
+
+yeccpars2_26(S, '%', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 35, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, '*', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 36, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, '+', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 37, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, '-', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 38, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, '/', Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 39, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, atom_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 32, Ss, Stack, T, Ts, Tzr);
+yeccpars2_26(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 33, Ss, Stack, T, Ts, Tzr);
 yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccgoto_expr(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
+ NewStack = yeccpars2_26_(Stack),
+ yeccpars2_34(_S, Cat, [26 | Ss], NewStack, T, Ts, Tzr).
 
 yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- NewStack = yeccpars2_27_(Stack),
- yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+ yeccgoto_expr(hd(Ss), Cat, Ss, Stack, T, Ts, Tzr).
 
 yeccpars2_28(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  NewStack = yeccpars2_28_(Stack),
@@ -482,41 +492,41 @@ yeccpars2_31(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
 
 yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
  NewStack = yeccpars2_32_(Stack),
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_33(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ NewStack = yeccpars2_33_(Stack),
+ yeccgoto_expr(hd(Ss), Cat, Ss, NewStack, T, Ts, Tzr).
+
+yeccpars2_34(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_34_(Stack),
  yeccgoto_exprs(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
--dialyzer({nowarn_function, yeccpars2_33/7}).
-yeccpars2_33(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
- yeccpars1(S, 27, Ss, Stack, T, Ts, Tzr);
-yeccpars2_33(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
+-dialyzer({nowarn_function, yeccpars2_35/7}).
+yeccpars2_35(S, atom_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 28, Ss, Stack, T, Ts, Tzr);
-yeccpars2_33(S, identifier, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_35(S, bool_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 29, Ss, Stack, T, Ts, Tzr);
-yeccpars2_33(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_35(S, float_lit, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 30, Ss, Stack, T, Ts, Tzr);
-yeccpars2_33(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+yeccpars2_35(S, identifier, Ss, Stack, T, Ts, Tzr) ->
  yeccpars1(S, 31, Ss, Stack, T, Ts, Tzr);
-yeccpars2_33(_, _, _, _, T, _, _) ->
+yeccpars2_35(S, int_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 32, Ss, Stack, T, Ts, Tzr);
+yeccpars2_35(S, string_lit, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars1(S, 33, Ss, Stack, T, Ts, Tzr);
+yeccpars2_35(_, _, _, _, T, _, _) ->
  yeccerror(T).
 
-%% yeccpars2_34: see yeccpars2_33
+%% yeccpars2_36: see yeccpars2_35
 
-%% yeccpars2_35: see yeccpars2_33
+%% yeccpars2_37: see yeccpars2_35
 
-%% yeccpars2_36: see yeccpars2_33
+%% yeccpars2_38: see yeccpars2_35
 
-%% yeccpars2_37: see yeccpars2_33
-
-yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_38_(Stack),
- yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
-
-yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_|Nss] = Ss,
- NewStack = yeccpars2_39_(Stack),
- yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+%% yeccpars2_39: see yeccpars2_35
 
 yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  [_,_|Nss] = Ss,
@@ -534,13 +544,23 @@ yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_43(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_,_,_,_,_,_,_,_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_43_(Stack),
- yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+ yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 yeccpars2_44(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- [_|Nss] = Ss,
+ [_,_|Nss] = Ss,
  NewStack = yeccpars2_44_(Stack),
+ yeccgoto_binary_op(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_45(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_,_,_,_,_,_,_,_|Nss] = Ss,
+ NewStack = yeccpars2_45_(Stack),
+ yeccgoto_function(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
+
+yeccpars2_46(_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ [_|Nss] = Ss,
+ NewStack = yeccpars2_46_(Stack),
  yeccgoto_root(hd(Nss), Cat, Nss, NewStack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_arg/7}).
@@ -553,23 +573,23 @@ yeccgoto_arg(12, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_args(10, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_11(11, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_args(12=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_20(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_21(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_binary_op/7}).
-yeccgoto_binary_op(23=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_binary_op(25=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_binary_op(33=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_binary_op(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(24=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_binary_op(35=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_binary_op(36=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_binary_op(37=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_26(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(38=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_binary_op(39=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_27(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_decl/7}).
 yeccgoto_decl(0, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -578,26 +598,26 @@ yeccgoto_decl(3, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_3(3, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_expr/7}).
-yeccgoto_expr(23, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_25(25, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_expr(25, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_25(25, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_expr(33=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_expr(34=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(24, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_26(26, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(26, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_26(26, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(35=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_44(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(36=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_39(_S, Cat, Ss, Stack, T, Ts, Tzr);
+ yeccpars2_43(_S, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_expr(37=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_38(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_42(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(38=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_41(_S, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_expr(39=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_40(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_exprs/7}).
-yeccgoto_exprs(23, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_24(24, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_exprs(25=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_32(_S, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_exprs(24, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_25(25, Cat, Ss, Stack, T, Ts, Tzr);
+yeccgoto_exprs(26=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_34(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_function/7}).
 yeccgoto_function(0=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
@@ -609,13 +629,13 @@ yeccgoto_function(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
 yeccgoto_root(0, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_1(1, Cat, Ss, Stack, T, Ts, Tzr);
 yeccgoto_root(3=_S, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_44(_S, Cat, Ss, Stack, T, Ts, Tzr).
+ yeccpars2_46(_S, Cat, Ss, Stack, T, Ts, Tzr).
 
 -dialyzer({nowarn_function, yeccgoto_type/7}).
 yeccgoto_type(13, Cat, Ss, Stack, T, Ts, Tzr) ->
  yeccpars2_14(14, Cat, Ss, Stack, T, Ts, Tzr);
-yeccgoto_type(21, Cat, Ss, Stack, T, Ts, Tzr) ->
- yeccpars2_22(22, Cat, Ss, Stack, T, Ts, Tzr).
+yeccgoto_type(22, Cat, Ss, Stack, T, Ts, Tzr) ->
+ yeccpars2_23(23, Cat, Ss, Stack, T, Ts, Tzr).
 
 -compile({inline,yeccpars2_3_/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 10).
@@ -642,21 +662,21 @@ yeccpars2_8_(__Stack0) ->
   end | __Stack].
 
 -compile({inline,yeccpars2_10_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 52).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 54).
 yeccpars2_10_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_12_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 52).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 54).
 yeccpars2_12_(__Stack0) ->
  [begin
    [ ]
   end | __Stack0].
 
 -compile({inline,yeccpars2_14_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 54).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 56).
 yeccpars2_14_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
@@ -668,7 +688,7 @@ yeccpars2_14_(__Stack0) ->
 yeccpars2_15_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_type ( bool , line ( __1 ) )
+   rufus_form : make_type ( atom , line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_16_/1}).
@@ -676,7 +696,7 @@ yeccpars2_15_(__Stack0) ->
 yeccpars2_16_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_type ( float , line ( __1 ) )
+   rufus_form : make_type ( bool , line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_17_/1}).
@@ -684,7 +704,7 @@ yeccpars2_16_(__Stack0) ->
 yeccpars2_17_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_type ( int , line ( __1 ) )
+   rufus_form : make_type ( float , line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_18_/1}).
@@ -692,142 +712,158 @@ yeccpars2_17_(__Stack0) ->
 yeccpars2_18_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_type ( string , line ( __1 ) )
+   rufus_form : make_type ( int , line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_19_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 53).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 26).
 yeccpars2_19_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   rufus_form : make_type ( string , line ( __1 ) )
+  end | __Stack].
+
+-compile({inline,yeccpars2_20_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 55).
+yeccpars2_20_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_arg ( list_to_atom ( chars ( __1 ) ) , __2 , line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_20_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 51).
-yeccpars2_20_(__Stack0) ->
+-compile({inline,yeccpars2_21_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 53).
+yeccpars2_21_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_23_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
-yeccpars2_23_(__Stack0) ->
- [begin
-   [ ]
-  end | __Stack0].
-
--compile({inline,yeccpars2_25_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
-yeccpars2_25_(__Stack0) ->
- [begin
-   [ ]
-  end | __Stack0].
-
--compile({inline,yeccpars2_27_/1}).
+-compile({inline,yeccpars2_24_/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 31).
-yeccpars2_27_(__Stack0) ->
- [__1 | __Stack] = __Stack0,
+yeccpars2_24_(__Stack0) ->
  [begin
-   rufus_form : make_literal ( bool , chars ( __1 ) , line ( __1 ) )
-  end | __Stack].
+   [ ]
+  end | __Stack0].
+
+-compile({inline,yeccpars2_26_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 31).
+yeccpars2_26_(__Stack0) ->
+ [begin
+   [ ]
+  end | __Stack0].
 
 -compile({inline,yeccpars2_28_/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 32).
 yeccpars2_28_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
-   rufus_form : make_literal ( float , chars ( __1 ) , line ( __1 ) )
+   rufus_form : make_literal ( atom , chars ( __1 ) , line ( __1 ) )
   end | __Stack].
 
 -compile({inline,yeccpars2_29_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 35).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
 yeccpars2_29_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   rufus_form : make_literal ( bool , chars ( __1 ) , line ( __1 ) )
+  end | __Stack].
+
+-compile({inline,yeccpars2_30_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
+yeccpars2_30_(__Stack0) ->
+ [__1 | __Stack] = __Stack0,
+ [begin
+   rufus_form : make_literal ( float , chars ( __1 ) , line ( __1 ) )
+  end | __Stack].
+
+-compile({inline,yeccpars2_31_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 37).
+yeccpars2_31_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_identifier ( list_to_atom ( chars ( __1 ) ) , line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_30_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 33).
-yeccpars2_30_(__Stack0) ->
+-compile({inline,yeccpars2_32_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 35).
+yeccpars2_32_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_literal ( int , chars ( __1 ) , line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_31_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 34).
-yeccpars2_31_(__Stack0) ->
+-compile({inline,yeccpars2_33_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 36).
+yeccpars2_33_(__Stack0) ->
  [__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_literal ( string , list_to_binary ( chars ( __1 ) ) , line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_32_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 29).
-yeccpars2_32_(__Stack0) ->
+-compile({inline,yeccpars2_34_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 30).
+yeccpars2_34_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 | __2 ]
   end | __Stack].
 
--compile({inline,yeccpars2_38_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 43).
-yeccpars2_38_(__Stack0) ->
+-compile({inline,yeccpars2_40_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 45).
+yeccpars2_40_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_binary_op ( '/' , __1 , __3 , line ( __2 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_39_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 41).
-yeccpars2_39_(__Stack0) ->
+-compile({inline,yeccpars2_41_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 43).
+yeccpars2_41_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_binary_op ( '-' , __1 , __3 , line ( __2 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_40_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 40).
-yeccpars2_40_(__Stack0) ->
+-compile({inline,yeccpars2_42_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 42).
+yeccpars2_42_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_binary_op ( '+' , __1 , __3 , line ( __2 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_41_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 42).
-yeccpars2_41_(__Stack0) ->
+-compile({inline,yeccpars2_43_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 44).
+yeccpars2_43_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_binary_op ( '*' , __1 , __3 , line ( __2 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_42_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 44).
-yeccpars2_42_(__Stack0) ->
+-compile({inline,yeccpars2_44_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 46).
+yeccpars2_44_(__Stack0) ->
  [__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_binary_op ( '%' , __1 , __3 , line ( __2 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_43_/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 49).
-yeccpars2_43_(__Stack0) ->
+-compile({inline,yeccpars2_45_/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 51).
+yeccpars2_45_(__Stack0) ->
  [__9,__8,__7,__6,__5,__4,__3,__2,__1 | __Stack] = __Stack0,
  [begin
    rufus_form : make_func ( list_to_atom ( chars ( __2 ) ) , __4 , __6 , __8 , line ( __1 ) )
   end | __Stack].
 
--compile({inline,yeccpars2_44_/1}).
+-compile({inline,yeccpars2_46_/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 12).
-yeccpars2_44_(__Stack0) ->
+yeccpars2_46_(__Stack0) ->
  [__2,__1 | __Stack] = __Stack0,
  [begin
    [ __1 ] ++ __2
   end | __Stack].
 
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 71).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_parse.yrl", 73).

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -1,6 +1,6 @@
 Nonterminals root decl expr exprs function type arg args binary_op.
 
-Terminals '(' ')' '{' '}' ',' '+' '-' '*' '/' '%' func identifier import module bool bool_lit float float_lit int int_lit string string_lit.
+Terminals '(' ')' '{' '}' ',' '+' '-' '*' '/' '%' func identifier import module atom atom_lit bool bool_lit float float_lit int int_lit string string_lit.
 
 Rootsymbol root.
 
@@ -23,6 +23,7 @@ decl -> function          : '$1'.
 
 %% Scalar types
 
+type -> atom   : rufus_form:make_type(atom, line('$1')).
 type -> bool   : rufus_form:make_type(bool, line('$1')).
 type -> float  : rufus_form:make_type(float, line('$1')).
 type -> int    : rufus_form:make_type(int, line('$1')).
@@ -32,6 +33,7 @@ type -> string : rufus_form:make_type(string, line('$1')).
 
 exprs -> expr exprs : ['$1'|'$2'].
 exprs -> '$empty'   : [].
+expr  -> atom_lit   : rufus_form:make_literal(atom, chars('$1'), line('$1')).
 expr  -> bool_lit   : rufus_form:make_literal(bool, chars('$1'), line('$1')).
 expr  -> float_lit  : rufus_form:make_literal(float, chars('$1'), line('$1')).
 expr  -> int_lit    : rufus_form:make_literal(int, chars('$1'), line('$1')).

--- a/rf/src/rufus_scan.erl
+++ b/rf/src/rufus_scan.erl
@@ -12,10 +12,27 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 73).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 79).
 
-strip(TokenChars, TokenLen) ->
+trim_atom(TokenChars, TokenLen) ->
+    {TokenChars1, TokenLen1} = trim_leading_colon(TokenChars, TokenLen),
+    case is_single_quoted(TokenChars1) of
+        true ->
+            list_to_atom(trim_quotes(TokenChars1, TokenLen1));
+        false ->
+            list_to_atom(TokenChars1)
+    end.
+
+trim_leading_colon(TokenChars, TokenLen) ->
+    TrimmedTokenLen = TokenLen - 1,
+    TrimmedTokenChars = lists:sublist(TokenChars, 2, TrimmedTokenLen),
+    {TrimmedTokenChars, TrimmedTokenLen}.
+
+trim_quotes(TokenChars, TokenLen) ->
     lists:sublist(TokenChars, 2, TokenLen - 2).
+
+is_single_quoted(TokenChars) ->
+    (hd(TokenChars) == $') and (lists:last(TokenChars) == $').
 
 -file("/usr/local/Cellar/erlang/22.0.1/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 14).
 
@@ -308,767 +325,873 @@ adjust_line(T, A, [_|Cs], L) ->
 %% return signal either an unrecognised character or end of current
 %% input.
 
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.erl", 310).
-yystate() -> 60.
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.erl", 327).
+yystate() -> 70.
 
-yystate(67, [117|Ics], Line, Tlen, _, _) ->
-    yystate(61, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(67, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,67};
-yystate(66, [97|Ics], Line, Tlen, _, _) ->
-    yystate(62, Ics, Line, Tlen+1, 25, Tlen);
-yystate(66, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(66, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(66, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,66};
-yystate(65, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(55, Ics, Line, Tlen+1, Action, Alen);
-yystate(65, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,65};
-yystate(64, [32|Ics], Line, Tlen, _, _) ->
-    yystate(64, Ics, Line, Tlen+1, 0, Tlen);
-yystate(64, [9|Ics], Line, Tlen, _, _) ->
-    yystate(64, Ics, Line, Tlen+1, 0, Tlen);
-yystate(64, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line,64};
-yystate(63, [45|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
-yystate(63, [43|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
-yystate(63, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
-yystate(63, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,63};
-yystate(62, [116|Ics], Line, Tlen, _, _) ->
-    yystate(54, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(62, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,62};
-yystate(61, [108|Ics], Line, Tlen, _, _) ->
-    yystate(53, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(61, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,61};
-yystate(60, [125|Ics], Line, Tlen, Action, Alen) ->
-    yystate(52, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [123|Ics], Line, Tlen, Action, Alen) ->
-    yystate(44, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [116|Ics], Line, Tlen, Action, Alen) ->
-    yystate(36, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [115|Ics], Line, Tlen, Action, Alen) ->
+yystate(77, [39|Ics], Line, Tlen, Action, Alen) ->
+    yystate(71, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(77, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,77};
+yystate(76, [101|Ics], Line, Tlen, _, _) ->
+    yystate(26, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(76, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,76};
+yystate(75, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 2, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 2, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 2, Tlen);
+yystate(75, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 2, Tlen);
+yystate(75, Ics, Line, Tlen, _, _) ->
+    {2,Tlen,Ics,Line,75};
+yystate(74, [32|Ics], Line, Tlen, _, _) ->
+    yystate(74, Ics, Line, Tlen+1, 0, Tlen);
+yystate(74, [9|Ics], Line, Tlen, _, _) ->
+    yystate(74, Ics, Line, Tlen+1, 0, Tlen);
+yystate(74, Ics, Line, Tlen, _, _) ->
+    {0,Tlen,Ics,Line,74};
+yystate(73, [101|Ics], Line, Tlen, _, _) ->
+    yystate(75, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(73, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,73};
+yystate(72, [111|Ics], Line, Tlen, _, _) ->
+    yystate(64, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(72, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,72};
+yystate(71, Ics, Line, Tlen, _, _) ->
+    {11,Tlen,Ics,Line};
+yystate(70, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(62, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [123|Ics], Line, Tlen, Action, Alen) ->
+    yystate(54, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(46, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [115|Ics], Line, Tlen, Action, Alen) ->
+    yystate(6, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [109|Ics], Line, Tlen, Action, Alen) ->
+    yystate(41, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [105|Ics], Line, Tlen, Action, Alen) ->
+    yystate(67, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [103|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [104|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [102|Ics], Line, Tlen, Action, Alen) ->
     yystate(3, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [109|Ics], Line, Tlen, Action, Alen) ->
-    yystate(51, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [105|Ics], Line, Tlen, Action, Alen) ->
-    yystate(37, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [103|Ics], Line, Tlen, Action, Alen) ->
+yystate(70, [100|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [99|Ics], Line, Tlen, Action, Alen) ->
+    yystate(72, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [98|Ics], Line, Tlen, Action, Alen) ->
     yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [104|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [102|Ics], Line, Tlen, Action, Alen) ->
-    yystate(26, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [100|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [101|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [99|Ics], Line, Tlen, Action, Alen) ->
-    yystate(22, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [98|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [97|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [61|Ics], Line, Tlen, Action, Alen) ->
-    yystate(49, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [47|Ics], Line, Tlen, Action, Alen) ->
-    yystate(39, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [45|Ics], Line, Tlen, Action, Alen) ->
-    yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [44|Ics], Line, Tlen, Action, Alen) ->
-    yystate(23, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [43|Ics], Line, Tlen, Action, Alen) ->
-    yystate(15, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [42|Ics], Line, Tlen, Action, Alen) ->
-    yystate(7, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [41|Ics], Line, Tlen, Action, Alen) ->
+yystate(70, [97|Ics], Line, Tlen, Action, Alen) ->
     yystate(0, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [40|Ics], Line, Tlen, Action, Alen) ->
-    yystate(4, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [37|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(64, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [10|Ics], Line, Tlen, Action, Alen) ->
-    yystate(56, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(60, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(64, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(57, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 108 ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 110, C =< 114 ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(60, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,60};
-yystate(59, [100|Ics], Line, Tlen, _, _) ->
-    yystate(67, Ics, Line, Tlen+1, 25, Tlen);
+yystate(70, [61|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [58|Ics], Line, Tlen, Action, Alen) ->
+    yystate(39, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [47|Ics], Line, Tlen, Action, Alen) ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(13, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [42|Ics], Line, Tlen, Action, Alen) ->
+    yystate(2, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [41|Ics], Line, Tlen, Action, Alen) ->
+    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [40|Ics], Line, Tlen, Action, Alen) ->
+    yystate(14, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [37|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(74, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(66, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(70, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(74, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(69, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [C|Ics], Line, Tlen, Action, Alen) when C >= 106, C =< 108 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [C|Ics], Line, Tlen, Action, Alen) when C >= 110, C =< 114 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, [C|Ics], Line, Tlen, Action, Alen) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(70, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,70};
+yystate(69, [46|Ics], Line, Tlen, _, _) ->
+    yystate(61, Ics, Line, Tlen+1, 14, Tlen);
+yystate(69, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(69, Ics, Line, Tlen+1, 14, Tlen);
+yystate(69, Ics, Line, Tlen, _, _) ->
+    {14,Tlen,Ics,Line,69};
+yystate(68, [115|Ics], Line, Tlen, _, _) ->
+    yystate(76, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(68, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,68};
+yystate(67, [110|Ics], Line, Tlen, _, _) ->
+    yystate(59, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [109|Ics], Line, Tlen, _, _) ->
+    yystate(43, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(67, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,67};
+yystate(66, [10|Ics], Line, Tlen, _, _) ->
+    yystate(66, Ics, Line+1, Tlen+1, 1, Tlen);
+yystate(66, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line,66};
+yystate(65, [108|Ics], Line, Tlen, _, _) ->
+    yystate(73, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(65, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,65};
+yystate(64, [110|Ics], Line, Tlen, _, _) ->
+    yystate(56, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(64, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,64};
+yystate(63, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(63, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(63, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(63, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(63, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(77, Ics, Line, Tlen+1, Action, Alen);
+yystate(63, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,63};
+yystate(62, Ics, Line, Tlen, _, _) ->
+    {19,Tlen,Ics,Line};
+yystate(61, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(45, Ics, Line, Tlen+1, Action, Alen);
+yystate(61, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,61};
+yystate(60, [108|Ics], Line, Tlen, _, _) ->
+    yystate(68, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(60, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,60};
+yystate(59, [116|Ics], Line, Tlen, _, _) ->
+    yystate(51, Ics, Line, Tlen+1, 27, Tlen);
 yystate(59, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
 yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(59, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
 yystate(59, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,59};
-yystate(58, [111|Ics], Line, Tlen, _, _) ->
-    yystate(66, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(58, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,58};
-yystate(57, [46|Ics], Line, Tlen, _, _) ->
-    yystate(65, Ics, Line, Tlen+1, 12, Tlen);
+    {27,Tlen,Ics,Line,59};
+yystate(58, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(50, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(58, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,58};
+yystate(57, [117|Ics], Line, Tlen, _, _) ->
+    yystate(65, Ics, Line, Tlen+1, 27, Tlen);
+yystate(57, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
 yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(57, Ics, Line, Tlen+1, 12, Tlen);
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(57, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
 yystate(57, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line,57};
-yystate(56, [10|Ics], Line, Tlen, _, _) ->
-    yystate(56, Ics, Line+1, Tlen+1, 1, Tlen);
+    {27,Tlen,Ics,Line,57};
+yystate(56, [115|Ics], Line, Tlen, _, _) ->
+    yystate(48, Ics, Line, Tlen+1, 27, Tlen);
+yystate(56, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(56, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
 yystate(56, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line,56};
-yystate(55, [101|Ics], Line, Tlen, _, _) ->
-    yystate(63, Ics, Line, Tlen+1, 11, Tlen);
-yystate(55, [69|Ics], Line, Tlen, _, _) ->
-    yystate(63, Ics, Line, Tlen+1, 11, Tlen);
-yystate(55, [45|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
-yystate(55, [43|Ics], Line, Tlen, _, _) ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
+    {27,Tlen,Ics,Line,56};
 yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(55, Ics, Line, Tlen+1, 11, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(55, Ics, Line, Tlen+1, 11, Tlen);
+yystate(55, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
     yystate(55, Ics, Line, Tlen+1, 11, Tlen);
 yystate(55, Ics, Line, Tlen, _, _) ->
     {11,Tlen,Ics,Line,55};
-yystate(54, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 4, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 4, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 4, Tlen);
-yystate(54, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 4, Tlen);
 yystate(54, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,54};
-yystate(53, [101|Ics], Line, Tlen, _, _) ->
-    yystate(45, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(53, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,53};
-yystate(52, Ics, Line, Tlen, _, _) ->
-    {17,Tlen,Ics,Line};
-yystate(51, [111|Ics], Line, Tlen, _, _) ->
-    yystate(59, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(51, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,51};
-yystate(50, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 9, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 9, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 9, Tlen);
-yystate(50, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 9, Tlen);
-yystate(50, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line,50};
-yystate(49, Ics, Line, Tlen, _, _) ->
-    {19,Tlen,Ics,Line};
-yystate(48, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(40, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(48, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,48};
-yystate(47, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(47, Ics, Line, Tlen+1, 11, Tlen);
-yystate(47, Ics, Line, Tlen, _, _) ->
-    {11,Tlen,Ics,Line,47};
-yystate(46, [108|Ics], Line, Tlen, _, _) ->
-    yystate(38, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(46, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,46};
-yystate(45, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 7, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 7, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 7, Tlen);
-yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 7, Tlen);
-yystate(45, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line,45};
-yystate(44, Ics, Line, Tlen, _, _) ->
-    {16,Tlen,Ics,Line};
-yystate(43, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 6, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
-yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 6, Tlen);
-yystate(43, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,43};
-yystate(42, [99|Ics], Line, Tlen, _, _) ->
-    yystate(50, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [97|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [98|Ics], Line, Tlen, _, _) ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(42, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,42};
-yystate(41, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 2, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 2, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 2, Tlen);
-yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 2, Tlen);
-yystate(41, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line,41};
-yystate(40, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line};
-yystate(39, Ics, Line, Tlen, _, _) ->
-    {23,Tlen,Ics,Line};
-yystate(38, [115|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(38, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,38};
-yystate(37, [110|Ics], Line, Tlen, _, _) ->
-    yystate(29, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [109|Ics], Line, Tlen, _, _) ->
-    yystate(13, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(37, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,37};
-yystate(36, [114|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(36, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,36};
-yystate(35, [103|Ics], Line, Tlen, _, _) ->
-    yystate(43, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(35, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,35};
-yystate(34, [110|Ics], Line, Tlen, _, _) ->
-    yystate(42, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(34, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,34};
-yystate(33, [108|Ics], Line, Tlen, _, _) ->
-    yystate(41, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(33, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,33};
-yystate(32, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(32, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,32};
-yystate(31, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(57, Ics, Line, Tlen+1, 21, Tlen);
-yystate(31, Ics, Line, Tlen, _, _) ->
-    {21,Tlen,Ics,Line,31};
-yystate(30, [101|Ics], Line, Tlen, _, _) ->
-    yystate(16, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 100 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, [C|Ics], Line, Tlen, _, _) when C >= 102, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(30, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,30};
-yystate(29, [116|Ics], Line, Tlen, _, _) ->
-    yystate(21, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(29, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,29};
-yystate(28, [117|Ics], Line, Tlen, _, _) ->
-    yystate(30, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(28, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,28};
-yystate(27, [110|Ics], Line, Tlen, _, _) ->
-    yystate(35, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(27, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,27};
-yystate(26, [117|Ics], Line, Tlen, _, _) ->
-    yystate(34, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [108|Ics], Line, Tlen, _, _) ->
-    yystate(58, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [97|Ics], Line, Tlen, _, _) ->
-    yystate(46, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(26, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,26};
-yystate(25, [111|Ics], Line, Tlen, _, _) ->
-    yystate(33, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(25, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,25};
-yystate(24, [34|Ics], Line, Tlen, Action, Alen) ->
-    yystate(32, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,24};
-yystate(23, Ics, Line, Tlen, _, _) ->
     {18,Tlen,Ics,Line};
-yystate(22, [111|Ics], Line, Tlen, _, _) ->
-    yystate(14, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(22, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,22};
-yystate(21, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 5, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 5, Tlen);
-yystate(21, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,21};
-yystate(20, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, [32|Ics], Line, Tlen, Action, Alen) ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, [9|Ics], Line, Tlen, Action, Alen) ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
-    yystate(48, Ics, Line, Tlen+1, Action, Alen);
-yystate(20, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,20};
-yystate(19, [105|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(19, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,19};
-yystate(18, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 8, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 8, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 8, Tlen);
-yystate(18, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 8, Tlen);
-yystate(18, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line,18};
-yystate(17, [111|Ics], Line, Tlen, _, _) ->
-    yystate(25, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(17, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,17};
-yystate(16, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 10, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 10, Tlen);
-yystate(16, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line,16};
-yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(57, Ics, Line, Tlen+1, 20, Tlen);
-yystate(15, Ics, Line, Tlen, _, _) ->
-    {20,Tlen,Ics,Line,15};
-yystate(14, [110|Ics], Line, Tlen, _, _) ->
-    yystate(6, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(14, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,14};
-yystate(13, [112|Ics], Line, Tlen, _, _) ->
-    yystate(5, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(13, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,13};
-yystate(12, Ics, Line, Tlen, _, _) ->
-    {24,Tlen,Ics,Line};
-yystate(11, [114|Ics], Line, Tlen, _, _) ->
-    yystate(19, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(11, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,11};
-yystate(10, [116|Ics], Line, Tlen, _, _) ->
-    yystate(18, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(10, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,10};
-yystate(9, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 3, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 3, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 3, Tlen);
-yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 3, Tlen);
-yystate(9, Ics, Line, Tlen, _, _) ->
-    {3,Tlen,Ics,Line,9};
-yystate(8, [95|Ics], Line, Tlen, Action, Alen) ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(8, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,8};
-yystate(7, Ics, Line, Tlen, _, _) ->
-    {22,Tlen,Ics,Line};
-yystate(6, [115|Ics], Line, Tlen, _, _) ->
-    yystate(1, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 114 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 116, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(6, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,6};
-yystate(5, [111|Ics], Line, Tlen, _, _) ->
-    yystate(2, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(5, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,5};
-yystate(4, Ics, Line, Tlen, _, _) ->
-    {14,Tlen,Ics,Line};
-yystate(3, [116|Ics], Line, Tlen, _, _) ->
-    yystate(11, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(3, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,3};
-yystate(2, [114|Ics], Line, Tlen, _, _) ->
-    yystate(10, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(2, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,2};
-yystate(1, [116|Ics], Line, Tlen, _, _) ->
-    yystate(9, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, [34|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
-    yystate(32, Ics, Line, Tlen+1, 25, Tlen);
-yystate(1, Ics, Line, Tlen, _, _) ->
-    {25,Tlen,Ics,Line,1};
-yystate(0, Ics, Line, Tlen, _, _) ->
+yystate(53, [45|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(53, [43|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(53, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(53, Ics, Line, Tlen, _, _) ->
+    {13,Tlen,Ics,Line,53};
+yystate(52, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 8, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 8, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 8, Tlen);
+yystate(52, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 8, Tlen);
+yystate(52, Ics, Line, Tlen, _, _) ->
+    {8,Tlen,Ics,Line,52};
+yystate(51, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 9, Tlen);
+yystate(51, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 9, Tlen);
+yystate(51, Ics, Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line,51};
+yystate(50, Ics, Line, Tlen, _, _) ->
     {15,Tlen,Ics,Line};
+yystate(49, [100|Ics], Line, Tlen, _, _) ->
+    yystate(57, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 99 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, [C|Ics], Line, Tlen, _, _) when C >= 101, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(49, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,49};
+yystate(48, [116|Ics], Line, Tlen, _, _) ->
+    yystate(40, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(48, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,48};
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(55, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(55, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(55, Ics, Line, Tlen+1, Action, Alen);
+yystate(47, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,47};
+yystate(46, [114|Ics], Line, Tlen, _, _) ->
+    yystate(38, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(46, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,46};
+yystate(45, [101|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line, Tlen+1, 13, Tlen);
+yystate(45, [69|Ics], Line, Tlen, _, _) ->
+    yystate(53, Ics, Line, Tlen+1, 13, Tlen);
+yystate(45, [45|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(45, [43|Ics], Line, Tlen, _, _) ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(45, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(45, Ics, Line, Tlen+1, 13, Tlen);
+yystate(45, Ics, Line, Tlen, _, _) ->
+    {13,Tlen,Ics,Line,45};
+yystate(44, [116|Ics], Line, Tlen, _, _) ->
+    yystate(52, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(44, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,44};
+yystate(43, [112|Ics], Line, Tlen, _, _) ->
+    yystate(35, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 111 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, [C|Ics], Line, Tlen, _, _) when C >= 113, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(43, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,43};
+yystate(42, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(42, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(42, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,42};
+yystate(41, [111|Ics], Line, Tlen, _, _) ->
+    yystate(49, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(41, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,41};
+yystate(40, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 4, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 4, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 4, Tlen);
+yystate(40, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 4, Tlen);
+yystate(40, Ics, Line, Tlen, _, _) ->
+    {4,Tlen,Ics,Line,40};
+yystate(39, [39|Ics], Line, Tlen, Action, Alen) ->
+    yystate(63, Ics, Line, Tlen+1, Action, Alen);
+yystate(39, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(39, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(47, Ics, Line, Tlen+1, Action, Alen);
+yystate(39, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,39};
+yystate(38, [117|Ics], Line, Tlen, _, _) ->
+    yystate(76, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 116 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(38, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,38};
+yystate(37, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(37, Ics, Line, Tlen+1, 13, Tlen);
+yystate(37, Ics, Line, Tlen, _, _) ->
+    {13,Tlen,Ics,Line,37};
+yystate(36, [97|Ics], Line, Tlen, _, _) ->
+    yystate(44, Ics, Line, Tlen+1, 27, Tlen);
+yystate(36, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(36, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(36, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,36};
+yystate(35, [111|Ics], Line, Tlen, _, _) ->
+    yystate(27, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(35, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,35};
+yystate(34, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(42, Ics, Line, Tlen+1, Action, Alen);
+yystate(34, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,34};
+yystate(33, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 10, Tlen);
+yystate(33, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line,33};
+yystate(32, [111|Ics], Line, Tlen, _, _) ->
+    yystate(24, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(32, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,32};
+yystate(31, Ics, Line, Tlen, _, _) ->
+    {21,Tlen,Ics,Line};
+yystate(30, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(34, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [32|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [9|Ics], Line, Tlen, Action, Alen) ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 65, C =< 90 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 97, C =< 122 ->
+    yystate(58, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,30};
+yystate(29, Ics, Line, Tlen, _, _) ->
+    {25,Tlen,Ics,Line};
+yystate(28, [111|Ics], Line, Tlen, _, _) ->
+    yystate(36, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(28, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,28};
+yystate(27, [114|Ics], Line, Tlen, _, _) ->
+    yystate(19, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(27, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,27};
+yystate(26, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 12, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 12, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 12, Tlen);
+yystate(26, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 12, Tlen);
+yystate(26, Ics, Line, Tlen, _, _) ->
+    {12,Tlen,Ics,Line,26};
+yystate(25, [103|Ics], Line, Tlen, _, _) ->
+    yystate(33, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 102 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 104, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(25, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,25};
+yystate(24, [111|Ics], Line, Tlen, _, _) ->
+    yystate(16, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(24, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,24};
+yystate(23, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 6, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 6, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 6, Tlen);
+yystate(23, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 6, Tlen);
+yystate(23, Ics, Line, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,23};
+yystate(22, Ics, Line, Tlen, _, _) ->
+    {26,Tlen,Ics,Line};
+yystate(21, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(69, Ics, Line, Tlen+1, 23, Tlen);
+yystate(21, Ics, Line, Tlen, _, _) ->
+    {23,Tlen,Ics,Line,21};
+yystate(20, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 5, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 5, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 5, Tlen);
+yystate(20, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 5, Tlen);
+yystate(20, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,20};
+yystate(19, [116|Ics], Line, Tlen, _, _) ->
+    yystate(11, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(19, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,19};
+yystate(18, [95|Ics], Line, Tlen, Action, Alen) ->
+    yystate(34, Ics, Line, Tlen+1, Action, Alen);
+yystate(18, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,18};
+yystate(17, [110|Ics], Line, Tlen, _, _) ->
+    yystate(25, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(17, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,17};
+yystate(16, [108|Ics], Line, Tlen, _, _) ->
+    yystate(8, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 107 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(16, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,16};
+yystate(15, [109|Ics], Line, Tlen, _, _) ->
+    yystate(23, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 108 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, [C|Ics], Line, Tlen, _, _) when C >= 110, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(15, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,15};
+yystate(14, Ics, Line, Tlen, _, _) ->
+    {16,Tlen,Ics,Line};
+yystate(13, Ics, Line, Tlen, _, _) ->
+    {20,Tlen,Ics,Line};
+yystate(12, [99|Ics], Line, Tlen, _, _) ->
+    yystate(20, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [97|Ics], Line, Tlen, _, _) ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [98|Ics], Line, Tlen, _, _) ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, [C|Ics], Line, Tlen, _, _) when C >= 100, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(12, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,12};
+yystate(11, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 3, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 3, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 3, Tlen);
+yystate(11, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 3, Tlen);
+yystate(11, Ics, Line, Tlen, _, _) ->
+    {3,Tlen,Ics,Line,11};
+yystate(10, Ics, Line, Tlen, _, _) ->
+    {17,Tlen,Ics,Line};
+yystate(9, [105|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 104 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 106, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(9, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,9};
+yystate(8, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 7, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 7, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 7, Tlen);
+yystate(8, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 7, Tlen);
+yystate(8, Ics, Line, Tlen, _, _) ->
+    {7,Tlen,Ics,Line,8};
+yystate(7, [111|Ics], Line, Tlen, _, _) ->
+    yystate(15, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 110 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, [C|Ics], Line, Tlen, _, _) when C >= 112, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(7, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,7};
+yystate(6, [116|Ics], Line, Tlen, _, _) ->
+    yystate(1, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(6, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,6};
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(69, Ics, Line, Tlen+1, 22, Tlen);
+yystate(5, Ics, Line, Tlen, _, _) ->
+    {22,Tlen,Ics,Line,5};
+yystate(4, [110|Ics], Line, Tlen, _, _) ->
+    yystate(12, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 109 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, [C|Ics], Line, Tlen, _, _) when C >= 111, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(4, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,4};
+yystate(3, [117|Ics], Line, Tlen, _, _) ->
+    yystate(4, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [108|Ics], Line, Tlen, _, _) ->
+    yystate(28, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [97|Ics], Line, Tlen, _, _) ->
+    yystate(60, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 98, C =< 107 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 109, C =< 116 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, [C|Ics], Line, Tlen, _, _) when C >= 118, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(3, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,3};
+yystate(2, Ics, Line, Tlen, _, _) ->
+    {24,Tlen,Ics,Line};
+yystate(1, [114|Ics], Line, Tlen, _, _) ->
+    yystate(9, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 113 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, [C|Ics], Line, Tlen, _, _) when C >= 115, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(1, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,1};
+yystate(0, [116|Ics], Line, Tlen, _, _) ->
+    yystate(7, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, [34|Ics], Line, Tlen, _, _) ->
+    yystate(18, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 65, C =< 90 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 97, C =< 115 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, [C|Ics], Line, Tlen, _, _) when C >= 117, C =< 122 ->
+    yystate(42, Ics, Line, Tlen+1, 27, Tlen);
+yystate(0, Ics, Line, Tlen, _, _) ->
+    {27,Tlen,Ics,Line,0};
 yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
@@ -1096,22 +1219,23 @@ yyaction(8, _, _, TokenLine) ->
     yyaction_8(TokenLine);
 yyaction(9, _, _, TokenLine) ->
     yyaction_9(TokenLine);
-yyaction(10, TokenLen, YYtcs, TokenLine) ->
-    TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_10(TokenChars, TokenLine);
+yyaction(10, _, _, TokenLine) ->
+    yyaction_10(TokenLine);
 yyaction(11, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_11(TokenChars, TokenLine);
+    yyaction_11(TokenChars, TokenLen, TokenLine);
 yyaction(12, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
     yyaction_12(TokenChars, TokenLine);
 yyaction(13, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_13(TokenChars, TokenLen, TokenLine);
-yyaction(14, _, _, TokenLine) ->
-    yyaction_14(TokenLine);
-yyaction(15, _, _, TokenLine) ->
-    yyaction_15(TokenLine);
+    yyaction_13(TokenChars, TokenLine);
+yyaction(14, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_14(TokenChars, TokenLine);
+yyaction(15, TokenLen, YYtcs, TokenLine) ->
+    TokenChars = yypre(YYtcs, TokenLen),
+    yyaction_15(TokenChars, TokenLen, TokenLine);
 yyaction(16, _, _, TokenLine) ->
     yyaction_16(TokenLine);
 yyaction(17, _, _, TokenLine) ->
@@ -1130,140 +1254,155 @@ yyaction(23, _, _, TokenLine) ->
     yyaction_23(TokenLine);
 yyaction(24, _, _, TokenLine) ->
     yyaction_24(TokenLine);
-yyaction(25, TokenLen, YYtcs, TokenLine) ->
+yyaction(25, _, _, TokenLine) ->
+    yyaction_25(TokenLine);
+yyaction(26, _, _, TokenLine) ->
+    yyaction_26(TokenLine);
+yyaction(27, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    yyaction_25(TokenChars, TokenLine);
+    yyaction_27(TokenChars, TokenLine);
 yyaction(_, _, _, _) -> error.
 
 -compile({inline,yyaction_0/0}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 39).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 41).
 yyaction_0() ->
      skip_token .
 
 -compile({inline,yyaction_1/0}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 40).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 42).
 yyaction_1() ->
      skip_token .
 
 -compile({inline,yyaction_2/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 42).
-yyaction_2(TokenLine) ->
-     { token, { bool, TokenLine } } .
-
--compile({inline,yyaction_3/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 43).
-yyaction_3(TokenLine) ->
-     { token, { const, TokenLine } } .
-
--compile({inline,yyaction_4/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 44).
-yyaction_4(TokenLine) ->
-     { token, { float, TokenLine } } .
-
--compile({inline,yyaction_5/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 45).
-yyaction_5(TokenLine) ->
-     { token, { int, TokenLine } } .
-
--compile({inline,yyaction_6/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 46).
-yyaction_6(TokenLine) ->
-     { token, { string, TokenLine } } .
-
--compile({inline,yyaction_7/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 48).
-yyaction_7(TokenLine) ->
+yyaction_2(TokenLine) ->
      { token, { module, TokenLine } } .
 
--compile({inline,yyaction_8/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 49).
-yyaction_8(TokenLine) ->
+-compile({inline,yyaction_3/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 45).
+yyaction_3(TokenLine) ->
      { token, { import, TokenLine } } .
 
--compile({inline,yyaction_9/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 50).
-yyaction_9(TokenLine) ->
+-compile({inline,yyaction_4/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 46).
+yyaction_4(TokenLine) ->
+     { token, { const, TokenLine } } .
+
+-compile({inline,yyaction_5/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 47).
+yyaction_5(TokenLine) ->
      { token, { func, TokenLine } } .
 
--compile({inline,yyaction_10/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 52).
-yyaction_10(TokenChars, TokenLine) ->
-     { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
+-compile({inline,yyaction_6/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 49).
+yyaction_6(TokenLine) ->
+     { token, { atom, TokenLine } } .
 
--compile({inline,yyaction_11/2}).
+-compile({inline,yyaction_7/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 50).
+yyaction_7(TokenLine) ->
+     { token, { bool, TokenLine } } .
+
+-compile({inline,yyaction_8/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 51).
+yyaction_8(TokenLine) ->
+     { token, { float, TokenLine } } .
+
+-compile({inline,yyaction_9/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 52).
+yyaction_9(TokenLine) ->
+     { token, { int, TokenLine } } .
+
+-compile({inline,yyaction_10/1}).
 -file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 53).
-yyaction_11(TokenChars, TokenLine) ->
-     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+yyaction_10(TokenLine) ->
+     { token, { string, TokenLine } } .
+
+-compile({inline,yyaction_11/3}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 55).
+yyaction_11(TokenChars, TokenLen, TokenLine) ->
+     A = trim_atom (TokenChars, TokenLen),
+     { token, { atom_lit, TokenLine, A } } .
 
 -compile({inline,yyaction_12/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 54).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 57).
 yyaction_12(TokenChars, TokenLine) ->
+     { token, { bool_lit, TokenLine, list_to_atom (TokenChars) } } .
+
+-compile({inline,yyaction_13/2}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 58).
+yyaction_13(TokenChars, TokenLine) ->
+     { token, { float_lit, TokenLine, list_to_float (TokenChars) } } .
+
+-compile({inline,yyaction_14/2}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 59).
+yyaction_14(TokenChars, TokenLine) ->
      { token, { int_lit, TokenLine, list_to_integer (TokenChars) } } .
 
--compile({inline,yyaction_13/3}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 55).
-yyaction_13(TokenChars, TokenLen, TokenLine) ->
-     S = strip (TokenChars, TokenLen),
+-compile({inline,yyaction_15/3}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 60).
+yyaction_15(TokenChars, TokenLen, TokenLine) ->
+     S = trim_quotes (TokenChars, TokenLen),
      { token, { string_lit, TokenLine, S } } .
 
--compile({inline,yyaction_14/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 58).
-yyaction_14(TokenLine) ->
+-compile({inline,yyaction_16/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 63).
+yyaction_16(TokenLine) ->
      { token, { '(', TokenLine } } .
 
--compile({inline,yyaction_15/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 59).
-yyaction_15(TokenLine) ->
+-compile({inline,yyaction_17/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 64).
+yyaction_17(TokenLine) ->
      { token, { ')', TokenLine } } .
 
--compile({inline,yyaction_16/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 60).
-yyaction_16(TokenLine) ->
+-compile({inline,yyaction_18/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 65).
+yyaction_18(TokenLine) ->
      { token, { '{', TokenLine } } .
 
--compile({inline,yyaction_17/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 61).
-yyaction_17(TokenLine) ->
+-compile({inline,yyaction_19/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 66).
+yyaction_19(TokenLine) ->
      { token, { '}', TokenLine } } .
 
--compile({inline,yyaction_18/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 62).
-yyaction_18(TokenLine) ->
+-compile({inline,yyaction_20/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 67).
+yyaction_20(TokenLine) ->
      { token, { ',', TokenLine } } .
 
--compile({inline,yyaction_19/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 63).
-yyaction_19(TokenLine) ->
+-compile({inline,yyaction_21/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 68).
+yyaction_21(TokenLine) ->
      { token, { '=', TokenLine } } .
 
--compile({inline,yyaction_20/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 64).
-yyaction_20(TokenLine) ->
+-compile({inline,yyaction_22/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 69).
+yyaction_22(TokenLine) ->
      { token, { '+', TokenLine } } .
 
--compile({inline,yyaction_21/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 65).
-yyaction_21(TokenLine) ->
+-compile({inline,yyaction_23/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 70).
+yyaction_23(TokenLine) ->
      { token, { '-', TokenLine } } .
 
--compile({inline,yyaction_22/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 66).
-yyaction_22(TokenLine) ->
+-compile({inline,yyaction_24/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 71).
+yyaction_24(TokenLine) ->
      { token, { '*', TokenLine } } .
 
--compile({inline,yyaction_23/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 67).
-yyaction_23(TokenLine) ->
+-compile({inline,yyaction_25/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 72).
+yyaction_25(TokenLine) ->
      { token, { '/', TokenLine } } .
 
--compile({inline,yyaction_24/1}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 68).
-yyaction_24(TokenLine) ->
+-compile({inline,yyaction_26/1}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 73).
+yyaction_26(TokenLine) ->
      { token, { '%', TokenLine } } .
 
--compile({inline,yyaction_25/2}).
--file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 69).
-yyaction_25(TokenChars, TokenLine) ->
+-compile({inline,yyaction_27/2}).
+-file("/Users/jkakar/src/github.com/rufus-lang/rufus/rf/src/rufus_scan.xrl", 75).
+yyaction_27(TokenChars, TokenLine) ->
      { token, { identifier, TokenLine, TokenChars } } .
 
 -file("/usr/local/Cellar/erlang/22.0.1/lib/erlang/lib/parsetools-2.1.8/include/leexinc.hrl", 313).

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -26,6 +26,7 @@
 
 %% Scalar literals
 
+-type atom_lit_form() :: {atom_lit, context()}.
 -type bool_lit_form() :: {bool_lit, context()}.
 -type float_lit_form() :: {float_lit, context()}.
 -type int_lit_form() :: {int_lit, context()}.
@@ -43,6 +44,7 @@
 -type rufus_form() ::
         arg_form()
       | binary_op_form()
+      | atom_lit_form()
       | bool_lit_form()
       | float_lit_form()
       | func_form()

--- a/rf/test/rufus_annotate_locals_test.erl
+++ b/rf/test/rufus_annotate_locals_test.erl
@@ -29,6 +29,31 @@ forms_test() ->
 
 %% Arity-1 functions taking an argument and returning a literal
 
+forms_for_function_taking_an_atom_and_returning_an_atom_literal_test() ->
+    RufusText = "
+    module example
+    func Ping(m atom) atom { :pong }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_annotate_locals:forms(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func,
+         #{args => [{arg, #{line => 3,
+                            spec => m,
+                            type => {type, #{line => 3, spec => atom, source => rufus_text}}}}],
+           exprs => [{atom_lit, #{line => 3,
+                                  locals => #{m => {type, #{line => 3, spec => atom, source => rufus_text}}},
+                                  spec => pong,
+                                  type => {type, #{line => 3, spec => atom, source => inferred}}}}],
+           line => 3,
+           return_type => {type, #{line => 3, spec => atom, source => rufus_text}},
+           spec => 'Ping'}
+        }
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 forms_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
     module example
@@ -130,6 +155,31 @@ forms_for_function_taking_a_string_and_returning_a_string_literal_test() ->
     ?assertEqual(Expected, AnnotatedForms).
 
 %% Arity-1 functions taking and returning an argument
+
+forms_for_function_taking_an_atom_and_returning_it_test() ->
+    RufusText = "
+    module example
+    func Echo(b atom) atom { b }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_annotate_locals:forms(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func,
+         #{args => [{arg, #{line => 3,
+                            spec => b,
+                            type => {type, #{line => 3, spec => atom, source => rufus_text}}}}],
+           exprs =>
+                    [{identifier, #{line => 3,
+                                    locals => #{b => {type, #{line => 3, spec => atom, source => rufus_text}}},
+                                    spec => b}}],
+           line => 3,
+           return_type => {type, #{line => 3, spec => atom, source => rufus_text}},
+           spec => 'Echo'}
+        }
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
 
 forms_for_function_taking_a_bool_and_returning_it_test() ->
     RufusText = "

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -18,6 +18,14 @@ eval_chain_with_error_handler_test() ->
 
 %% Arity-0 functions returning a literal value for scalar types
 
+eval_with_function_returning_an_atom_literal_test() ->
+    RufusText = "
+    module example
+    func Ping() atom { :pong }
+    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(pong, example:'Ping'()).
+
 eval_with_function_returning_a_bool_literal_test() ->
     RufusText = "
     module example
@@ -51,6 +59,15 @@ eval_with_function_returning_a_string_literal_test() ->
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
 %% Arity-1 functions taking an unused parameter for scalar types
+
+eval_with_function_taking_an_atom_and_returning_an_atom_literal_test() ->
+    RufusText = "
+    module example
+    func Ping(m atom) atom { :pong }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(pong, example:'Ping'(hello)).
 
 eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     RufusText = "
@@ -89,6 +106,15 @@ eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
     ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
 
 %% Arity-1 functions taking an argument and returning it for scalar types
+
+eval_with_function_taking_an_atom_and_returning_it_test() ->
+    RufusText = "
+    module example
+    func Echo(m atom) atom { m }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(hello, example:'Echo'(hello)).
 
 eval_with_function_taking_a_bool_and_returning_it_test() ->
     RufusText = "

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -27,6 +27,24 @@ parse_import_test() ->
 
 %% Arity-0 functions returning a literal value for scalar types
 
+parse_function_returning_a_atom_test() ->
+    RufusText = "
+    module example
+    func Color() atom { :indigo }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {module, #{line => 2, spec => example}},
+     {func, #{args => [],
+              exprs => [{atom_lit, #{line => 3,
+                                     spec => indigo,
+                                     type => {type, #{line => 3, spec => atom, source => inferred}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => atom, source => rufus_text}},
+              spec => 'Color'}}
+    ], Forms).
+
 parse_function_returning_a_bool_test() ->
     RufusText = "
     module example
@@ -100,6 +118,26 @@ parse_function_returning_a_string_test() ->
     ], Forms).
 
 %% Arity-1 functions using an argument
+
+parse_function_taking_a_atom_and_returning_a_atom_test() ->
+    RufusText = "
+    module example
+    func Color(c atom) atom { :indigo }
+    ",
+    {ok, Tokens, _} = rufus_scan:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    ?assertEqual([
+     {module, #{line => 2, spec => example}},
+     {func, #{args => [{arg, #{line => 3,
+                               spec => c,
+                               type => {type, #{line => 3, spec => atom, source => rufus_text}}}}],
+              exprs => [{atom_lit, #{line => 3,
+                                     spec => indigo,
+                                     type => {type, #{line => 3, spec => atom, source => inferred}}}}],
+              line => 3,
+              return_type => {type, #{line => 3, spec => atom, source => rufus_text}},
+              spec => 'Color'}}
+    ], Forms).
 
 parse_function_taking_a_bool_and_returning_a_bool_test() ->
     RufusText = "

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -27,7 +27,7 @@ parse_import_test() ->
 
 %% Arity-0 functions returning a literal value for scalar types
 
-parse_function_returning_a_atom_test() ->
+parse_function_returning_an_atom_test() ->
     RufusText = "
     module example
     func Color() atom { :indigo }
@@ -119,7 +119,7 @@ parse_function_returning_a_string_test() ->
 
 %% Arity-1 functions using an argument
 
-parse_function_taking_a_atom_and_returning_a_atom_test() ->
+parse_function_taking_an_atom_and_returning_an_atom_test() ->
     RufusText = "
     module example
     func Color(c atom) atom { :indigo }

--- a/rf/test/rufus_scan_test.erl
+++ b/rf/test/rufus_scan_test.erl
@@ -25,6 +25,24 @@ string_with_import_test() ->
 
 %% Const
 
+string_with_atom_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const Name = :rufus"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "Name"},
+     {'=', 1},
+     {atom_lit, 1, rufus}
+    ], Tokens).
+
+string_with_quoted_atom_literal_test() ->
+    {ok, Tokens, _} = rufus_scan:string("const Name = :'rufus programming language'"),
+    ?assertEqual([
+     {const, 1},
+     {identifier, 1, "Name"},
+     {'=', 1},
+     {atom_lit, 1, 'rufus programming language'}
+    ], Tokens).
+
 string_with_false_bool_literal_test() ->
     {ok, Tokens, _} = rufus_scan:string("const Bool = false"),
     ?assertEqual([


### PR DESCRIPTION
All compile stages support a builtin `atom` type with literals like `:rufus` or `:'rufus programming language'`. Atoms are represented in Rufus exactly as they are in Erlang, both to minimize unnecessary differences and because this approach yields the best performance.