### PR TITLE
compiler: Compile cons forms

### DIFF
--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -69,6 +69,9 @@ forms(Acc, [{call, #{spec := Spec, args := Args, line := Line}}|T]) ->
     {ok, ArgsForms} = forms([], Args),
     Form = {call, Line, {atom, Line, Spec}, ArgsForms},
     forms([Form|Acc], T);
+forms(Acc, [{cons, _Context} = Cons|T]) ->
+    Form = box(Cons),
+    forms([Form|Acc], T);
 forms(Acc, [{float_lit, _Context} = FloatLit|T]) ->
     Form = box(FloatLit),
     forms([Form|Acc], T);
@@ -136,8 +139,6 @@ forms(Acc, []) ->
 forms(Acc, Form) ->
     erlang:error(unhandled_form, [Acc, Form]).
 
-%% Erlang form helpers
-
 %% rufus_operator_to_erlang_operator converts a Rufus operator to the Erlang
 %% equivalent.
 -spec rufus_operator_to_erlang_operator(atom(), atom()) -> atom().
@@ -186,6 +187,8 @@ box({atom_lit, #{spec := Value, line := Line}}) ->
     {atom, Line, Value};
 box({bool_lit, #{spec := Value, line := Line}}) ->
     {atom, Line, Value};
+box({cons, #{head := Head, tail := {list_lit, #{elements := Tail}}, line := Line}}) ->
+    list_to_cons([Head|Tail], Line);
 box({float_lit, #{spec := Value, line := Line}}) ->
     {float, Line, Value};
 box({int_lit, #{spec := Value, line := Line}}) ->

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -254,7 +254,7 @@ is_public(Name) ->
 is_private(LeadingChar) ->
     (LeadingChar >= $a) and (LeadingChar =< $z).
 
-%% list and cons helpers
+%% list helpers
 
 %% list_to_cons transforms a list of Rufus form elements in a list_lit form into
 %% an Erlang cons form.

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -118,21 +118,23 @@ forms(Acc, [{match, #{line := Line, left := Left, right := Right}}|T]) ->
 forms(Acc, [{module, #{line := Line, spec := Spec}}|T]) ->
     Form = {attribute, Line, module, Spec},
     forms([Form|Acc], T);
-forms(Acc, [Form = {param, #{line := Line, spec := Spec}}|T]) ->
-    TypeSpec = rufus_form:type_spec(Form),
-    ErlangForm = case TypeSpec of
-        atom ->
+forms(Acc, [{param, #{line := Line, spec := Spec, type := Type}}|T]) ->
+    Form = case Type of
+        {type, #{spec := atom}} ->
             {var, Line, Spec};
-        bool ->
+        {type, #{spec := bool}} ->
             {var, Line, Spec};
-        float ->
+        {type, #{spec := float}} ->
             {var, Line, Spec};
-        int ->
+        {type, #{spec := int}} ->
+            {var, Line, Spec};
+        {type, #{collection_type := list}} ->
             {var, Line, Spec};
         _ ->
+            TypeSpec = rufus_form:spec(Type),
             {tuple, Line, [{atom, Line, TypeSpec}, {var, Line, Spec}]}
     end,
-    forms([ErlangForm|Acc], T);
+    forms([Form|Acc], T);
 forms(Acc, [{string_lit, _Context} = StringLit|T]) ->
     Form = box(StringLit),
     forms([Form|Acc], T);

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -98,3 +98,12 @@ eval_for_function_taking_a_list_lit_form_and_returning_it_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2, 3, 4], example:'Echo'([1, 2, 3, 4])).
+
+eval_for_function_that_prepends_a_number_to_a_list_test() ->
+    RufusText = "
+    module example
+    func Prepend(n int, numbers list[int]) list[int] { list[int]{n|numbers} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([1, 2, 3, 4], example:'Prepend'(1, [2, 3, 4])).

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -58,3 +58,35 @@ eval_for_function_returning_a_list_with_expressions_as_elements_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([7, 5, 3], example:'Numbers'()).
+
+eval_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{1|{2}} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([1, 2], example:'Numbers'()).
+
+eval_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([1, 2, 3, 4], example:'Numbers'()).
+
+eval_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] {
+        head = 1
+        tail = list[int]{2, 3, 4}
+        list[int]{head|tail}
+    }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    io:format("example:'Numbers'() => ~p~n", [example:'Numbers'()]),
+    ?assertEqual([1, 2, 3, 4], example:'Numbers'()).

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -88,5 +88,13 @@ eval_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
     ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    io:format("example:'Numbers'() => ~p~n", [example:'Numbers'()]),
     ?assertEqual([1, 2, 3, 4], example:'Numbers'()).
+
+eval_for_function_taking_a_list_lit_form_and_returning_it_test() ->
+    RufusText = "
+    module example
+    func Echo(numbers list[int]) list[int] { numbers }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([1, 2, 3, 4], example:'Echo'([1, 2, 3, 4])).

--- a/rf/test/rufus_erlang_list_test.erl
+++ b/rf/test/rufus_erlang_list_test.erl
@@ -9,7 +9,8 @@ forms_for_function_returning_an_empty_list_lit_form_test() ->
     ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
@@ -24,7 +25,8 @@ forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
     ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
@@ -33,20 +35,37 @@ forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
     ],
     ?assertEqual(Expected, ErlangForms).
 
-forms_for_function_returning_a_list_lit_form_with_a_two_items_test() ->
+forms_for_function_returning_a_list_lit_form_with_two_items_test() ->
     RufusText = "
     module example
     func Empty() list[float] { list[float]{3.1, 4.1} }
     ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
         {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {float, 3, 3.1},
                                                          {cons, 3, {float, 3, 4.1},
                                                           {nil, 3}}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_taking_a_list_lit_form_and_returning_it_test() ->
+    RufusText = "
+    module example
+    func Echo(numbers list[int]) list[int] { numbers }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Echo', 1}]},
+        {function, 3, 'Echo', 1, [{clause, 3, [{var, 3, numbers}], [], [{var, 3, numbers}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -64,7 +83,7 @@ forms_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
         {attribute, 3, export, [{'Numbers', 0}]},
         {function, 3, 'Numbers', 0, [{clause, 3, [], [], [{cons, 3, {integer, 3, 1},
                                                            {cons, 3, {integer, 3, 2},
-                                                                     {nil, 3}}}]}]}
+                                                            {nil, 3}}}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 

--- a/rf/test/rufus_erlang_list_test.erl
+++ b/rf/test/rufus_erlang_list_test.erl
@@ -77,7 +77,6 @@ forms_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_te
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Numbers', 0}]},
@@ -87,5 +86,36 @@ forms_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_te
                                          {cons, 3, {integer, 3, 3},
                                           {cons, 3, {integer, 3, 4},
                                            {nil, 3}}}}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] {
+        head = 1
+        tail = list[int]{2, 3, 4}
+        list[int]{head|tail}
+    }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Numbers', 0}]},
+        {function, 3, 'Numbers', 0,
+         [{clause, 3, [], [],
+           [{match, 4, {var, 4, head}, {integer, 4, 1}},
+            {match, 5,
+             {var, 5, tail},
+             {cons, 5, {integer, 5, 2},
+              {cons, 5, {integer, 5, 3},
+               {cons, 5, {integer, 5, 4},
+                {nil, 5}}}}},
+            {cons, 6,
+             {var, 6, head},
+             {var, 6, tail}}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_list_test.erl
+++ b/rf/test/rufus_erlang_list_test.erl
@@ -29,7 +29,7 @@ forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
         {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {atom, 3, true},
-                                                                   {nil, 3}}]}]}
+                                                         {nil, 3}}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
@@ -45,7 +45,47 @@ forms_for_function_returning_a_list_lit_form_with_a_two_items_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
         {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {float, 3, 3.1},
-                                                                  {cons, 3, {float, 3, 4.1},
-                                                                            {nil, 3}}}]}]}
+                                                         {cons, 3, {float, 3, 4.1},
+                                                          {nil, 3}}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{1|{2}} }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Numbers', 0}]},
+        {function, 3, 'Numbers', 0, [{clause, 3, [], [], [{cons, 3, {integer, 3, 1},
+                                                           {cons, 3, {integer, 3, 2},
+                                                                     {nil, 3}}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_test() ->
+    RufusText = "
+    module example
+    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Numbers', 0}]},
+        {function, 3, 'Numbers', 0, [{clause, 3, [], [],
+                                      [{cons, 3, {integer, 3, 1},
+                                        {cons, 3, {integer, 3, 2},
+                                         {cons, 3, {integer, 3, 3},
+                                          {cons, 3, {integer, 3, 4},
+                                           {nil, 3}}}}}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
`rufus_erlang:forms/1` now has support to transform `cons` Rufus forms into Erlang forms. Code generation bugs related to list types in function parameters and variables are fixed.