### PR TITLE
build: Run Dialyzer in CI

### DIFF
--- a/rf/Makefile
+++ b/rf/Makefile
@@ -1,12 +1,15 @@
 all: 	clean check dialyzer build
 
-ci:		clean check build
+ci:		clean check prime-dialyzer dialyzer build
 
 clean:
 	@rebar3 clean
 
 check:
 	@rebar3 eunit
+
+prime-dialyzer:
+	@-rebar3 dialyzer > /dev/null
 
 dialyzer:
 	@rebar3 dialyzer

--- a/rf/Makefile
+++ b/rf/Makefile
@@ -8,6 +8,10 @@ clean:
 check:
 	@rebar3 eunit
 
+# Dialyzer emits many warnings about code outside the project the first time it
+# runs. `prime-dialyzer` exists to warm the cache and ignore these warnings. A
+# subsequent run of the `dialyzer` target will emit warnings related to the
+# project.
 prime-dialyzer:
 	@-rebar3 dialyzer > /dev/null
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -66,7 +66,8 @@
       | arg_form()
       | identifier_form()
       | type_form()
-      | binary_op_form().
+      | binary_op_form()
+      | string().
 
 %% Errors
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -66,8 +66,7 @@
       | arg_form()
       | identifier_form()
       | type_form()
-      | binary_op_form()
-      | string().
+      | binary_op_form().
 
 %% Errors
 


### PR DESCRIPTION
Dialyzer emits a stream of warnings related to code outside the project when it builds a PLT, the first time it runs. A new `prime-dialyzer` Make target pipes dialyzer output to `/dev/null` and ignores the exit code so that a subsequent run of Dialyzer only reports on issues in the project. The `ci` Make target now invokes `prime-dialyzer` and `dialyzer` Make targets to ensure that Dialyzer errors fail CI.