### PR TITLE
compiler: Generate unboxed atom values

### DIFF
--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -53,6 +53,7 @@ eval_chain(Input, []) ->
 compile(ErlangForms) ->
     case compile:forms(ErlangForms) of
         {ok, Module, BinaryOrCode, _Warnings} ->
+            %% TODO(jkakar) We should bail when there are warnings.
             load(Module, BinaryOrCode);
         {ok, Module, BinaryOrCode} ->
             load(Module, BinaryOrCode);

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -126,8 +126,6 @@ forms(Acc, [{match, #{line := Line, left := Left, right := Right}}|T]) ->
     {ok, [RightForm]} = forms([], [Right]),
     Form = {match, Line, LeftForm, RightForm},
     forms([Form|Acc], T);
-%% forms(Acc, [{func, _Context}|T]) ->
-%%     forms(Acc, T); %% no-op to satisfy Dialyzer
 forms(Acc, [{type, _Context}|T]) ->
     forms(Acc, T); %% no-op to satisfy Dialyzer
 forms(Acc, []) ->
@@ -149,7 +147,8 @@ rufus_operator_to_erlang_operator('%', float) ->
 rufus_operator_to_erlang_operator(Op, _) ->
     Op.
 
-%% guard_forms generates function guard_forms for float and integer parameters.
+%% guard_forms generates function guard forms for various scalar parameter
+%% types.
 -spec guard_forms(list(erlang_form()) | list(list()), list(param_form())) -> {ok, list(erlang_form())}.
 guard_forms(Acc, [{param, #{line := Line, spec := Name, type := {type, #{spec := atom}}}}|T]) ->
     GuardExpr = [{call, Line, {remote, Line, {atom, Line, erlang}, {atom, Line, is_atom}}, [{var, Line, Name}]}],
@@ -171,8 +170,8 @@ guard_forms(Acc, []) ->
     {ok, Acc}.
 
 %% box converts a Rufus literal to its representation in Erlang. atom, bool,
-%% float and int are all represented as primitive values in Erlang, while string
-%% is represented as an annotated {string, BinaryValue} tuple.
+%% float and int are all represented as scalar values in Erlang, while string is
+%% represented as an annotated {string, BinaryValue} tuple.
 -spec box(atom_lit_form() | bool_lit_form() | float_lit_form() | int_lit_form() | string_lit_form()) -> erlang3_form().
 box({atom_lit, #{line := Line, spec := Value}}) ->
     {atom, Line, Value};
@@ -226,37 +225,11 @@ make_export_forms(Acc, []) ->
 %% exported from the module, otherwise it returns false.
 -spec is_public(atom()) -> boolean().
 is_public(Name) ->
-    LeadingChar = string:slice(atom_to_list(Name), 0, 1),
+    LeadingChar = lists:nth(1, string:slice(atom_to_list(Name), 0, 1)),
     not is_private(LeadingChar).
 
 %% is_private returns true if Name represents a private function that should be
 %% exported from the module, otherwise it returns false.
--spec is_private(string()) -> boolean().
-is_private("_") -> true;
-is_private("a") -> true;
-is_private("b") -> true;
-is_private("c") -> true;
-is_private("d") -> true;
-is_private("e") -> true;
-is_private("f") -> true;
-is_private("g") -> true;
-is_private("h") -> true;
-is_private("i") -> true;
-is_private("j") -> true;
-is_private("k") -> true;
-is_private("l") -> true;
-is_private("m") -> true;
-is_private("n") -> true;
-is_private("o") -> true;
-is_private("p") -> true;
-is_private("q") -> true;
-is_private("r") -> true;
-is_private("s") -> true;
-is_private("t") -> true;
-is_private("u") -> true;
-is_private("v") -> true;
-is_private("w") -> true;
-is_private("x") -> true;
-is_private("y") -> true;
-is_private("z") -> true;
-is_private(_)   -> false.
+-spec is_private(integer()) -> boolean().
+is_private(C) ->
+    (C >= $a) and (C =< $z).

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -157,6 +157,7 @@ annotate_exports(Forms) ->
 -spec annotate_exports(list(erlang_form()), list(erlang_form())) -> {ok, list(erlang_form())}.
 annotate_exports(Acc, [Form = {attribute, _Line, module, _Name}|T]) ->
     {ok, ExportForms} = make_export_forms(T),
+    %% Inject export forms directly after the module declaration.
     annotate_exports(Acc ++ ExportForms ++ [Form], T);
 annotate_exports(Acc, [Form|T]) ->
     annotate_exports([Form|Acc], T);
@@ -169,11 +170,47 @@ make_export_forms(Forms) ->
 
 -spec make_export_forms(list(erlang_form()), list(erlang_form())) -> {ok, list(export_attribute_erlang_form())}.
 make_export_forms(Acc, [{function, Line, Spec, Arity, _Forms}|T]) ->
-    %% TODO(jkakar) We're exporting all functions for now, to move quickly, but
-    %% we need to apply the rules from the 'Exported identifiers' RDR here.
-    Form = {attribute, Line, export, [{Spec, Arity}]},
-    make_export_forms([Form|Acc], T);
+    case is_public(Spec) of
+        true ->
+            Form = {attribute, Line, export, [{Spec, Arity}]},
+            make_export_forms([Form|Acc], T);
+        false ->
+            make_export_forms(Acc, T)
+    end;
 make_export_forms(Acc, [_Form|T]) ->
     make_export_forms(Acc, T);
 make_export_forms(Acc, []) ->
     {ok, lists:reverse(Acc)}.
+
+is_public(Name) ->
+    LeadingChar = string:slice(atom_to_list(Name), 0, 1),
+    not is_private(LeadingChar).
+
+is_private("_") -> true;
+is_private("a") -> true;
+is_private("b") -> true;
+is_private("c") -> true;
+is_private("d") -> true;
+is_private("e") -> true;
+is_private("f") -> true;
+is_private("g") -> true;
+is_private("h") -> true;
+is_private("i") -> true;
+is_private("j") -> true;
+is_private("k") -> true;
+is_private("l") -> true;
+is_private("m") -> true;
+is_private("n") -> true;
+is_private("o") -> true;
+is_private("p") -> true;
+is_private("q") -> true;
+is_private("r") -> true;
+is_private("s") -> true;
+is_private("t") -> true;
+is_private("u") -> true;
+is_private("v") -> true;
+is_private("w") -> true;
+is_private("x") -> true;
+is_private("y") -> true;
+is_private("z") -> true;
+is_private(_)   -> false.

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -27,10 +27,7 @@ forms(RufusForms) ->
 group_forms_by_func(Forms) ->
     {value, ModuleForm} = lists:search(fun match_module_form/1, Forms),
     {ok, Globals} = rufus_form:globals(Forms),
-    {ok, group_forms_by_func(ModuleForm, Globals)}.
 
--spec group_forms_by_func(module_form(), globals()) -> list(rufus_form() | {func_group, context()}).
-group_forms_by_func(ModuleForm, Globals) ->
     GroupBy = fun(Name, FuncForms, Acc) ->
         {func, #{line := Line, params := Params}} = lists:nth(1, FuncForms),
         Form = {func_group, #{line => Line, spec => Name, arity => length(Params), forms => FuncForms}},
@@ -48,7 +45,7 @@ group_forms_by_func(ModuleForm, Globals) ->
     end,
     SortedFuncForms = lists:sort(SortBy, GroupedFuncForms),
 
-    [ModuleForm|lists:reverse(SortedFuncForms)].
+    {ok, [ModuleForm|lists:reverse(SortedFuncForms)]}.
 
 match_module_form({module, _Context}) ->
     true;

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -25,7 +25,12 @@ forms(RufusForms) ->
 %% represented as a list instead of a context map.
 -spec group_forms_by_func(list(rufus_form())) -> {ok, list(rufus_form() | {func_group, context()})}.
 group_forms_by_func(Forms) ->
-    {value, ModuleForm} = lists:search(fun match_module_form/1, Forms),
+    MatchModuleForm = fun({module, _Context}) ->
+        true;
+    (_) ->
+        false
+    end,
+    {value, ModuleForm} = lists:search(MatchModuleForm, Forms),
     {ok, Globals} = rufus_form:globals(Forms),
 
     GroupBy = fun(Name, FuncForms, Acc) ->
@@ -46,11 +51,6 @@ group_forms_by_func(Forms) ->
     SortedFuncForms = lists:sort(SortBy, GroupedFuncForms),
 
     {ok, [ModuleForm|lists:reverse(SortedFuncForms)]}.
-
-match_module_form({module, _Context}) ->
-    true;
-match_module_form(_) ->
-    false.
 
 -spec forms(list(erlang_form()), list(rufus_form() | {func_group, context()})) -> {ok, list(erlang_form())}.
 forms(Acc, [{module, #{line := Line, spec := Name}}|T]) ->

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -231,5 +231,5 @@ is_public(Name) ->
 %% is_private returns true if Name represents a private function that should be
 %% exported from the module, otherwise it returns false.
 -spec is_private(integer()) -> boolean().
-is_private(C) ->
-    (C >= $a) and (C =< $z).
+is_private(LeadingChar) ->
+    (LeadingChar >= $a) and (LeadingChar =< $z).

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -5,7 +5,7 @@ Colon         = \:
 Semicolon     = \;
 UnicodeLetter = [A-Za-z]
 Digit         = [0-9]
-Letter        = ({UnicodeLetter}|"_")
+Letter        = ({UnicodeLetter}|'_')
 Whitespace    = [\s\t]
 
 Module        = module

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -52,7 +52,6 @@
 %% Expressions
 
 -type func_form() :: {func, context()}.
--type funcs_form() :: {funcs, context()}.
 -type param_form() :: {param, context()}.
 -type identifier_form() :: {identifier, context()}.
 -type binary_op_form() :: {binary_op, context()}.
@@ -69,7 +68,6 @@
       | string_lit_form()
       | module_form()
       | func_form()
-      | funcs_form()
       | param_form()
       | identifier_form()
       | type_form()

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -52,6 +52,7 @@
 %% Expressions
 
 -type func_form() :: {func, context()}.
+-type funcs_form() :: {funcs, context()}.
 -type param_form() :: {param, context()}.
 -type identifier_form() :: {identifier, context()}.
 -type binary_op_form() :: {binary_op, context()}.
@@ -68,6 +69,7 @@
       | string_lit_form()
       | module_form()
       | func_form()
+      | funcs_form()
       | param_form()
       | identifier_form()
       | type_form()

--- a/rf/test/rufus_compile_call_test.erl
+++ b/rf/test/rufus_compile_call_test.erl
@@ -117,4 +117,4 @@ eval_with_function_call_with_one_argument_and_many_function_heads_test() ->
     ?assertEqual(false, example:'Echo'(false)),
     ?assertEqual(3.14159265359, example:'Echo'(3.14159265359)),
     ?assertEqual(42, example:'Echo'(42)),
-    ?assertEqual(<<"hello">>, example:'Echo'({string, <<"hello">>})).
+    ?assertEqual({string, <<"hello">>}, example:'Echo'({string, <<"hello">>})).

--- a/rf/test/rufus_compile_call_test.erl
+++ b/rf/test/rufus_compile_call_test.erl
@@ -34,7 +34,7 @@ eval_with_function_call_with_a_bool_argument_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({bool, true}, example:'Random'()).
+    ?assertEqual(true, example:'Random'()).
 
 eval_with_function_call_with_a_float_argument_test() ->
     RufusText = "

--- a/rf/test/rufus_compile_call_test.erl
+++ b/rf/test/rufus_compile_call_test.erl
@@ -99,3 +99,22 @@ eval_with_function_call_with_binary_op_argument_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(20, example:'SumAndDouble'(3, 7)).
+
+%% Multiple function heads
+
+eval_with_function_call_with_one_argument_and_many_function_heads_test() ->
+    RufusText = "
+    module example
+    func Echo(name atom) atom { name }
+    func Echo(b bool) bool { b }
+    func Echo(n float) float { n }
+    func Echo(n int) int { n }
+    func Echo(text string) string { text }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(hello, example:'Echo'(hello)),
+    ?assertEqual(false, example:'Echo'(false)),
+    ?assertEqual(3.14159265359, example:'Echo'(3.14159265359)),
+    ?assertEqual(42, example:'Echo'(42)),
+    ?assertEqual(<<"hello">>, example:'Echo'({string, <<"hello">>})).

--- a/rf/test/rufus_compile_call_test.erl
+++ b/rf/test/rufus_compile_call_test.erl
@@ -106,7 +106,6 @@ eval_with_function_call_with_one_argument_and_many_function_heads_test() ->
     RufusText = "
     module example
     func Echo(name atom) atom { name }
-    func Echo(b bool) bool { b }
     func Echo(n float) float { n }
     func Echo(n int) int { n }
     func Echo(text string) string { text }
@@ -114,7 +113,6 @@ eval_with_function_call_with_one_argument_and_many_function_heads_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(hello, example:'Echo'(hello)),
-    ?assertEqual(false, example:'Echo'(false)),
     ?assertEqual(3.14159265359, example:'Echo'(3.14159265359)),
     ?assertEqual(42, example:'Echo'(42)),
     ?assertEqual({string, <<"hello">>}, example:'Echo'({string, <<"hello">>})).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -18,7 +18,7 @@ eval_with_function_returning_a_bool_literal_test() ->
     func True() bool { true }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
-    ?assertEqual({bool, true}, example:'True'()).
+    ?assertEqual(true, example:'True'()).
 
 eval_with_function_returning_a_float_literal_test() ->
     RufusText = "
@@ -76,7 +76,7 @@ eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({bool, true}, example:'MaybeEcho'({bool, false})).
+    ?assertEqual(true, example:'MaybeEcho'(false)).
 
 eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
     RufusText = "
@@ -123,7 +123,7 @@ eval_with_function_taking_a_bool_and_returning_it_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    ?assertEqual({bool, false}, example:'Echo'({bool, false})).
+    ?assertEqual(false, example:'Echo'(false)).
 
 eval_with_function_taking_a_float_and_returning_it_test() ->
     RufusText = "

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -186,3 +186,14 @@ eval_with_function_taking_a_bool_and_returning_it_with_a_mismatched_return_type_
                                      source => rufus_text,
                                      spec => int}}},
     ?assertEqual({error, unmatched_return_type, Data}, rufus_compile:eval(RufusText)).
+
+%% Function exports
+
+eval_with_private_function_test() ->
+    RufusText = "
+    module example
+    func echo(s string) string { s }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertError(undef, example:echo({string, <<"Hello">>})).

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -22,7 +22,7 @@ eval_a_function_with_a_match_that_binds_a_bool_literal_test() ->
     }
     ",
     {ok, example} = rufus_compile:eval(RufusText),
-    ?assertEqual({bool, true}, example:'Truthy'()).
+    ?assertEqual(true, example:'Truthy'()).
 
 eval_a_function_with_a_match_that_binds_a_float_literal_test() ->
     RufusText = "

--- a/rf/test/rufus_erlang_call_test.erl
+++ b/rf/test/rufus_erlang_call_test.erl
@@ -150,20 +150,20 @@ forms_for_function_call_with_two_int_arguments_test() ->
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
-        {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Sum', 2}]},
+        {attribute, 4, export, [{'Random', 0}]},
+        {function, 4, 'Random', 0,
+            [{clause, 4,
+                 [],
+                 [],
+                 [{call, 4, {atom, 4, 'Sum'}, [{integer, 4, 1}, {integer, 4, 2}]}]}]
+        },
         {function, 3, 'Sum', 2,
             [{clause, 3,
                  [{var, 3, m}, {var, 3, n}],
                  [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}],
                   [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, m}]}]],
                  [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}]
-        },
-        {function, 4, 'Random', 0,
-            [{clause, 4,
-                 [],
-                 [],
-                 [{call, 4, {atom, 4, 'Sum'}, [{integer, 4, 1}, {integer, 4, 2}]}]}]
         }
     ],
     ?assertEqual(Expected, ErlangForms).
@@ -180,20 +180,20 @@ forms_for_function_call_with_two_float_arguments_test() ->
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
-        {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Sum', 2}]},
+        {attribute, 4, export, [{'Random', 0}]},
+        {function, 4, 'Random', 0,
+            [{clause, 4,
+                 [],
+                 [],
+                 [{call, 4, {atom, 4, 'Sum'}, [{float, 4, 1.2}, {float, 4, 2.3}]}]}]
+        },
         {function, 3, 'Sum', 2,
             [{clause, 3,
                  [{var, 3, m}, {var, 3, n}],
                  [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}],
                   [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, m}]}]],
                  [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}]
-        },
-        {function, 4, 'Random', 0,
-            [{clause, 4,
-                 [],
-                 [],
-                 [{call, 4, {atom, 4, 'Sum'}, [{float, 4, 1.2}, {float, 4, 2.3}]}]}]
         }
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_call_test.erl
+++ b/rf/test/rufus_erlang_call_test.erl
@@ -61,11 +61,13 @@ forms_for_function_call_with_a_bool_argument_test() ->
         {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Echo', 1}]},
         {function, 3, 'Echo', 1, [
-                {clause, 3, [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}], [], [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}]}
+            {clause, 3, [{var, 3, b}], [
+                [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+                [{var, 3, b}]}
             ]},
         {function, 4, 'Random', 0, [
-                {clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{tuple, 4, [{atom, 4, bool}, {atom, 4, true}]}]}]}
-            ]}
+            {clause, 4, [], [], [
+                {call, 4, {atom, 4, 'Echo'}, [{atom, 4, true}]}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -316,7 +316,7 @@ forms_for_function_taking_a_string_and_returning_a_string_test() ->
 
 %% Function exports
 
-forms_for_private_functions_are_not_exported_test() ->
+forms_for_private_functions_with_leading_lowercase_character_are_not_exported_test() ->
     RufusText = "
     module example
     func echo(s string) string { s }
@@ -333,3 +333,21 @@ forms_for_private_functions_are_not_exported_test() ->
                          [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+%% forms_for_private_functions_with_leading_underscore_are_not_exported_test() ->
+%%     RufusText = "
+%%     module example
+%%     func _Echo(s string) string { s }
+%%     ",
+%%     {ok, Tokens} = rufus_tokenize:string(RufusText),
+%%     {ok, Forms} = rufus_parse:parse(Tokens),
+%%     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+%%     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+%%     Expected = [
+%%         {attribute, 2, module, example},
+%%         {function, 3, '_Echo', 1,
+%%             [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
+%%                          [],
+%%                          [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
+%%     ],
+%%     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -313,3 +313,23 @@ forms_for_function_taking_a_string_and_returning_a_string_test() ->
                          [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+%% Function exports
+
+forms_for_private_functions_are_not_exported_test() ->
+    RufusText = "
+    module example
+    func echo(s string) string { s }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {function, 3, 'echo', 1,
+            [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
+                         [],
+                         [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -333,21 +333,3 @@ forms_for_private_functions_with_leading_lowercase_character_are_not_exported_te
                          [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
-
-%% forms_for_private_functions_with_leading_underscore_are_not_exported_test() ->
-%%     RufusText = "
-%%     module example
-%%     func _Echo(s string) string { s }
-%%     ",
-%%     {ok, Tokens} = rufus_tokenize:string(RufusText),
-%%     {ok, Forms} = rufus_parse:parse(Tokens),
-%%     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-%%     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-%%     Expected = [
-%%         {attribute, 2, module, example},
-%%         {function, 3, '_Echo', 1,
-%%             [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
-%%                          [],
-%%                          [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
-%%     ],
-%%     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -28,12 +28,10 @@ forms_for_function_returning_a_bool_literal_test() ->
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
-    BoolExpr = {atom, 3, false},
-    BoxedBoolExpr = {tuple, 3, [{atom, 3, bool}, BoolExpr]},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'False', 0}]},
-        {function, 3, 'False', 0, [{clause, 3, [], [], [BoxedBoolExpr]}]}
+        {function, 3, 'False', 0, [{clause, 3, [], [], [{atom, 3, false}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -153,13 +151,14 @@ forms_for_function_taking_an_unused_bool_and_returning_a_bool_literal_test() ->
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
+
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
-        {function, 3, 'MaybeEcho', 1, [
-            {clause, 3, [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}],
-                        [],
-                        [{tuple, 3, [{atom, 3, bool}, {atom, 3, true}]}]}]}
+        {function, 3, 'MaybeEcho', 1,
+            [{clause, 3, [{var, 3, b}],
+                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+                         [{atom, 3, true}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -252,9 +251,9 @@ forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
         {function, 3, 'Echo', 1,
-            [{clause, 3, [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}],
-                         [],
-                         [{tuple, 3, [{atom, 3, bool}, {var, 3, b}]}]}]}
+            [{clause, 3, [{var, 3, b}],
+                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+                         [{var, 3, b}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 

--- a/rf/test/rufus_erlang_match_test.erl
+++ b/rf/test/rufus_erlang_match_test.erl
@@ -36,9 +36,8 @@ forms_for_function_with_a_match_that_binds_a_bool_literal_test() ->
     Expected = [{attribute, 2, module, example},
                   {attribute, 3, export, [{'Truthy', 0}]},
                   {function, 3, 'Truthy', 0, [
-                      {clause, 3, [], [], [{match, 4, {tuple, 4, [{atom, 4, bool}, {var, 4, response}]},
-                                                      {tuple, 4, [{atom, 4, bool}, {atom, 4, true}]}},
-                                                      {tuple, 5, [{atom, 5, bool}, {var, 5, response}]}]}]}],
+                      {clause, 3, [], [], [{match, 4, {var, 4, response}, {atom, 4, true}},
+                                           {var, 5, response}]}]}],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_match_that_binds_a_float_literal_test() ->


### PR DESCRIPTION
Boolean values are represented as raw `true` and `false` values, instead of as boxed `{bool, true}` and `{bool, false}` values. This improves efficiency and will also make implemented boolean operators more straightforward, though it means that the compiler will have to detect and warn about cases where a boolean parameter will be shadowed by an equivalent atom parameter defined in a preceding function head. The compiler now generates working code for functions that have multiple heads. Visibility logic has been improved. Functions that start with a lowercase letter are not exported anymore.