### PR TITLE
compiler: Typecheck binary_op expressions with and, or and xor operators

### DIFF
--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -34,7 +34,7 @@ group_forms_by_func(Forms) ->
     {ok, Globals} = rufus_form:globals(Forms),
 
     GroupBy = fun(Name, FuncForms, Acc) ->
-        {func, #{line := Line, params := Params}} = lists:nth(1, FuncForms),
+        {func, #{line := Line, params := Params}} = hd(FuncForms),
         Form = {func_group, #{line => Line, spec => Name, arity => length(Params), forms => FuncForms}},
         [Form|Acc]
     end,
@@ -225,7 +225,7 @@ make_export_forms(Acc, []) ->
 %% exported from the module, otherwise it returns false.
 -spec is_public(atom()) -> boolean().
 is_public(Name) ->
-    LeadingChar = lists:nth(1, string:slice(atom_to_list(Name), 0, 1)),
+    LeadingChar = hd(string:slice(atom_to_list(Name), 0, 1)),
     not is_private(LeadingChar).
 
 %% is_private returns true if Name represents a private function that should be

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -108,7 +108,7 @@ push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
 %% exclusively ints or exclusively floats. Inferred type information is added to
 %% every `binary_op` form. Return values:
 %% - `{ok, AnnotatedForms}` if no issues are found. Every `binary_op` form is
-%%   annotated with a inferred type annotation.
+%%   annotated with a type annotation.
 %% - `{error, unmatched_operand_type, Form}` is thrown if an `int` operand is
 %%   mixed with a `float` operand. `Form` contains the illegal operands.
 %% - `{error, unsupported_operand_type, Form}` is thrown if a type other than an

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -106,9 +106,9 @@ push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
 
 %% typecheck_and_annotate_binary_op ensures that binary_op operands are
 %% exclusively ints or exclusively floats. Inferred type information is added to
-%% every `binary_op` form. Returns values:
+%% every `binary_op` form. Return values:
 %% - `{ok, AnnotatedForms}` if no issues are found. Every `binary_op` form is
-%%   annotated with an inferred type annotation.
+%%   annotated with a inferred type annotation.
 %% - `{error, unmatched_operand_type, Form}` is thrown if an `int` operand is
 %%   mixed with a `float` operand. `Form` contains the illegal operands.
 %% - `{error, unsupported_operand_type, Form}` is thrown if a type other than an

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -108,7 +108,7 @@ push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
 %% exclusively ints or exclusively floats. Inferred type information is added to
 %% every `binary_op` form. Return values:
 %% - `{ok, AnnotatedForms}` if no issues are found. Every `binary_op` form is
-%%   annotated with a type annotation.
+%%   annotated with type information.
 %% - `{error, unmatched_operand_type, Form}` is thrown if an `int` operand is
 %%   mixed with a `float` operand. `Form` contains the illegal operands.
 %% - `{error, unsupported_operand_type, Form}` is thrown if a type other than an

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -100,26 +100,15 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
     {ok, RightType} = resolve_type(Globals, Right),
     LeftTypeSpec = rufus_form:type_spec(LeftType),
     RightTypeSpec = rufus_form:type_spec(RightType),
-    SupportedType = case Op of
-        '+'   -> fun supported_arithmetic_type/2;
-        '-'   -> fun supported_arithmetic_type/2;
-        '*'   -> fun supported_arithmetic_type/2;
-        '/'   -> fun supported_arithmetic_type/2;
-        '%'   -> fun supported_arithmetic_type/2;
-        'or'  -> fun supported_boolean_type/2;
-        'xor' -> fun supported_boolean_type/2;
-        'and' -> fun supported_boolean_type/2
-    end,
-
-    SupportedTypePair = case Op of
-        '+'   -> fun supported_arithmetic_type_pair/2;
-        '-'   -> fun supported_arithmetic_type_pair/2;
-        '*'   -> fun supported_arithmetic_type_pair/2;
-        '/'   -> fun supported_arithmetic_type_pair/2;
-        '%'   -> fun supported_arithmetic_type_pair/2;
-        'or'  -> fun supported_boolean_type_pair/2;
-        'xor' -> fun supported_boolean_type_pair/2;
-        'and' -> fun supported_boolean_type_pair/2
+    {SupportedType, SupportedTypePair} = case Op of
+        '+'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
+        '-'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
+        '*'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
+        '/'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
+        '%'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
+        'or'  -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2};
+        'xor' -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2};
+        'and' -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2}
     end,
 
     case SupportedType(Op, LeftTypeSpec) and SupportedType(Op, RightTypeSpec) of

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -100,20 +100,20 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
     {ok, RightType} = resolve_type(Globals, Right),
     LeftTypeSpec = rufus_form:type_spec(LeftType),
     RightTypeSpec = rufus_form:type_spec(RightType),
