### PR TITLE
rufus-lang.org: Serve and render Markdown documents

### DIFF
--- a/rufus-lang.org/public/doc/rdr/0000-rufus-decision-records.md
+++ b/rufus-lang.org/public/doc/rdr/0000-rufus-decision-records.md
@@ -2,6 +2,7 @@
 
 * ID: RDR-0000
 * Status: Accepted
+* Authors: Jamu Kakar <[jkakar@kakar.ca](mailto:jkakar@kakar.ca)>
 * Deciders: Jamu Kakar <[jkakar@kakar.ca](mailto:jkakar@kakar.ca)>
 * Date: March 24, 2019
 

--- a/rufus-lang.org/public/doc/rdr/0001-template.md
+++ b/rufus-lang.org/public/doc/rdr/0001-template.md
@@ -1,32 +1,34 @@
-[Copy this template to a file called `nnnn-<title>.md`. A number will be
-assigned at the time the decision is accepted.]
+_Copy this template to a file called `nnnn-<title>.md`. Replace all italics text
+to create a new proposal. A number will be assigned at the time the decision is
+accepted._
 
-# Short decision title
+# _Short decision title_
 
-* ID: RDR-_nnnn_
-* Status: [Drafting | Proposed | Rejected | Accepted | Deprecated | Superseded by [RDR-0005](0005-example.md)]
-* Deciders: [List the decision makers, like "John Doe <[johndoe@example.com](mailto:johndoe@example.com)>"]
-* Date: [Month DD, YYYY when the decision was last updated]
+* ID: RDR-nnnn
+* Status: _Drafting | Proposed | Rejected | Accepted | Deprecated | Superseded by [RDR-0005](0005-example.md)_
+* Authors: _List the authors, like "John Doe <[johndoe@example.com](mailto:johndoe@example.com)>"_
+* Deciders: _List the decision makers, like "Jane Doe <[janedoe@example.com](mailto:janedoe@example.com)>"_
+* Date: _Month DD, YYYY when the decision was last updated_
 
 ## Context and problem statement
 
-[Describe the context and problem statement, e.g., in free form. You may want to
-articulate the problem in form of a question.]
+_Describe the context and problem statement, e.g., in free form. You may want to
+articulate the problem in form of a question._
 
 ## Decision drivers
 
-* [driver 1, e.g., a force, facing concern, …]
-* [driver 2, e.g., a force, facing concern, …]
-* …
+* _driver 1, e.g., user experience, …_
+* _driver 2, e.g., technical issue, …_
+* _…_
 
 ## Considered options
 
-* [option 1]
-* [option 2]
-* [option 3]
-* …
+* _option 1_
+* _option 2_
+* _option 3_
+* _…_
 
 ## Decision outcome
 
-Chosen option: "[option 1]", because [justification. e.g., is a more isolated
-design that can be implemented in a cleaner way than the other options].
+Chosen option: "_option 1_", because _decision tradeoffs, e.g., is a more isolated
+design that can be implemented in a cleaner way than the other options._

--- a/rufus-lang.org/public/doc/rdr/nnnn-exported-identifiers.md
+++ b/rufus-lang.org/public/doc/rdr/nnnn-exported-identifiers.md
@@ -1,7 +1,8 @@
 # Exported identifiers
 
-* ID: RDR-_nnnn_
+* ID: RDR-nnnn
 * Status: Drafting
+* Authors: Jamu Kakar <[jkakar@kakar.ca](mailto:jkakar@kakar.ca)>
 * Deciders: Jamu Kakar <[jkakar@kakar.ca](mailto:jkakar@kakar.ca)>
 * Date: May 3, 2019
 
@@ -15,6 +16,8 @@ Rufus provide for users to manage encapsulation?
 ## Decision drivers
 
 * A user can tell whether an identifier is public or private at a glance.
+* Works well for all users, including those that uses non-latin languages and
+  alphabets.
 * It's not possible to access private modules from outside their package.
 * It's not possible to access private types, constants, or functions from
   outside their module.
@@ -27,8 +30,8 @@ Idenifiers for types, constants, and functions defined in the module block that
 start with an `_` or a Unicode lower case letter (Unicode class "Ll") are
 private. All other identifiers for types, constants, and functions are exported.
 
