### PR TITLE
compiler: Tokenize and parse comparison expressions with == != < <= > >= operators

### DIFF
--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -13,6 +13,8 @@ Terminals
     '+' '-' '*' '/' '%'
     ',' ';' '='
     'and' 'or'
+    '==' '!='
+    '<' '<=' '>' '>='
     module import
     func identifier
     atom atom_lit
@@ -32,14 +34,20 @@ Rootsymbol root.
 %% Operator precedence
 %%
 
-Left 100 '+'.
-Left 100 '-'.
-Left 100 '*'.
-Left 100 '/'.
-Left 100 '%'.
-Left 90  'and'.
-Left 80  'or'.
-Left 50  '='.
+Left     70 '*'.
+Left     70 '/'.
+Left     70 '%'.
+Left     60 '+'.
+Left     60 '-'.
+Nonassoc 50 '=='.
+Nonassoc 50 '!='.
+Nonassoc 50 '<'.
+Nonassoc 50 '<='.
+Nonassoc 50 '>'.
+Nonassoc 50 '>='.
+Left     40 'and'.
+Left     30 'or'.
+Left     20 '='.
 
 %%
 %% Grammar rules
@@ -64,6 +72,12 @@ binary_op -> expr '/' expr       : rufus_form:make_binary_op('/', '$1', '$3', li
 binary_op -> expr '%' expr       : rufus_form:make_binary_op('%', '$1', '$3', line('$2')).
 binary_op -> expr 'and' expr     : rufus_form:make_binary_op('and', '$1', '$3', line('$2')).
 binary_op -> expr 'or' expr      : rufus_form:make_binary_op('or', '$1', '$3', line('$2')).
+binary_op -> expr '==' expr      : rufus_form:make_binary_op('==', '$1', '$3', line('$2')).
+binary_op -> expr '!=' expr      : rufus_form:make_binary_op('!=', '$1', '$3', line('$2')).
+binary_op -> expr '<' expr       : rufus_form:make_binary_op('<', '$1', '$3', line('$2')).
+binary_op -> expr '<=' expr      : rufus_form:make_binary_op('<=', '$1', '$3', line('$2')).
+binary_op -> expr '>' expr       : rufus_form:make_binary_op('>', '$1', '$3', line('$2')).
+binary_op -> expr '>=' expr      : rufus_form:make_binary_op('>=', '$1', '$3', line('$2')).
 
 block -> '{' exprs '}' ';'       : '$2'.
 

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -1,99 +1,111 @@
 Definitions.
 
-Newline       = \n
-Colon         = \:
-Semicolon     = \;
-UnicodeLetter = [A-Za-z]
-Digit         = [0-9]
-Letter        = ({UnicodeLetter}|'_')
-Whitespace    = [\s\t]
+Newline            = \n
+Colon              = \:
+Semicolon          = \;
+UnicodeLetter      = [A-Za-z]
+Digit              = [0-9]
+Letter             = ({UnicodeLetter}|'_')
+Whitespace         = [\s\t]
 
-Module        = module
-Import        = import
-Const         = const
-Func          = func
+Module             = module
+Import             = import
+Const              = const
+Func               = func
 
-List          = list
+List               = list
 
-AtomType      = atom
-BoolType      = bool
-FloatType     = float
-IntType       = int
-StringType    = string
-ListType      = {List}\[Identifier\]
+AtomType           = atom
+BoolType           = bool
+FloatType          = float
+IntType            = int
+StringType         = string
+ListType           = {List}\[Identifier\]
 
-AtomLiteral   = {Colon}({UnicodeLetter}+({Digit}|{UnicodeLetter})?|\'({Digit}|{UnicodeLetter}|{Whitespace})+\')
-BoolLiteral   = (true|false)
-Exponent      = (e|E)?(\+|\-)?{Digit}+
-FloatLiteral  = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
-IntLiteral    = (\+|\-)?{Digit}+
-StringLiteral = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
+AtomLiteral        = {Colon}({UnicodeLetter}+({Digit}|{UnicodeLetter})?|\'({Digit}|{UnicodeLetter}|{Whitespace})+\')
+BoolLiteral        = (true|false)
+Exponent           = (e|E)?(\+|\-)?{Digit}+
+FloatLiteral       = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
+IntLiteral         = (\+|\-)?{Digit}+
+StringLiteral      = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
 
-LeftBrace     = \{
-RightBrace    = \}
-LeftBracket   = \[
-RightBracket  = \]
-LeftParen     = \(
-RightParen    = \)
-Comma         = ,
-Match         = =
-Cons          = \|
-Plus          = \+
-Minus         = \-
-Multiply      = \*
-Divide        = \/
-Remainder     = \%
-And           = and
-Or            = or
+LeftBrace          = \{
+RightBrace         = \}
+LeftBracket        = \[
+RightBracket       = \]
+LeftParen          = \(
+RightParen         = \)
+Comma              = ,
+Match              = =
+Cons               = \|
+Plus               = \+
+Minus              = \-
+Multiply           = \*
+Divide             = \/
+Remainder          = \%
+And                = and
+Or                 = or
+Equal              = ==
+NotEqual           = !=
+LessThan           = <
+LessThanOrEqual    = <=
+GreaterThan        = >
+GreaterThanOrEqual = >=
 
-Identifier    = {Letter}({Letter}|{Digit})*
+Identifier         = {Letter}({Letter}|{Digit})*
 
 Rules.
 
-{Whitespace}+   : skip_token.
-{Newline}+      : {token, {eol, TokenLine}}.
-{Semicolon}+    : {token, {';', TokenLine}}.
+{Whitespace}+        : skip_token.
+{Newline}+           : {token, {eol, TokenLine}}.
+{Semicolon}+         : {token, {';', TokenLine}}.
 
-{Module}        : {token, {module, TokenLine}}.
-{Import}        : {token, {import, TokenLine}}.
-{Const}         : {token, {const, TokenLine}}.
-{Func}          : {token, {func, TokenLine}}.
+{Module}             : {token, {module, TokenLine}}.
+{Import}             : {token, {import, TokenLine}}.
+{Const}              : {token, {const, TokenLine}}.
+{Func}               : {token, {func, TokenLine}}.
 
-{List}          : {token, {list, TokenLine}}.
+{List}               : {token, {list, TokenLine}}.
 
-{AtomType}      : {token, {atom, TokenLine}}.
-{BoolType}      : {token, {bool, TokenLine}}.
-{FloatType}     : {token, {float, TokenLine}}.
-{IntType}       : {token, {int, TokenLine}}.
-{StringType}    : {token, {string, TokenLine}}.
-{ListType}      : {token, {list, TokenLine}}.
+{AtomType}           : {token, {atom, TokenLine}}.
+{BoolType}           : {token, {bool, TokenLine}}.
+{FloatType}          : {token, {float, TokenLine}}.
+{IntType}            : {token, {int, TokenLine}}.
+{StringType}         : {token, {string, TokenLine}}.
+{ListType}           : {token, {list, TokenLine}}.
 
-{AtomLiteral}   : A = trim_atom_markup(TokenChars, TokenLen),
-                  {token, {atom_lit, TokenLine, A}}.
-{BoolLiteral}   : {token, {bool_lit, TokenLine, list_to_atom(TokenChars)}}.
-{FloatLiteral}  : {token, {float_lit, TokenLine, list_to_float(TokenChars)}}.
-{IntLiteral}    : {token, {int_lit, TokenLine, list_to_integer(TokenChars)}}.
-{StringLiteral} : S = trim_quotes(TokenChars, TokenLen),
-                  {token, {string_lit, TokenLine, S}}.
+{AtomLiteral}        : A = trim_atom_markup(TokenChars, TokenLen),
+                       {token, {atom_lit, TokenLine, A}}.
+{BoolLiteral}        : {token, {bool_lit, TokenLine, list_to_atom(TokenChars)}}.
+{FloatLiteral}       : {token, {float_lit, TokenLine, list_to_float(TokenChars)}}.
+{IntLiteral}         : {token, {int_lit, TokenLine, list_to_integer(TokenChars)}}.
+{StringLiteral}      : S = trim_quotes(TokenChars, TokenLen),
+                       {token, {string_lit, TokenLine, S}}.
 
-{LeftBrace}     : {token, {'{', TokenLine}}.
-{RightBrace}    : {token, {'}', TokenLine}}.
-{LeftBracket}   : {token, {'[', TokenLine}}.
-{RightBracket}  : {token, {']', TokenLine}}.
-{LeftParen}     : {token, {'(', TokenLine}}.
-{RightParen}    : {token, {')', TokenLine}}.
-{Comma}         : {token, {',', TokenLine}}.
-{Match}         : {token, {'=', TokenLine}}.
-{Cons}          : {token, {'|', TokenLine}}.
-{Plus}          : {token, {'+', TokenLine}}.
-{Minus}         : {token, {'-', TokenLine}}.
-{Multiply}      : {token, {'*', TokenLine}}.
-{Divide}        : {token, {'/', TokenLine}}.
-{Remainder}     : {token, {'%', TokenLine}}.
-{And}           : {token, {'and', TokenLine}}.
-{Or}            : {token, {'or', TokenLine}}.
+{LeftBrace}          : {token, {'{', TokenLine}}.
+{RightBrace}         : {token, {'}', TokenLine}}.
+{LeftBracket}        : {token, {'[', TokenLine}}.
+{RightBracket}       : {token, {']', TokenLine}}.
+{LeftParen}          : {token, {'(', TokenLine}}.
+{RightParen}         : {token, {')', TokenLine}}.
+{Comma}              : {token, {',', TokenLine}}.
+{Match}              : {token, {'=', TokenLine}}.
+{Cons}               : {token, {'|', TokenLine}}.
+{Plus}               : {token, {'+', TokenLine}}.
+{Minus}              : {token, {'-', TokenLine}}.
+{Multiply}           : {token, {'*', TokenLine}}.
+{Divide}             : {token, {'/', TokenLine}}.
+{Remainder}          : {token, {'%', TokenLine}}.
+{And}                : {token, {'and', TokenLine}}.
+{Or}                 : {token, {'or', TokenLine}}.
+{Equal}              : {token, {'==', TokenLine}}.
+{NotEqual}           : {token, {'!=', TokenLine}}.
+{LessThan}           : {token, {'<', TokenLine}}.
+{LessThanOrEqual}    : {token, {'<=', TokenLine}}.
+{GreaterThan}        : {token, {'>', TokenLine}}.
+{GreaterThanOrEqual} : {token, {'>=', TokenLine}}.
 
-{Identifier}    : {token, {identifier, TokenLine, TokenChars}}.
+{Identifier}         : {token, {identifier, TokenLine, TokenChars}}.
 
 Erlang code.
 

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -2,6 +2,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Mathematical operators
+
 parse_function_adding_two_ints_test() ->
     RufusText = "func Three() int { 1 + 2 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
@@ -277,6 +279,8 @@ parse_function_remaindering_three_ints_test() ->
                          spec => 'Four'}}],
     ?assertEqual(Expected, Forms).
 