-    {SupportedType, SupportedTypePair} = case Op of
-        '+'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
-        '-'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
-        '*'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
-        '/'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
-        '%'   -> {fun supported_arithmetic_type/2, fun supported_arithmetic_type_pair/2};
-        'or'  -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2};
-        'xor' -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2};
-        'and' -> {fun supported_boolean_type/2,    fun supported_boolean_type_pair/2}
+    {AllowType, AllowTypePair} = case Op of
+        '+'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
+        '-'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
+        '*'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
+        '/'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
+        '%'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
+        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
+        'xor' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
+        'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2}
     end,
 
-    case SupportedType(Op, LeftTypeSpec) and SupportedType(Op, RightTypeSpec) of
+    case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of
         true ->
-            case SupportedTypePair(LeftTypeSpec, RightTypeSpec) of
+            case AllowTypePair(LeftTypeSpec, RightTypeSpec) of
                 true ->
                     {ok, LeftType};
                 false ->
@@ -123,21 +123,31 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
             throw({error, unsupported_operand_type, #{form => Form}})
     end.
 
--spec supported_arithmetic_type(atom(), float | int | atom()) -> boolean().
-supported_arithmetic_type('%', float) -> false;
-supported_arithmetic_type(_, float) -> true;
-supported_arithmetic_type(_, int) -> true;
-supported_arithmetic_type(_, _) -> false.
+%% allow_type_with_arithmetic_binary_op returns true if the specified type may
+%% be used with the specified arithmetic operator, otherwise false.
+-spec allow_type_with_arithmetic_binary_op(atom(), float | int | atom()) -> boolean().
+allow_type_with_arithmetic_binary_op('%', float) -> false;
+allow_type_with_arithmetic_binary_op(_, float) -> true;
+allow_type_with_arithmetic_binary_op(_, int) -> true;
+allow_type_with_arithmetic_binary_op(_, _) -> false.
 
--spec supported_arithmetic_type_pair(float | int | atom(), float | int | atom()) -> boolean().
-supported_arithmetic_type_pair(float, float) -> true;
-supported_arithmetic_type_pair(int, int) -> true;
-supported_arithmetic_type_pair(_, _) -> false.
+%% allow_type_pair_with_arithmetic_binary_op returns true if the specified pair
+%% of types are either both of type float, or both of type int, which are the
+%% only types that may be used with an arithmetic operator.
+-spec allow_type_pair_with_arithmetic_binary_op(float | int | atom(), float | int | atom()) -> boolean().
+allow_type_pair_with_arithmetic_binary_op(float, float) -> true;
+allow_type_pair_with_arithmetic_binary_op(int, int) -> true;
+allow_type_pair_with_arithmetic_binary_op(_, _) -> false.
 
--spec supported_boolean_type(atom(), bool | atom()) -> boolean().
-supported_boolean_type(_, bool) -> true;
-supported_boolean_type(_, _) -> false.
+%% allow_type_with_boolean_binary_op returns true if the specified type may be
+%% used with the specified boolean operator, otherwise false.
+-spec allow_type_with_boolean_binary_op(atom(), bool | atom()) -> boolean().
+allow_type_with_boolean_binary_op(_, bool) -> true;
+allow_type_with_boolean_binary_op(_, _) -> false.
 
--spec supported_boolean_type_pair(bool | atom(), bool | atom()) -> boolean().
-supported_boolean_type_pair(bool, bool) -> true;
-supported_boolean_type_pair(_, _) -> false.
+%% allow_type_pair_with_boolean_binary_op returns true if the specified pair of
+%% types are both of type bool, which is the only type that may be used with a
+%% boolean operator.
+-spec allow_type_pair_with_boolean_binary_op(bool | atom(), bool | atom()) -> boolean().
+allow_type_pair_with_boolean_binary_op(bool, bool) -> true;
+allow_type_pair_with_boolean_binary_op(_, _) -> false.

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -125,7 +125,7 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
 
 %% allow_type_with_arithmetic_binary_op returns true if the specified type may
 %% be used with the specified arithmetic operator, otherwise false.
--spec allow_type_with_arithmetic_binary_op(atom(), float | int | atom()) -> boolean().
+-spec allow_type_with_arithmetic_binary_op(arithmetic_operator(), float | int | atom()) -> boolean().
 allow_type_with_arithmetic_binary_op('%', float) -> false;
 allow_type_with_arithmetic_binary_op(_, float) -> true;
 allow_type_with_arithmetic_binary_op(_, int) -> true;
@@ -141,7 +141,7 @@ allow_type_pair_with_arithmetic_binary_op(_, _) -> false.
 
 %% allow_type_with_boolean_binary_op returns true if the specified type may be
 %% used with the specified boolean operator, otherwise false.
--spec allow_type_with_boolean_binary_op(atom(), bool | atom()) -> boolean().
+-spec allow_type_with_boolean_binary_op(boolean_operator(), bool | atom()) -> boolean().
 allow_type_with_boolean_binary_op(_, bool) -> true;
 allow_type_with_boolean_binary_op(_, _) -> false.
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -53,7 +53,6 @@
 
 -type arithmetic_operator() :: '+' | '-' | '*' | '/' | '%'.
 -type boolean_operator() :: 'or' | 'xor' | 'and'.
--type operator() :: arithmetic_operator() | boolean_operator().
 
 %% Expressions
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -49,6 +49,12 @@
        | int
        | string.
 
+%% Operators
+
+-type arithmetic_operator() :: '+' | '-' | '*' | '/' | '%'.
+-type boolean_operator() :: 'or' | 'xor' | 'and'.
+-type operator() :: arithmetic_operator() | boolean_operator().
+
 %% Expressions
 
 -type func_form() :: {func, context()}.

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -169,8 +169,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_strings_test() ->
                                                                type => {type, #{line => 3,
                                                                                 source => inferred,
                                                                                 spec => string}}}}}}},