-A public module called `math` with a public `Pi` constant and a private `float`
-constant:
+Example: A public module called `math` with a public `Pi` constant and a private
+`quarter` constant, both `float`s:
 
 ```rufus
 module math
@@ -44,8 +47,8 @@ module example
 
 import "math"
 
-func Area(radius tuple{:radius, int}) float {
-    math.Pow(math.Pi * radius, 2)
+func Area(:radius, r float) float {
+    math.Pow(math.Pi * r, 2)
 }
 ```
 
@@ -59,8 +62,8 @@ start with an `_` or a lowercase letter are only accessible within the package.
 All other modules are externally accessible. This makes the privacy mechanism
 uniform and eliminates the need to special-case `internal` directories.
 
-A public module called `Math` with a public `Pi` constant and a private `float`
-constant:
+Example: A public module called `Math` with a public `Pi` constant and a private
+`quarter` constant:
 
 ```rufus
 module Math
@@ -76,8 +79,8 @@ module example
 
 import "Math"
 
-func Area(:radius, radius float) float {
-    Math.Pow(Math.Pi * radius, 2)
+func Area(:radius, r float) float {
+    Math.Pow(Math.Pi * r, 2)
 }
 func Area(:rectangle, tuple{length, width float}) float {
     length * width
@@ -87,7 +90,7 @@ func Area(:square, side float) float {
 }
 ```
 
-An issue with this approach is that there can be problems with case-insensitive
+An issue with this approach is the possibility of collisions on case-insensitive
 filesystems. A private `math` module in `math.rf` could conflict with a public
 `Math` module in `Math.rf`, for example.
 
@@ -99,3 +102,6 @@ obvious when reading code because they start with an `_` or a lowercase letter.
 We will fail a build if two or more Rufus source files in the same directory
 have names that differ only by case. This will prevent collision issues on
 case-insensitive filesystems.
+
+Open question: will a leading `_` for module, type, constant, or function cause
+parser grammer conflicts with `_` in pattern matching syntax and semantics?

--- a/rufus-lang.org/public/doc/spec.md
+++ b/rufus-lang.org/public/doc/spec.md
@@ -58,7 +58,8 @@ The syntax is specified using Extended Backus-Naur Form (EBNF):
 Production  = production_name "=" [ Expression ] "." .
 Expression  = Alternative { "|" Alternative } .
 Alternative = Term { Term } .
-Term        = production_name | token [ "…" token ] | Group | Option | Repetition .
+Term        = production_name | token [ "…" token ] | Group |
+              Option | Repetition .
 Group       = "(" Expression ")" .
 Option      = "[" Expression "]" .
 Repetition  = "{" Expression "}" .
