### PR TITLE
compiler: Compile list_lit forms

### DIFF
--- a/rf/Makefile
+++ b/rf/Makefile
@@ -4,6 +4,7 @@ ci:		clean check prime-dialyzer dialyzer build
 
 clean:
 	@rebar3 clean
+	@-rm -rf _build
 
 check:
 	@rebar3 eunit

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -179,7 +179,7 @@ guard_forms(Acc, []) ->
 %% box converts a Rufus literal to its representation in Erlang. atom, bool,
 %% float and int are all represented as scalar values in Erlang, while string is
 %% represented as an annotated {string, BinaryValue} tuple.
--spec box(atom_lit_form() | bool_lit_form() | float_lit_form() | int_lit_form() | string_lit_form()) -> erlang3_form().
+-spec box(atom_lit_form() | bool_lit_form() | float_lit_form() | int_lit_form() | list_lit_form() | string_lit_form()) -> (erlang3_form() | erlang4_form()).
 box({atom_lit, #{spec := Value, line := Line}}) ->
     {atom, Line, Value};
 box({bool_lit, #{spec := Value, line := Line}}) ->
@@ -245,7 +245,7 @@ is_private(LeadingChar) ->
 
 %% list_to_cons transforms a list of Rufus form elements in a list_lit form into
 %% an Erlang cons form.
--spec list_to_cons(list(rufus_form()), integer()) -> erlang_form().
+-spec list_to_cons(list(rufus_form()), integer()) -> term().
 list_to_cons([Form|[]], Line) ->
     {ok, [Head|_]} = forms([], [Form]),
     {cons, Line, Head, {nil, Line}};

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -243,6 +243,9 @@ is_public(Name) ->
 is_private(LeadingChar) ->
     (LeadingChar >= $a) and (LeadingChar =< $z).
 
+%% list_to_cons transforms a list of Rufus form elements in a list_lit form into
+%% an Erlang cons form.
+-spec list_to_cons(list(rufus_form()), integer()) -> erlang_form().
 list_to_cons([Form|[]], Line) ->
     {ok, [Head|_]} = forms([], [Form]),
     {cons, Line, Head, {nil, Line}};

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -1,0 +1,60 @@
+-module(rufus_compile_list_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+eval_for_function_returning_an_empty_list_test() ->
+    RufusText = "
+    module example
+    func Empty() list[int] { list[int]{} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([], example:'Empty'()).
+
+eval_for_function_returning_a_list_with_a_single_element_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{7} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([7], example:'Numbers'()).
+
+eval_for_function_returning_a_list_with_two_elements_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{7, 918} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([7, 918], example:'Numbers'()).
+
+eval_for_function_returning_a_list_of_lists_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[list[int]] {
+        list[list[int]]{
+            list[int]{7},
+            list[int]{918, 23},
+        }
+    }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([[7], [918, 23]], example:'Numbers'()).
+
+eval_for_function_returning_a_list_with_expressions_as_elements_test() ->
+    RufusText = "
+    module example
+    func Three() int { 3 }
+    func Numbers() list[int] {
+        list[int]{
+            3 + 4,
+            5 = 5,
+            Three(),
+        }
+    }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([7, 5, 3], example:'Numbers'()).

--- a/rf/test/rufus_erlang_list_test.erl
+++ b/rf/test/rufus_erlang_list_test.erl
@@ -1,0 +1,51 @@
+-module(rufus_erlang_list_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+forms_for_function_returning_an_empty_list_lit_form_test() ->
+    RufusText = "
+    module example
+    func Empty() list[int] { list[int]{} }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Empty', 0}]},
+        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{nil, 3}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
+    RufusText = "
+    module example
+    func Empty() list[bool] { list[bool]{true} }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Empty', 0}]},
+        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {atom, 3, true},
+                                                                   {nil, 3}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_list_lit_form_with_a_two_items_test() ->
+    RufusText = "
+    module example
+    func Empty() list[float] { list[float]{3.1, 4.1} }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Empty', 0}]},
+        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {float, 3, 3.1},
+                                                                  {cons, 3, {float, 3, 4.1},
+                                                                            {nil, 3}}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
`rufus_erlang:forms/1` generates Erlang forms from Rufus `list_lit` forms.