-    {error, Reason, Data} = rufus_expr:typecheck_and_annotate(Forms),
-    ?assertEqual(unsupported_operand_type, Reason),
+    {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 %% arithmetic binary_op expressions with the remainder operator

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -2,9 +2,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% binary_op expressions
+%% arithmetic binary_op expressions
 
-typecheck_and_annotate_binary_op_with_ints_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_ints_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 19 + 23 }
@@ -37,7 +37,7 @@ typecheck_and_annotate_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_binary_op_with_floats_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_floats_test() ->
     RufusText = "
     module example
     func Pi() float { 1.0 + 2.14159265359 }
@@ -70,7 +70,7 @@ typecheck_and_annotate_binary_op_with_floats_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_binary_op_with_float_and_int_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_float_and_int_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 19.0 + 23 }
@@ -93,7 +93,7 @@ typecheck_and_annotate_binary_op_with_float_and_int_test() ->
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_binary_op_with_float_and_float_and_int_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_float_and_float_and_int_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 13.0 + 6.0 + 23 }
@@ -126,7 +126,7 @@ typecheck_and_annotate_binary_op_with_float_and_float_and_int_test() ->
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_binary_op_with_bools_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_bools_test() ->
     RufusText = "
     module example
     func Concat() bool { true + false }
@@ -149,7 +149,7 @@ typecheck_and_annotate_binary_op_with_bools_test() ->
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_binary_op_with_strings_test() ->
+typecheck_and_annotate_arithmetic_binary_op_with_strings_test() ->
     RufusText = "
     module example
     func Concat() string { \"port\" + \"manteau\" }
@@ -173,9 +173,9 @@ typecheck_and_annotate_binary_op_with_strings_test() ->
     ?assertEqual(unsupported_operand_type, Reason),
     ?assertEqual(Expected, Data).
 
-%% binary_op expressions with the remainder operator
+%% arithmetic binary_op expressions with the remainder operator
 
-typecheck_and_annotate_remainder_binary_op_with_ints_test() ->
+typecheck_and_annotate_remainder_arithmetic_binary_op_with_ints_test() ->
     RufusText = "
     module example
     func Six() int { 27 % 7 }
@@ -208,7 +208,7 @@ typecheck_and_annotate_remainder_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_remainder_binary_op_with_floats_test() ->
+typecheck_and_annotate_remainder_arithmetic_binary_op_with_floats_test() ->
     RufusText = "
     module example
     func Six() int { 27.0 % 7.0 }
@@ -228,6 +228,63 @@ typecheck_and_annotate_remainder_binary_op_with_floats_test() ->
                                                               type => {type, #{line => 3,
                                                                                source => inferred,
                                                                                spec => float}}}}}}},