@@ -108,9 +109,12 @@ The following terms are used to denote specific Unicode character classes:
 
 ```
 newline        = /* the Unicode code point U+000A */ .
-unicode_char   = /* an arbitrary Unicode code point except newline */ .
-unicode_letter = /* a Unicode code point classified as "Letter" */ .
-unicode_digit  = /* a Unicode code point classified as "Number, decimal digit" */ .
+unicode_char   = /* an arbitrary Unicode code point except
+                    newline */ .
+unicode_letter = /* a Unicode code point classified as
+                    "Letter" */ .
+unicode_digit  = /* a Unicode code point classified as
+                    "Number, decimal digit" */ .
 ```
 
 In [The Unicode Standard 8.0](http://www.unicode.org/versions/Unicode8.0.0/), Section 4.5 "General Category" defines a set
@@ -188,6 +192,7 @@ The following keywords are reserved and may not be used as identifiers.
 
 ```
 func
+import
 module
 ```
 
@@ -285,10 +290,10 @@ string_lit = `"` { unicode_value | byte_value } `"` .
 These examples all represent the same string:
 
 ```
-"日本語"                                 // UTF-8 input text
-"\u65e5\u672c\u8a9e"                    // the explicit Unicode code points
-"\U000065e5\U0000672c\U00008a9e"        // the explicit Unicode code points
-"\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"  // the explicit UTF-8 bytes
+"日本語"                                 // UTF-8
+"\u65e5\u672c\u8a9e"                    // Unicode code points
+"\U000065e5\U0000672c\U00008a9e"        // Unicode code points
+"\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"  // UTF-8 bytes
 ```
 
 ## Types
@@ -455,7 +460,8 @@ assignment.
 ```
 Operand     = Literal | OperandName | "(" Expression ")" .
 Literal     = BasicLit | CompositeLit | FunctionLit .
-BasicLit    = int_lit | float_lit | imaginary_lit | rune_lit | string_lit .
+BasicLit    = int_lit | float_lit | imaginary_lit |
+              rune_lit | string_lit .
 OperandName = identifier | QualifiedIdent.
 ```
 
@@ -515,7 +521,8 @@ modules whose contents it wishes to use, followed by a possibly empty set of
 declarations of constants, types, and functions.
 
 ```
-SourceFile       = ModuleClause ";" { ImportDecl ";" } { TopLevelDecl ";" } .
+SourceFile       = ModuleClause ";" { ImportDecl ";" }
+                   { TopLevelDecl ";" } .
 ```
 
 ### Module clause
@@ -547,7 +554,8 @@ exported identifiers of that module. The import names an identifier
 to be imported.
 
 ```
-ImportDecl       = "import" ( ImportSpec | "(" { ImportSpec ";" } ")" ) .
+ImportDecl       = "import" ( ImportSpec |
+                              "(" { ImportSpec ";" } ")" ) .
 ImportSpec       = [ "." | ModuleName ] ImportPath .
 ImportPath       = string_lit .
 ```
@@ -591,7 +599,7 @@ exported identifiers.
 
 Here is a complete Rufus module that implements a prime sieve.
 
-```
+```rufus
 module main
 
 import "std/List"

--- a/rufus-lang.org/public/error/not-found.md
+++ b/rufus-lang.org/public/error/not-found.md
@@ -1,0 +1,3 @@
+# Page not found!
+
+Sorry, but the page you were looking for could not be found.

--- a/rufus-lang.org/public/index.html
+++ b/rufus-lang.org/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <!-- <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" /> -->
     <link href="https://fonts.googleapis.com/css?family=Heebo:400,500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:600&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- <meta name="theme-color" content="#000000" /> -->
     <meta
@@ -12,18 +13,18 @@
     />
     <!-- <link rel="apple-touch-icon" href="logo192.png" /> -->
     <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+         manifest.json provides metadata used when your web app is installed on a
+         user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+         Notice the use of %PUBLIC_URL% in the tags above.
+         It will be replaced with the URL of the `public` folder during the build.
+         Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
+         Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+         work correctly both with client-side routing and a non-root public URL.
+         Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Rufus</title>
   </head>

--- a/rufus-lang.org/public/index.md
+++ b/rufus-lang.org/public/index.md
@@ -1,0 +1,34 @@
+# Rufus programming language
+
+```rufus
+module main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, world!")
+}
+```
+
+## Design goals
+
+### Users first
+
+### Large teams
+
+Rufus caters to large engineering teams building and operating huge numbers of
+services that run continuously for years, with no end in sight. In this
+environment, services outlive people. Over its lifetime, service ownership will
+be transferred to another team, people on the owning team will transfer to other
+teams, and people will leave. Teams need to know that new team members can join
+a project and quickly learn how the systems work. Considering its lifetime,
+operations is the primary cost of a service
+
+### New developers
+
+Rufus should provide a great experience for a user that has little to no
+programming experience, with documentation, tooling, mentorship opportunities,
+and more.
+
+### Open source
+

--- a/rufus-lang.org/src/component/MarkdownDocument.css
+++ b/rufus-lang.org/src/component/MarkdownDocument.css
@@ -4,27 +4,27 @@
 }
 
 .MarkdownDocument h1 {
+  color: #292e31;
+  font-weight: 400;
   text-align: left;
   text-decoration: none;
-  font-weight: 400;
-  color: #292e31;
 }
 
 .MarkdownDocument h2 {
+  color: #292e31;
+  font-weight: 400;
   text-align: left;
   text-decoration: none;
-  font-weight: 400;
-  color: #292e31;
 }
 
 .MarkdownDocument h3 {
+  color: #292e31;
+  font-weight: 400;
   text-align: left;
   text-decoration: none;
-  font-weight: 400;
-  color: #292e31;
 }
 
-.MarkdownDocument ol li {
+.MarkdownDocument ol {
   margin-left: -2.45em;
 }
 
@@ -32,12 +32,24 @@
   color: #939da3;
 }
 
+.MarkdownDocument ul {
+  margin-left: -2.45em;
+}
+
 .MarkdownDocument ul li {
   color: #4c555a;
   list-style-type: disc;
-  margin-left: -2.45em;
+  list-style-position: outside;
 }
 
 .MarkdownDocument ul li::before {
   color: #939da3;
+}
+
+.MarkdownDocument pre {
+  background: #fafafb;
+  border: 1px solid #f0f2f3;
+  margin: 35px -150px;
+  padding: 25px 150px;
+  position: relative;
 }

