### PR TITLE
compiler: Tokenize and parse binary_op expressions with and, or and xor operators

### DIFF
--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -14,6 +14,7 @@ Terminals
     '{' '}' '(' ')' ','
     '+' '-' '*' '/' '%'
     ';' '='
+    'and' 'or' 'xor'
     module import
     func identifier
     atom atom_lit
@@ -37,7 +38,10 @@ Left 100 '-'.
 Left 100 '*'.
 Left 100 '/'.
 Left 100 '%'.
-Left 50 '='.
+Left 100 'and'.
+Left 80  'or'.
+Left 80  'xor'.
+Left 50  '='.
 
 %%
 %% Grammar rules
@@ -86,6 +90,9 @@ binary_op -> expr '-' expr       : rufus_form:make_binary_op('-', '$1', '$3', li
 binary_op -> expr '*' expr       : rufus_form:make_binary_op('*', '$1', '$3', line('$2')).
 binary_op -> expr '/' expr       : rufus_form:make_binary_op('/', '$1', '$3', line('$2')).
 binary_op -> expr '%' expr       : rufus_form:make_binary_op('%', '$1', '$3', line('$2')).
+binary_op -> expr 'and' expr     : rufus_form:make_binary_op('and', '$1', '$3', line('$2')).
+binary_op -> expr 'or' expr      : rufus_form:make_binary_op('or', '$1', '$3', line('$2')).
+binary_op -> expr 'xor' expr     : rufus_form:make_binary_op('xor', '$1', '$3', line('$2')).
 
 match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
 

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -37,6 +37,9 @@ Minus         = \-
 Multiply      = \*
 Divide        = \/
 Remainder     = \%
+And           = and
+Or            = or
+XOr           = xor
 
 Identifier    = {Letter}({Letter}|{Digit})*
 
@@ -76,6 +79,9 @@ Rules.
 {Multiply}      : {token, {'*', TokenLine}}.
 {Divide}        : {token, {'/', TokenLine}}.
 {Remainder}     : {token, {'%', TokenLine}}.
+{And}           : {token, {'and', TokenLine}}.
+{Or}            : {token, {'or', TokenLine}}.
+{XOr}           : {token, {'xor', TokenLine}}.
 
 {Identifier}    : {token, {identifier, TokenLine, TokenChars}}.
 

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -336,3 +336,90 @@ parse_function_remaindering_three_ints_test() ->
                                        source => rufus_text}},
                spec => 'Four'}}
     ], Forms).
+
+parse_function_anding_two_bools_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { true and false }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 3,
+                                                 op => 'and',
+                                                 right => {bool_lit, #{line => 3,
+                                                                       spec => false,
+                                                                       type => {type, #{line => 3,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_oring_two_bools_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { true or false }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 3,
+                                                 op => 'or',
+                                                 right => {bool_lit, #{line => 3,
+                                                                       spec => false,
+                                                                       type => {type, #{line => 3,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Truthy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_xoring_two_bools_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { true xor false }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 3,
+                                                 op => 'xor',
+                                                 right => {bool_lit, #{line => 3,
+                                                                       spec => false,
+                                                                       type => {type, #{line => 3,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Truthy'}}],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_binary_op_test.erl
+++ b/rf/test/rufus_raw_tokenize_binary_op_test.erl
@@ -41,3 +41,27 @@ string_with_binary_op_expression_using_remainder_operator_test() ->
         {'%', 1},
         {int_lit, 1, 5}
     ], Tokens).
+
+string_with_binary_op_expression_using_and_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("true and false"),
+    ?assertEqual([
+        {bool_lit, 1, true},
+        {'and', 1},
+        {bool_lit, 1, false}
+    ], Tokens).
+
+string_with_binary_op_expression_using_or_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("true or false"),
+    ?assertEqual([
+        {bool_lit, 1, true},
+        {'or', 1},
+        {bool_lit, 1, false}
+    ], Tokens).
+
+string_with_binary_op_expression_using_xor_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("true xor false"),
+    ?assertEqual([
+        {bool_lit, 1, true},
+        {'xor', 1},
+        {bool_lit, 1, false}
+    ], Tokens).


### PR DESCRIPTION
New `and`, `or`, and `xor` operators can be tokenized and parsed in `binary_op` expressions.