### PR TITLE
compiler: Compile binary_op expressions with and, and or operators

### DIFF
--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -9,7 +9,7 @@
 
 -ifdef(EUNIT).
 -export([compile/1]).
--export([eval_chain/2]).
+-export([eval_stages/2]).
 -endif.
 
 %% API
@@ -27,24 +27,24 @@ eval(RufusText) ->
         fun rufus_erlang:forms/1,
         fun compile/1
     ],
-    eval_chain(RufusText, CompilationStages).
+    eval_stages(RufusText, CompilationStages).
 
 %% Private API
 
-%% eval_chain runs each compilation stage H as H(Input), in order. Each
+%% eval_stages runs each compilation stage H as H(Input), in order. Each
 %% compilation stage must return {ok, Output} on success. Any other response is
 %% treated as an error. The output from one compilation stage is provided as
 %% input to the next. Processing stops when a compilation stage returns an
 %% error.
--spec eval_chain(any(), list(fun((_) -> any()))) -> ok_tuple() | error_tuple() | error_triple().
-eval_chain(Input, [H|T]) ->
+-spec eval_stages(any(), list(fun((_) -> any()))) -> ok_tuple() | error_tuple() | error_triple().
+eval_stages(Input, [H|T]) ->
     case H(Input) of
         {ok, Forms} ->
-            eval_chain(Forms, T);
+            eval_stages(Forms, T);
         Error ->
             Error
     end;
-eval_chain(Input, []) ->
+eval_stages(Input, []) ->
     {ok, Input}.
 
 %% compile uses the Erlang compiler to compile Erlang abstract forms and loads

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -144,6 +144,10 @@ rufus_operator_to_erlang_operator('%', int) ->
     'rem';
 rufus_operator_to_erlang_operator('%', float) ->
     erlang:error(unsupported_operand_type, ['%', float]);
+rufus_operator_to_erlang_operator('and', bool) ->
+    'andalso';
+rufus_operator_to_erlang_operator('or', bool) ->
+    'orelse';
 rufus_operator_to_erlang_operator(Op, _) ->
     Op.
 

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -14,7 +14,7 @@ Terminals
     '{' '}' '(' ')' ','
     '+' '-' '*' '/' '%'
     ';' '='
-    'and' 'or' 'xor'
+    'and' 'or'
     module import
     func identifier
     atom atom_lit
@@ -40,7 +40,6 @@ Left 100 '/'.
 Left 100 '%'.
 Left 100 'and'.
 Left 80  'or'.
-Left 80  'xor'.
 Left 50  '='.
 
 %%
@@ -92,7 +91,6 @@ binary_op -> expr '/' expr       : rufus_form:make_binary_op('/', '$1', '$3', li
 binary_op -> expr '%' expr       : rufus_form:make_binary_op('%', '$1', '$3', line('$2')).
 binary_op -> expr 'and' expr     : rufus_form:make_binary_op('and', '$1', '$3', line('$2')).
 binary_op -> expr 'or' expr      : rufus_form:make_binary_op('or', '$1', '$3', line('$2')).
-binary_op -> expr 'xor' expr     : rufus_form:make_binary_op('xor', '$1', '$3', line('$2')).
 
 match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
 

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -39,7 +39,6 @@ Divide        = \/
 Remainder     = \%
 And           = and
 Or            = or
-XOr           = xor
 
 Identifier    = {Letter}({Letter}|{Digit})*
 
@@ -81,7 +80,6 @@ Rules.
 {Remainder}     : {token, {'%', TokenLine}}.
 {And}           : {token, {'and', TokenLine}}.
 {Or}            : {token, {'or', TokenLine}}.
-{XOr}           : {token, {'xor', TokenLine}}.
 
 {Identifier}    : {token, {identifier, TokenLine, TokenChars}}.
 

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -106,9 +106,8 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
         '*'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
         '/'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
         '%'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        'xor' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2}
+        'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
+        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2}
     end,
 
     case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -52,7 +52,7 @@
 %% Operators
 
 -type arithmetic_operator() :: '+' | '-' | '*' | '/' | '%'.
--type boolean_operator() :: 'or' | 'xor' | 'and'.
+-type boolean_operator() :: 'and' | 'or'.
 
 %% Expressions
 

