### PR TITLE
compiler: Add benchmarks to measure type annotation ideas

### DIFF
--- a/rf/benchmark/rufus_benchmark_test.erl
+++ b/rf/benchmark/rufus_benchmark_test.erl
@@ -1,0 +1,118 @@
+-module(rufus_benchmark_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+untyped_some_arguments_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        some_arguments(1, 1, 1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+typed_some_arguments_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        some_typed_arguments({int, int, int, int}, 1, 1, 1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+untyped_many_arguments_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        many_arguments(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+typed_many_arguments_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        many_typed_arguments({int, int, int, int, int, int, int, int, int, int, int, int, int}, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+interleaved_typed_many_arguments_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        interleaved_many_typed_arguments(int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1, int, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+untyped_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        untyped_sum(1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+typed_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        typed_sum({int, int}, 1, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+interleaved_typed_function_calls_test() ->
+    Iterations = 10000000,
+    StartTime = os:timestamp(),
+    benchmark(Iterations, fun() ->
+        interleaved_typed_sum(int, 1, int, 1)
+    end),
+    Duration = time_diff(StartTime),
+    io:format("time spent  => ~p~n", [Duration]),
+    ?assert(false).
+
+%% Test helper functions
+
+time_diff(Init) ->
+    timer:now_diff(os:timestamp(), Init) / 1000000.
+
+benchmark(0, _Fn) ->
+    ok;
+benchmark(Repetitions, Fn) ->
+    Fn(),
+    benchmark(Repetitions-1, Fn).
+
+untyped_sum(A, B) ->
+    A + B.
+
+typed_sum({int, int}, A, B) ->
+    A + B.
+
+interleaved_typed_sum(int, A, int, B) ->
+    A + B.
+
+some_arguments(_, _, _, _) ->
+    ok.
+
+some_typed_arguments({int, int, int, int}, _, _, _, _) ->
+    ok.
+
+many_arguments(_, _, _, _, _, _, _, _, _, _, _, _, _) ->
+    ok.
+
+many_typed_arguments({int, int, int, int, int, int, int, int, int, int, int, int, int}, _, _, _, _, _, _, _, _, _, _, _, _, _) ->
+    ok.
+
+interleaved_many_typed_arguments(int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _, int, _) ->
+    ok.


### PR DESCRIPTION
A new `benchmark/rufus_benchmark_test.erl` file has some rudimentary benchmarks that can be run with eunit to the cost of type annotations in function heads. The test is kept out of the `test` directory because it more than doubles the test suite time by adding 2.4s of execution time. It should really be turned into something that can run outside eunit.

```
$ rebar3 eunit
===> Verifying dependencies...
===> Compiling rf
===> Performing EUnit tests...
FFFFFFFF.............................................................................................................................................................................................................................................................................................................................
Failures:

  1) rufus_benchmark_test:untyped_some_arguments_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.312185

     Output: time spent  => 0.312185

  2) rufus_benchmark_test:typed_some_arguments_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.393103

     Output: time spent  => 0.393103

  3) rufus_benchmark_test:untyped_many_arguments_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.420045

     Output: time spent  => 0.420045

  4) rufus_benchmark_test:typed_many_arguments_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.422019

     Output: time spent  => 0.422019

  5) rufus_benchmark_test:interleaved_typed_many_arguments_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.49261

     Output: time spent  => 0.49261

  6) rufus_benchmark_test:untyped_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.273085

     Output: time spent  => 0.273085

  7) rufus_benchmark_test:typed_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.338383

     Output: time spent  => 0.338383

  8) rufus_benchmark_test:interleaved_typed_function_calls_test/0
     Failure/Error: ?assert(false)
       expected: true
            got: false
     %% eunit_proc.erl:325:in `eunit_proc:with_timeout/3`
     Output: time spent  => 0.307881

     Output: time spent  => 0.307881


Finished in 4.496 seconds
325 tests, 8 failures
===> Error running tests
```