+%% Conditional operators
+
 parse_function_anding_two_bools_test() ->
     RufusText = "func Falsy() bool { true and false }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
@@ -323,4 +327,150 @@ parse_function_oring_two_bools_test() ->
                                                  source => rufus_text,
                                                  spec => bool}},
                          spec => 'Truthy'}}],
+    ?assertEqual(Expected, Forms).
+
+%% Comparison operators
+
+parse_function_comparing_two_bools_for_equality_test() ->
+    RufusText = "func Falsy() bool { true == false }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 1,
+                                                 op => '==',
+                                                 right => {bool_lit, #{line => 1,
+                                                                       spec => false,
+                                                                       type => {type, #{line => 1,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_comparing_two_bools_for_inequality_test() ->
+    RufusText = "func Falsy() bool { true != true }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
+                                                                      spec => true,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => bool}}}},
+                                                 line => 1,
+                                                 op => '!=',
+                                                 right => {bool_lit, #{line => 1,
+                                                                       spec => true,
+                                                                       type => {type, #{line => 1,
+                                                                                        source => inferred,
+                                                                                        spec => bool}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_comparing_two_ints_to_determine_which_is_lesser_test() ->
+    RufusText = "func Falsy() bool { 5 < 3 }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
+                                                                     spec => 5,
+                                                                     type => {type, #{line => 1,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 1,
+                                                 op => '<',
+                                                 right => {int_lit, #{line => 1,
+                                                                      spec => 3,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_comparing_two_ints_to_determine_which_is_lesser_or_equal_test() ->
+    RufusText = "func Falsy() bool { 5 <= 3 }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
+                                                                     spec => 5,
+                                                                     type => {type, #{line => 1,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 1,
+                                                 op => '<=',
+                                                 right => {int_lit, #{line => 1,
+                                                                      spec => 3,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_comparing_two_ints_to_determine_which_is_greater_test() ->
+    RufusText = "func Falsy() bool { 3 > 5 }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
+                                                                     spec => 3,
+                                                                     type => {type, #{line => 1,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 1,
+                                                 op => '>',
+                                                 right => {int_lit, #{line => 1,
+                                                                      spec => 5,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    ?assertEqual(Expected, Forms).
+
+parse_function_comparing_two_ints_to_determine_which_is_greater_or_equal_test() ->
+    RufusText = "func Falsy() bool { 3 >= 5 }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
+                                                                     spec => 3,
+                                                                     type => {type, #{line => 1,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 1,
+                                                 op => '>=',
+                                                 right => {int_lit, #{line => 1,
+                                                                      spec => 5,
+                                                                      type => {type, #{line => 1,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}}}}],
+                         line => 1,
+                         params => [],
+                         return_type => {type, #{line => 1,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_binary_op_test.erl
+++ b/rf/test/rufus_raw_tokenize_binary_op_test.erl
@@ -57,3 +57,51 @@ string_with_binary_op_expression_using_or_operator_test() ->
         {'or', 1},
         {bool_lit, 1, false}
     ], Tokens).
+
+string_with_binary_op_expression_using_equal_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("true == false"),
+    ?assertEqual([
+        {bool_lit, 1, true},
+        {'==', 1},
+        {bool_lit, 1, false}
+    ], Tokens).
+
+string_with_binary_op_expression_using_not_equal_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("true != false"),
+    ?assertEqual([
+        {bool_lit, 1, true},
+        {'!=', 1},
+        {bool_lit, 1, false}
+    ], Tokens).
+
+string_with_binary_op_expression_using_less_than_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("3 < 5"),
+    ?assertEqual([
+        {int_lit, 1, 3},
+        {'<', 1},
+        {int_lit, 1, 5}
+    ], Tokens).
+
+string_with_binary_op_expression_using_less_than_or_equal_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("3 <= 5"),
+    ?assertEqual([
+        {int_lit, 1, 3},
+        {'<=', 1},
+        {int_lit, 1, 5}
+    ], Tokens).
+
+string_with_binary_op_expression_using_greater_than_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("3 > 5"),
+    ?assertEqual([
+        {int_lit, 1, 3},
+        {'>', 1},
+        {int_lit, 1, 5}
+    ], Tokens).
+
+string_with_binary_op_expression_using_greater_than_or_equal_operator_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("3 >= 5"),
+    ?assertEqual([
+        {int_lit, 1, 3},
+        {'>=', 1},
+        {int_lit, 1, 5}
+    ], Tokens).


### PR DESCRIPTION
New `==`, `!=`, `<`, `<=`, `>`, `>=` operators can be tokenized and parsed in `binary_op` expressions.