--- a/rf/test/rufus_compile_binary_op_test.erl
+++ b/rf/test/rufus_compile_binary_op_test.erl
@@ -137,3 +137,43 @@ eval_with_function_returning_a_remainder_of_three_int_literals_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(4, example:'Four'()).
+
+%% Arity-0 functions returning the result of a boolean operation
+
+eval_with_function_returning_the_result_of_an_and_operation_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { true and false }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(false, example:'Falsy'()).
+
+eval_with_function_returning_the_result_of_an_and_operation_with_a_call_operand_test() ->
+    RufusText = "
+    module example
+    func False() bool { false }
+    func Falsy() bool { true and False() }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(false, example:'Falsy'()).
+
+eval_with_function_returning_the_result_of_an_or_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { true or false }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+eval_with_function_returning_the_result_of_an_or_operation_with_a_call_operand_test() ->
+    RufusText = "
+    module example
+    func True() bool { true }
+    func Truthy() bool { True() or false }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).

--- a/rf/test/rufus_compile_test.erl
+++ b/rf/test/rufus_compile_test.erl
@@ -2,16 +2,16 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-eval_chain_without_handlers_test() ->
-    ?assertEqual({ok, "hello!"}, rufus_compile:eval_chain("hello!", [])).
+eval_stages_without_handlers_test() ->
+    ?assertEqual({ok, "hello!"}, rufus_compile:eval_stages("hello!", [])).
 
-eval_chain_with_ok_handler_test() ->
+eval_stages_with_ok_handler_test() ->
     Reverse = fun(Word) -> {ok, lists:reverse(Word)} end,
-    ?assertEqual({ok, "ahah"}, rufus_compile:eval_chain("haha", [Reverse])).
+    ?assertEqual({ok, "ahah"}, rufus_compile:eval_stages("haha", [Reverse])).
 
-eval_chain_with_error_handler_test() ->
+eval_stages_with_error_handler_test() ->
     Error = fun(_) -> {error, reason} end,
     Explode = fun(_) -> throw(explode) end,
-    %% Explode never runs because eval_chain stops iterating over handlers when
+    %% Explode never runs because eval_stages stops iterating over handlers when
     %% it encounters a failure from Error.
-    ?assertEqual({error, reason}, rufus_compile:eval_chain("haha", [Error, Explode])).
+    ?assertEqual({error, reason}, rufus_compile:eval_stages("haha", [Error, Explode])).

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -394,32 +394,3 @@ parse_function_oring_two_bools_test() ->
                                                  spec => bool}},
                          spec => 'Truthy'}}],
     ?assertEqual(Expected, Forms).
-
-parse_function_xoring_two_bools_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { true xor false }
-    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 3,
-                                                 op => 'xor',
-                                                 right => {bool_lit, #{line => 3,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 3,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Truthy'}}],
-    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_binary_op_test.erl
+++ b/rf/test/rufus_raw_tokenize_binary_op_test.erl
@@ -57,11 +57,3 @@ string_with_binary_op_expression_using_or_operator_test() ->
         {'or', 1},
         {bool_lit, 1, false}
     ], Tokens).
-
-string_with_binary_op_expression_using_xor_operator_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("true xor false"),
-    ?assertEqual([
-        {bool_lit, 1, true},
-        {'xor', 1},
-        {bool_lit, 1, false}
-    ], Tokens).

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -53,7 +53,7 @@ resolve_boolean_binary_op_with_bools_test() ->
         Form = rufus_form:make_binary_op(Op, Left, Right, 9),
         Expected = rufus_form:make_inferred_type(bool, 9),
         ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or', 'xor']).
+    end, ['and', 'or']).
 
 resolve_boolean_unsupported_operand_type_error_test() ->
     lists:map(fun(Op) ->
@@ -61,7 +61,7 @@ resolve_boolean_unsupported_operand_type_error_test() ->
         Right = rufus_form:make_literal(bool, true, 9),
         Form = rufus_form:make_binary_op(Op, Left, Right, 9),
         ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or', 'xor']).
+    end, ['and', 'or']).
 
 resolve_boolean_nested_unsupported_operand_type_error_test() ->
     lists:map(fun(Op) ->
@@ -71,4 +71,4 @@ resolve_boolean_nested_unsupported_operand_type_error_test() ->
         RightForm = rufus_form:make_literal(int, 23, 9),
         Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
         ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or', 'xor']).
+    end, ['and', 'or']).


### PR DESCRIPTION
`and` and `or` `binary_op` expressions are compiled to `andalso` and `orelse` expressions in Erlang. Support for `xor` has been removed because it has relatively low precedence and can result in surprising behavior. `rufus_compile:eval_chain/2` has been renamed to `rufus_compile:eval_stages/2` to make its purpose more clear.