-    {error, Reason, Data} = rufus_expr:typecheck_and_annotate(Forms),
-    ?assertEqual(unsupported_operand_type, Reason),
+    {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, Data).
+
+%% boolean binary_op expressions
+
+typecheck_and_annotate_boolean_binary_op_with_bools_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { true and false }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{params => [],
+                         exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 3,
+                                                 op => 'and',
+                                                 right => {bool_lit, #{line => 3,
+                                                                       spec => false,
+                                                                       type => {type, #{line => 3,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_boolean_binary_op_with_bool_and_int_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { true and 0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = #{form => {binary_op, #{left => {bool_lit, #{line => 3,
+                                                            spec => true,
+                                                            type => {type, #{line => 3,
+                                                                             source => inferred,
+                                                                             spec => bool}}}},
+                                       line => 3,
+                                       locals => #{},
+                                       op => 'and',
+                                       right => {int_lit, #{line => 3,
+                                                            spec => 0,
+                                                            type => {type, #{line => 3,
+                                                                             source => inferred,
+                                                                             spec => int}}}}}}},
+    {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -62,3 +62,13 @@ resolve_boolean_unsupported_operand_type_error_test() ->
         Form = rufus_form:make_binary_op(Op, Left, Right, 9),
         ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
     end, ['and', 'or', 'xor']).
+
+resolve_boolean_nested_unsupported_operand_type_error_test() ->
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(bool, true, 9),
+        Right = rufus_form:make_literal(bool, false, 9),
+        LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
+        RightForm = rufus_form:make_literal(int, 23, 9),
+        Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
+        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
+    end, ['and', 'or', 'xor']).

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-resolve_binary_op_with_ints_test() ->
+resolve_arithmetic_binary_op_with_ints_test() ->
     lists:map(fun(Op) ->
         Left = rufus_form:make_literal(int, 5, 9),
         Right = rufus_form:make_literal(int, 7, 9),
@@ -11,7 +11,7 @@ resolve_binary_op_with_ints_test() ->
         ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
     end, ['+', '-', '*', '/', '%']).
 
-resolve_binary_op_with_floats_test() ->
+resolve_arithmetic_binary_op_with_floats_test() ->
     lists:map(fun(Op) ->
         Left = rufus_form:make_literal(float, 1.0, 9),
         Right = rufus_form:make_literal(float, 2.14159265359, 9),
@@ -20,7 +20,7 @@ resolve_binary_op_with_floats_test() ->
         ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
     end, ['+', '-', '*', '/']).
 
-resolve_unmatched_operand_type_error_test() ->
+resolve_arithmetic_unmatched_operand_type_error_test() ->
     lists:map(fun(Op) ->
         Left = rufus_form:make_literal(int, 5, 9),
         Right = rufus_form:make_literal(float, 2.14159265359, 9),
@@ -28,7 +28,7 @@ resolve_unmatched_operand_type_error_test() ->
         ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
     end, ['+', '-', '*', '/']).
 