--- a/rufus-lang.org/src/component/MarkdownDocument.js
+++ b/rufus-lang.org/src/component/MarkdownDocument.js
@@ -4,8 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import './MarkdownDocument.css';
 
 class MarkdownDocument extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {input: ''};
     }
 
@@ -14,12 +14,19 @@ class MarkdownDocument extends React.Component {
     }
 
     getData() {
-        const url = process.env.PUBLIC_URL + '/doc/rdr/0000-rufus-decision-records.md';
+        const pathname = document.location.pathname;
+        const markdownPathname = pathname === "/" ? "/index.md" : pathname + ".md";
+        const url = process.env.PUBLIC_URL + markdownPathname;
         var xhr = new XMLHttpRequest();
         xhr.addEventListener('load', () => {
             this.setState({input: xhr.responseText});
         });
         xhr.open('GET', url);
+        xhr.onerror = function () {
+            console.log("** An error occurred during the HTTP request to load Markdown content **");
+            console.log("status: " + xhr.status);
+            console.log("statusText: " + xhr.statusText);
+        };
         xhr.send();
     }
 

--- a/rufus-lang.org/src/component/NotFound.js
+++ b/rufus-lang.org/src/component/NotFound.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import MarkdownDocument from './MarkdownDocument';
+
+class NotFound extends React.Component {
+    render() {
+        return (
+            <MarkdownDocument path="/error/not-found.md" />
+        );
+    }
+}
+
+export default NotFound;

--- a/rufus-lang.org/src/index.css
+++ b/rufus-lang.org/src/index.css
@@ -4,16 +4,19 @@
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   background: #f5f7f9;
   color: #4c555a;
-  margin: 0;
   font-family: 'Heebo', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  margin: 0;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 11.5pt;
+  font-weight: 600;
+  color: #424770;
 }
 
 a, a:visited {

--- a/rufus-lang.org/src/index.js
+++ b/rufus-lang.org/src/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Route, BrowserRouter as Router } from 'react-router-dom'
+import { Route, BrowserRouter as Router, Switch } from 'react-router-dom'
 
 import App from './App';
+import NotFound from './component/NotFound';
 import * as serviceWorker from './serviceWorker';
 
 import './index.css';
@@ -10,8 +11,10 @@ import './index.css';
 const routing = (
     <Router>
         <div>
-            <Route exact path="/" component={App} />
-            <Route path="/doc/rdr/:name" component={App} />
+            <Switch>
+                <Route path="/" component={App} />
+                <Route component={NotFound} />
+            </Switch>
         </div>
     </Router>
 );

--- a/rufus-lang.org/src/layout/Header.css
+++ b/rufus-lang.org/src/layout/Header.css
@@ -4,10 +4,10 @@
 
 a.Header-logo {
   font-size: 18pt;
-  text-align: left;
-  text-decoration: none;
   font-weight: 500;
   margin-left: 25px;
+  text-align: left;
+  text-decoration: none;
 }
 
 .Header-links {

--- a/rufus-lang.org/src/layout/Main.css
+++ b/rufus-lang.org/src/layout/Main.css
@@ -1,7 +1,7 @@
 .Main {
   background: #ffffff;
   border: 1px solid #eaecee;
-  width: 878px;
-  min-height: 725px;
   margin: 0 auto 75px;
+  min-height: 725px;
+  width: 878px;
 }

--- a/rufus-lang.org/src/layout/Main.js
+++ b/rufus-lang.org/src/layout/Main.js
@@ -4,16 +4,14 @@ import MarkdownDocument from './../component/MarkdownDocument';
 
 import './Main.css';
 
-class Main extends React.Component {
-    render() {
-        return (
-            <main className="Main">
-                <div className="Main-content">
-                    <MarkdownDocument />
-                </div>
-            </main>
-        );
-    }
+function Main() {
+    return (
+        <main className="Main">
+            <div className="Main-content">
+                <MarkdownDocument path="/doc/spec" />
+            </div>
+        </main>
+    );
 }
 
 export default Main;


### PR DESCRIPTION
Rufus decision records now have an `Authors` list. Code blocks have been styled and some have been updated to use 60 character or less. Longer lines don't render well. If a Markdown document exists for a given browser path, without the trailing `.md` file extension, the document will be served and rendered. Otherwise, the page will crash. Serving _HTTP 404 Not Found_ responses when a document can't be found will be addressed in a subsequent change.