### PR TITLE
compiler: Parse match expressions that bind variables

### DIFF
--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -13,6 +13,7 @@
     make_import/2,
     make_inferred_type/2,
     make_literal/3,
+    make_match/3,
     make_module/2,
     make_param/3,
     make_type/2,
@@ -89,29 +90,23 @@ make_module(Spec, Line) ->
 make_import(Spec, Line) ->
     {import, #{spec => Spec, line => Line}}.
 
-%% Identifier form builder API
+%% Type form builder API
 
-%% make_identifier returns a form for an identifier.
--spec make_identifier(atom(), integer()) -> {identifier, #{spec => atom(), line => integer()}}.
-make_identifier(Spec, Line) ->
-    {identifier, #{spec => Spec, line => Line}}.
+%% make_inferred_type creates a type form with 'inferred' as the 'source' value,
+%% to indicate that the type has been inferred by the compiler.
+-spec make_inferred_type(type_spec(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
+make_inferred_type(Spec, Line) ->
+    make_type(Spec, inferred, Line).
 
-%% Literal form builder API
+%% make_type returns a type form with 'rufus_text' as the 'source' value, to
+%% indicate that the type came from source code.
+-spec make_type(atom(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
+make_type(Spec, Line) ->
+    make_type(Spec, rufus_text, Line).
 
-%% make_literal returns a form for a literal value.
--spec make_literal(literal(), atom(), term()) -> literal_form().
-make_literal(TypeSpec, Spec, Line) ->
-    FormSpec = list_to_atom(unicode:characters_to_list([atom_to_list(TypeSpec), "_lit"])),
-    {FormSpec, #{spec => Spec,
-                 type => make_inferred_type(TypeSpec, Line),
-                 line => Line}}.
-
-%% Binary operation form builder API
-
-%% make_binary_op returns a form for a binary operation.
--spec make_binary_op(atom(), rufus_form(), rufus_form(), integer()) -> {binary_op, #{op => atom(), left => rufus_form(), right => rufus_form(), line => integer()}}.
-make_binary_op(Op, Left, Right, Line) ->
-    {binary_op, #{op => Op, left => Left, right => Right, line => Line}}.
+-spec make_type(type_spec(), type_source(), integer()) -> type_form().
+make_type(Spec, Source, Line) ->
+    {type, #{spec => Spec, source => Source, line => Line}}.
 
 %% Function form builder API
 
@@ -130,23 +125,36 @@ make_param(Spec, Type, Line) ->
 make_call(Spec, Args, Line) ->
     {call, #{spec => Spec, args => Args, line => Line}}.
 
-%% Type form builder API
+%% Identifier form builder API
 
-%% make_inferred_type creates a type form with 'inferred' as the 'source' value,
-%% to indicate that the type has been inferred by the compiler.
--spec make_inferred_type(type_spec(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
-make_inferred_type(Spec, Line) ->
-    make_type(Spec, inferred, Line).
+%% make_identifier returns a form for an identifier.
+-spec make_identifier(atom(), integer()) -> {identifier, #{spec => atom(), line => integer()}}.
+make_identifier(Spec, Line) ->
+    {identifier, #{spec => Spec, line => Line}}.
 
-%% make_type returns a type form with 'rufus_text' as the 'source' value, to
-%% indicate that the type came from source code.
--spec make_type(atom(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
-make_type(Spec, Line) ->
-    make_type(Spec, rufus_text, Line).
+%% Literal form builder API
 
--spec make_type(type_spec(), type_source(), integer()) -> type_form().
-make_type(Spec, Source, Line) ->
-    {type, #{spec => Spec, source => Source, line => Line}}.
+%% make_literal returns a form for a literal value.
+-spec make_literal(literal(), atom(), term()) -> literal_form().
+make_literal(TypeSpec, Spec, Line) ->
+    FormSpec = list_to_atom(unicode:characters_to_list([atom_to_list(TypeSpec), "_lit"])),
+    {FormSpec, #{spec => Spec,
+                 type => make_inferred_type(TypeSpec, Line),
+                 line => Line}}.
+
+%% binary_op form builder API
+
+%% make_binary_op returns a form for a binary operation.
+-spec make_binary_op(atom(), rufus_form(), rufus_form(), integer()) -> {binary_op, #{op => atom(), left => rufus_form(), right => rufus_form(), line => integer()}}.
+make_binary_op(Op, Left, Right, Line) ->
+    {binary_op, #{op => Op, left => Left, right => Right, line => Line}}.
+
+%% match form builder API
+
+%% make_match returns a form for a binary operation.
+-spec make_match(rufus_form(), rufus_form(), integer()) -> {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
+make_match(Left, Right, Line) ->
+    {match, #{left => Left, right => Right, line => Line}}.
 
 %% Private API
 

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -151,7 +151,7 @@ make_binary_op(Op, Left, Right, Line) ->
 
 %% match form builder API
 
-%% make_match returns a form for a binary operation.
+%% make_match returns a form for a match expression.
 -spec make_match(rufus_form(), rufus_form(), integer()) -> {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_match(Left, Right, Line) ->
     {match, #{left => Left, right => Right, line => Line}}.

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -8,12 +8,12 @@ Nonterminals
     type
     block
     func_decl param params expr exprs args
-    binary_op.
+    binary_op match.
 
 Terminals
     '{' '}' '(' ')' ','
     '+' '-' '*' '/' '%'
-    ';'
+    ';' '='
     module import
     func identifier
     atom atom_lit
@@ -37,6 +37,7 @@ Left 100 '-'.
 Left 100 '*'.
 Left 100 '/'.
 Left 100 '%'.
+Left 300 '='.
 
 %%
 %% Grammar rules
@@ -56,7 +57,7 @@ type -> int                      : rufus_form:make_type(int, line('$1')).
 type -> string                   : rufus_form:make_type(string, line('$1')).
 
 func_decl -> func identifier '(' params ')' type block :
-                                    rufus_form:make_func(list_to_atom(text('$2')), '$4', '$6', '$7', line('$1')).
+                                   rufus_form:make_func(list_to_atom(text('$2')), '$4', '$6', '$7', line('$1')).
 
 params -> param params           : ['$1'|'$2'].
 params -> '$empty'               : [].
@@ -77,6 +78,7 @@ expr  -> int_lit                 : rufus_form:make_literal(int, text('$1'), line
 expr  -> string_lit              : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
 expr  -> identifier              : rufus_form:make_identifier(list_to_atom(text('$1')), line('$1')).
 expr  -> binary_op               : '$1'.
+expr  -> match                   : '$1'.
 expr  -> identifier '(' args ')' : rufus_form:make_call(list_to_atom(text('$1')), '$3', line('$1')).
 
 binary_op -> expr '+' expr       : rufus_form:make_binary_op('+', '$1', '$3', line('$2')).
@@ -84,6 +86,8 @@ binary_op -> expr '-' expr       : rufus_form:make_binary_op('-', '$1', '$3', li
 binary_op -> expr '*' expr       : rufus_form:make_binary_op('*', '$1', '$3', line('$2')).
 binary_op -> expr '/' expr       : rufus_form:make_binary_op('/', '$1', '$3', line('$2')).
 binary_op -> expr '%' expr       : rufus_form:make_binary_op('%', '$1', '$3', line('$2')).
+
+match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
 
 Erlang code.
 

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -162,3 +162,9 @@ make_inferred_type_test() ->
 
 make_type_test() ->
     ?assertEqual({type, #{spec => float, source => rufus_text, line => 37}}, rufus_form:make_type(float, 37)).
+
+make_match_test() ->
+    Left = rufus_form:make_identifier(n, 3),
+    Right = rufus_form:make_identifier(m, 3),
+    ?assertEqual({match, #{left => Left, right => Right, line => 3}},
+                 rufus_form:make_match(Left, Right, 3)).

--- a/rf/test/rufus_parse_test.erl
+++ b/rf/test/rufus_parse_test.erl
@@ -810,3 +810,185 @@ parse_function_calling_a_function_with_an_argument_test() ->
                                        spec => string}},
                spec => 'Echo'}}
     ], Forms).
+
+%% match tests
+
+parse_function_with_a_match_that_binds_a_variable_test() ->
+    RufusText = "
+    module example
+    func Echo(n int) int {
+        m = n
+        m
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => m}},
+                                             line => 4,
+                                             right => {identifier, #{line => 4,
+                                                                     spec => n}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => m}}],
+                         line => 3,
+                         params => [{param, #{line => 3,
+                                              spec => n,
+                                              type => {type, #{line => 3,
+                                                               source => rufus_text,
+                                                               spec => int}}}}],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => int}},
+                         spec => 'Echo'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_an_atom_literal_test() ->
+    RufusText = "
+    module example
+    func Ping() atom {
+        response = :pong
+        response
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => response}},
+                                             line => 4,
+                                             right => {atom_lit, #{line => 4,
+                                                                   spec => pong,
+                                                                   type => {type, #{line => 4,
+                                                                                    source => inferred,
+                                                                                    spec => atom}}}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => response}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => atom}},
+                         spec => 'Ping'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_a_bool_literal_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool {
+        response = true
+        response
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => response}},
+                                             line => 4,
+                                             right => {bool_lit, #{line => 4,
+                                                                   spec => true,
+                                                                   type => {type, #{line => 4,
+                                                                                    source => inferred,
+                                                                                    spec => bool}}}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => response}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Truthy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_a_float_literal_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() float {
+        response = 42.0
+        response
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => response}},
+                                             line => 4,
+                                             right => {float_lit, #{line => 4,
+                                                                    spec => 42.0,
+                                                                    type => {type, #{line => 4,
+                                                                                     source => inferred,
+                                                                                     spec => float}}}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => response}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => float}},
+                         spec => 'FortyTwo'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_an_int_literal_test() ->
+    RufusText = "
+    module example
+    func FortyTwo() int {
+        response = 42
+        response
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => response}},
+                                             line => 4,
+                                             right => {int_lit, #{line => 4,
+                                                                  spec => 42,
+                                                                  type => {type, #{line => 4,
+                                                                                   source => inferred,
+                                                                                   spec => int}}}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => response}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => int}},
+                         spec => 'FortyTwo'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_a_string_literal_test() ->
+    RufusText = "
+    module example
+    func Ping() string {
+        response = \"pong\"
+        response
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
+                                                                    spec => response}},
+                                             line => 4,
+                                             right => {string_lit, #{line => 4,
+                                                                     spec => <<"pong">>,
+                                                                     type => {type, #{line => 4,
+                                                                                      source => inferred,
+                                                                                      spec => string}}}}}},
+                                   {identifier, #{line => 5,
+                                                  spec => response}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => string}},
+                         spec => 'Ping'}}],
+    ?assertEqual(Expected, Forms).


### PR DESCRIPTION
The parser creates `match` forms from simple `$left = $right` match expressions.