-resolve_nested_unmatched_operand_type_error_test() ->
+resolve_arithmetic_nested_unmatched_operand_type_error_test() ->
     lists:map(fun(Op) ->
         Left = rufus_form:make_literal(float, 13.0, 9),
         Right = rufus_form:make_literal(float, 6.0, 9),
@@ -38,10 +38,27 @@ resolve_nested_unmatched_operand_type_error_test() ->
         ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
     end, ['+', '-', '*', '/']).
 
-resolve_unsupported_operand_type_error_test() ->
+resolve_arithmetic_unsupported_operand_type_error_test() ->
     lists:map(fun(Op) ->
         Left = rufus_form:make_literal(bool, true, 9),
         Right = rufus_form:make_literal(bool, false, 9),
         Form = rufus_form:make_binary_op(Op, Left, Right, 9),
         ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
     end, ['+', '-', '*', '/', '%']).
+
+resolve_boolean_binary_op_with_bools_test() ->
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(bool, true, 9),
+        Right = rufus_form:make_literal(bool, false, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        Expected = rufus_form:make_inferred_type(bool, 9),
+        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+    end, ['and', 'or', 'xor']).
+
+resolve_boolean_unsupported_operand_type_error_test() ->
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(int, 3, 9),
+        Right = rufus_form:make_literal(bool, true, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
+    end, ['and', 'or', 'xor']).

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -3,40 +3,45 @@
 -include_lib("eunit/include/eunit.hrl").
 
 resolve_binary_op_with_ints_test() ->
-    Op = '+',
-    Left = rufus_form:make_literal(int, 5, 9),
-    Right = rufus_form:make_literal(int, 7, 9),
-    Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-    Expected = rufus_form:make_inferred_type(int, 9),
-    ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form)).
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(int, 5, 9),
+        Right = rufus_form:make_literal(int, 7, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        Expected = rufus_form:make_inferred_type(int, 9),
+        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+    end, ['+', '-', '*', '/', '%']).
 
 resolve_binary_op_with_floats_test() ->
-    Op = '+',
-    Left = rufus_form:make_literal(float, 1.0, 9),
-    Right = rufus_form:make_literal(float, 2.14159265359, 9),
-    Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-    Expected = rufus_form:make_inferred_type(float, 9),
-    ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form)).
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(float, 1.0, 9),
+        Right = rufus_form:make_literal(float, 2.14159265359, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        Expected = rufus_form:make_inferred_type(float, 9),
+        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+    end, ['+', '-', '*', '/']).
 
 resolve_unmatched_operand_type_error_test() ->
-    Op = '+',
-    Left = rufus_form:make_literal(int, 5, 9),
-    Right = rufus_form:make_literal(float, 2.14159265359, 9),
-    Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-    ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form)).
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(int, 5, 9),
+        Right = rufus_form:make_literal(float, 2.14159265359, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
+    end, ['+', '-', '*', '/']).
 
 resolve_nested_unmatched_operand_type_error_test() ->
-    Op = '+',
-    Left = rufus_form:make_literal(float, 13.0, 9),
-    Right = rufus_form:make_literal(float, 6.0, 9),
-    LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
-    RightForm = rufus_form:make_literal(int, 23, 9),
-    Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
-    ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form)).
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(float, 13.0, 9),
+        Right = rufus_form:make_literal(float, 6.0, 9),
+        LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
+        RightForm = rufus_form:make_literal(int, 23, 9),
+        Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
+        ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
+    end, ['+', '-', '*', '/']).
 
 resolve_unsupported_operand_type_error_test() ->
-    Op = '+',
-    Left = rufus_form:make_literal(bool, true, 9),
-    Right = rufus_form:make_literal(bool, false, 9),
-    Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-    ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form)).
+    lists:map(fun(Op) ->
+        Left = rufus_form:make_literal(bool, true, 9),
+        Right = rufus_form:make_literal(bool, false, 9),
+        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
+    end, ['+', '-', '*', '/', '%']).


### PR DESCRIPTION
`rufus_type:resolve/2` typechecks and resolves `binary_op` expressions with boolean operators `and`, `or`, and `xor`. `rufus_expr:typecheck_and_annotate/1` uses this new support for boolean operators to annotate boolean `binary_op` expressions with type information.