### PR TITLE
compiler: Typecheck and annotate binary_op expressions with == != < <= > >= comparison operators

### DIFF
--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -25,14 +25,11 @@ main(Args) ->
 run("compile", _Args) ->
     RufusText ="
     module example
-
-    func Number() int {
-        42
-    }
-",
+    func Numbers() list[int] { list[int]{17, 9, 31, 48} }
+    ",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, example} = rufus_compile:eval(RufusText),
-    io:format("example:Number() =>~n~n    ~p~n", [example:'Number'()]),
+    io:format("example:Numbers() =>~n~n    ~p~n", [example:'Numbers'()]),
     0;
 run("debug:erlang-forms", [Filename]) ->
     {ok, BinaryContents} = file:read_file(Filename),

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -54,7 +54,12 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
         '%'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
         'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
         'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        '=='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2}
+        '=='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
+        '!='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
+        '<'  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
+        '<='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
+        '>'  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
+        '>='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2}
     end,
 
     ok = case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of
@@ -79,6 +84,11 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
     end.
 
 binary_op_type('==', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('!=', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('<', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('<=', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('>', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('>=', Line) -> rufus_form:make_inferred_type(bool, Line);
 binary_op_type(_, _) -> default.
 
 %% allow_type_with_arithmetic_binary_op returns true if the specified type may
@@ -110,9 +120,23 @@ allow_type_with_boolean_binary_op(_, _) -> false.
 allow_type_pair_with_boolean_binary_op(bool, bool) -> true;
 allow_type_pair_with_boolean_binary_op(_, _) -> false.
 
+%% allow_type_with_comparison_operator returns true if the specified type may be
+%% used with the specified comparison operator, otherwise false.
 -spec allow_type_with_comparison_operator(comparison_operator(), bool | atom()) -> boolean().
-allow_type_with_comparison_operator('==', _) -> true.
+allow_type_with_comparison_operator('==', _) -> true;
+allow_type_with_comparison_operator('!=', _) -> true;
+allow_type_with_comparison_operator('<', int) -> true;
+allow_type_with_comparison_operator('<', float) -> true;
+allow_type_with_comparison_operator('<=', int) -> true;
+allow_type_with_comparison_operator('<=', float) -> true;
+allow_type_with_comparison_operator('>', int) -> true;
+allow_type_with_comparison_operator('>', float) -> true;
+allow_type_with_comparison_operator('>=', int) -> true;
+allow_type_with_comparison_operator('>=', float) -> true;
+allow_type_with_comparison_operator(_, _) -> false.
 
+%% allow_type_pair_with_comparison_operator returns true if the specified pair
+%% of types are both of same type, which is a requirement for comparisons.
 -spec allow_type_pair_with_comparison_operator(type_spec(), type_spec()) -> boolean().
 allow_type_pair_with_comparison_operator(Spec, Spec) -> true;
 allow_type_pair_with_comparison_operator(_, _) -> false.

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -47,19 +47,19 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
     LeftTypeSpec = rufus_form:type_spec(LeftType),
     RightTypeSpec = rufus_form:type_spec(RightType),
     {AllowType, AllowTypePair} = case Op of
-        '+'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        '-'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        '*'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        '/'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        '%'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
-        'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        '=='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
-        '!='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
-        '<'  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
-        '<='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
-        '>'  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2};
-        '>='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2}
+        '+'   -> {fun allow_type_with_mathematical_operator/2, fun allow_type_pair_with_mathematical_operator/2};
+        '-'   -> {fun allow_type_with_mathematical_operator/2, fun allow_type_pair_with_mathematical_operator/2};
+        '*'   -> {fun allow_type_with_mathematical_operator/2, fun allow_type_pair_with_mathematical_operator/2};
+        '/'   -> {fun allow_type_with_mathematical_operator/2, fun allow_type_pair_with_mathematical_operator/2};
+        '%'   -> {fun allow_type_with_mathematical_operator/2, fun allow_type_pair_with_mathematical_operator/2};
+        'and' -> {fun allow_type_with_conditional_operator/2,  fun allow_type_pair_with_conditional_operator/2};
+        'or'  -> {fun allow_type_with_conditional_operator/2,  fun allow_type_pair_with_conditional_operator/2};
+        '=='  -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2};
+        '!='  -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2};
+        '<'   -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2};
+        '<='  -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2};
+        '>'   -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2};
+        '>='  -> {fun allow_type_with_comparison_operator/2,   fun allow_type_pair_with_comparison_operator/2}
     end,
 
     ok = case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of
@@ -91,34 +91,34 @@ binary_op_type('>', Line) -> rufus_form:make_inferred_type(bool, Line);
 binary_op_type('>=', Line) -> rufus_form:make_inferred_type(bool, Line);
 binary_op_type(_, _) -> default.
 
-%% allow_type_with_arithmetic_binary_op returns true if the specified type may
+%% allow_type_with_mathematical_operator returns true if the specified type may
 %% be used with the specified arithmetic operator, otherwise false.
--spec allow_type_with_arithmetic_binary_op(arithmetic_operator(), float | int | atom()) -> boolean().
-allow_type_with_arithmetic_binary_op('%', float) -> false;
-allow_type_with_arithmetic_binary_op(_, float) -> true;
-allow_type_with_arithmetic_binary_op(_, int) -> true;
-allow_type_with_arithmetic_binary_op(_, _) -> false.
+-spec allow_type_with_mathematical_operator(arithmetic_operator(), float | int | atom()) -> boolean().
+allow_type_with_mathematical_operator('%', float) -> false;
+allow_type_with_mathematical_operator(_, float) -> true;
+allow_type_with_mathematical_operator(_, int) -> true;
+allow_type_with_mathematical_operator(_, _) -> false.
 
-%% allow_type_pair_with_arithmetic_binary_op returns true if the specified pair
+%% allow_type_pair_with_mathematical_operator returns true if the specified pair
 %% of types are either both of type float, or both of type int, which are the
 %% only types that may be used with an arithmetic operator.
--spec allow_type_pair_with_arithmetic_binary_op(float | int | atom(), float | int | atom()) -> boolean().
-allow_type_pair_with_arithmetic_binary_op(float, float) -> true;
-allow_type_pair_with_arithmetic_binary_op(int, int) -> true;
-allow_type_pair_with_arithmetic_binary_op(_, _) -> false.
+-spec allow_type_pair_with_mathematical_operator(float | int | atom(), float | int | atom()) -> boolean().
+allow_type_pair_with_mathematical_operator(float, float) -> true;
+allow_type_pair_with_mathematical_operator(int, int) -> true;
+allow_type_pair_with_mathematical_operator(_, _) -> false.
 
-%% allow_type_with_boolean_binary_op returns true if the specified type may be
-%% used with the specified boolean operator, otherwise false.
--spec allow_type_with_boolean_binary_op(boolean_operator(), bool | atom()) -> boolean().
-allow_type_with_boolean_binary_op(_, bool) -> true;
-allow_type_with_boolean_binary_op(_, _) -> false.
+%% allow_type_with_conditional_operator returns true if the specified type may
+%% be used with the specified boolean operator, otherwise false.
+-spec allow_type_with_conditional_operator(boolean_operator(), bool | atom()) -> boolean().
+allow_type_with_conditional_operator(_, bool) -> true;
+allow_type_with_conditional_operator(_, _) -> false.
 
-%% allow_type_pair_with_boolean_binary_op returns true if the specified pair of
-%% types are both of type bool, which is the only type that may be used with a
-%% boolean operator.
--spec allow_type_pair_with_boolean_binary_op(bool | atom(), bool | atom()) -> boolean().
-allow_type_pair_with_boolean_binary_op(bool, bool) -> true;
-allow_type_pair_with_boolean_binary_op(_, _) -> false.
+%% allow_type_pair_with_conditional_operator returns true if the specified pair
+%% of types are both of type bool, which is the only type that may be used with
+%% a boolean operator.
+-spec allow_type_pair_with_conditional_operator(bool | atom(), bool | atom()) -> boolean().
+allow_type_pair_with_conditional_operator(bool, bool) -> true;
+allow_type_pair_with_conditional_operator(_, _) -> false.
 
 %% allow_type_with_comparison_operator returns true if the specified type may be
 %% used with the specified comparison operator, otherwise false.

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -41,7 +41,7 @@ resolve_type(Globals, Form = {identifier, _Context}) ->
 %% binary_op form helpers
 
 -spec resolve_binary_op_type(globals(), binary_op_form()) -> {ok, type_form()} | no_return().
-resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, right := Right}}) ->
+resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, right := Right, line := Line}}) ->
     {ok, LeftType} = resolve_type(Globals, Left),
     {ok, RightType} = resolve_type(Globals, Right),
     LeftTypeSpec = rufus_form:type_spec(LeftType),
@@ -53,20 +53,33 @@ resolve_binary_op_type(Globals, Form = {binary_op, #{op := Op, left := Left, rig
         '/'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
         '%'   -> {fun allow_type_with_arithmetic_binary_op/2, fun allow_type_pair_with_arithmetic_binary_op/2};
         'and' -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
-        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2}
+        'or'  -> {fun allow_type_with_boolean_binary_op/2,    fun allow_type_pair_with_boolean_binary_op/2};
+        '=='  -> {fun allow_type_with_comparison_operator/2,  fun allow_type_pair_with_comparison_operator/2}
     end,
 
-    case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of
+    ok = case AllowType(Op, LeftTypeSpec) and AllowType(Op, RightTypeSpec) of
         true ->
-            case AllowTypePair(LeftTypeSpec, RightTypeSpec) of
-                true ->
-                    {ok, LeftType};
-                false ->
-                    throw({error, unmatched_operand_type, #{form => Form}})
-            end;
+            ok;
         false ->
             throw({error, unsupported_operand_type, #{form => Form}})
+    end,
+
+    {ok, LeftType} = case AllowTypePair(LeftTypeSpec, RightTypeSpec) of
+        true ->
+            {ok, LeftType};
+        false ->
+            throw({error, unmatched_operand_type, #{form => Form}})
+    end,
+
+    case binary_op_type(Op, Line) of
+        default ->
+            {ok, LeftType};
+        Type ->
+            {ok, Type}
     end.
+
+binary_op_type('==', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type(_, _) -> default.
 
 %% allow_type_with_arithmetic_binary_op returns true if the specified type may
 %% be used with the specified arithmetic operator, otherwise false.
@@ -96,6 +109,13 @@ allow_type_with_boolean_binary_op(_, _) -> false.
 -spec allow_type_pair_with_boolean_binary_op(bool | atom(), bool | atom()) -> boolean().
 allow_type_pair_with_boolean_binary_op(bool, bool) -> true;
 allow_type_pair_with_boolean_binary_op(_, _) -> false.
+
+-spec allow_type_with_comparison_operator(comparison_operator(), bool | atom()) -> boolean().
+allow_type_with_comparison_operator('==', _) -> true.
+
+-spec allow_type_pair_with_comparison_operator(type_spec(), type_spec()) -> boolean().
+allow_type_pair_with_comparison_operator(Spec, Spec) -> true;
+allow_type_pair_with_comparison_operator(_, _) -> false.
 
 %% call form helpers
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -47,17 +47,18 @@
       | list_lit_form()
       | cons_form().
 
-- type literal() ::
-         atom
-       | bool
-       | float
-       | int
-       | string.
+-type literal() ::
+        atom
+      | bool
+      | float
+      | int
+      | string.
 
 %% Operators
 
 -type arithmetic_operator() :: '+' | '-' | '*' | '/' | '%'.
 -type boolean_operator() :: 'and' | 'or'.
+-type comparison_operator() :: '==' | '!=' | '<' | '<=' | '>' | '>='.
 
 %% Expressions
 

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -395,3 +395,389 @@ typecheck_and_annotate_equal_binary_op_with_ints_test() ->
                          spec => 'Falsy'}}],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_equal_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { 1 == 2.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
+                                                       spec => 1,
+                                                       type => {type, #{line => 3,
+                                                                        source => inferred,
+                                                                        spec => int}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '==',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 2.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_inequal_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 1 != 1 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 1,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '!=',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 1,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_inequal_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { :two != 2.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
+                                                        spec => two,
+                                                        type => {type, #{line => 3,
+                                                                         source => inferred,
+                                                                         spec => atom}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '!=',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 2.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_less_than_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 2 < 1 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 2,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '<',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 1,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_less_than_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { 2 < 1.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
+                                                       spec => 2,
+                                                       type => {type, #{line => 3,
+                                                                        source => inferred,
+                                                                        spec => int}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '<',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 1.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_less_than_binary_op_with_unsupported_operand_type_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { :two < :one }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
+                                                        spec => two,
+                                                        type => {type, #{line => 3,
+                                                                         source => inferred,
+                                                                         spec => atom}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '<',
+                                   right => {atom_lit, #{line => 3,
+                                                         spec => one,
+                                                         type => {type, #{line => 3,
+                                                                          source => inferred,
+                                                                          spec => atom}}}}}}},
+    ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_less_than_or_equal_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 2 <= 1 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 2,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '<=',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 1,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_less_than_or_equal_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { 2 <= 1.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
+                                                       spec => 2,
+                                                       type => {type, #{line => 3,
+                                                                        source => inferred,
+                                                                        spec => int}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '<=',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 1.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_less_than_or_equal_binary_op_with_unsupported_operand_type_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { :two <= :one }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
+                                                        spec => two,
+                                                        type => {type, #{line => 3,
+                                                                         source => inferred,
+                                                                         spec => atom}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '<=',
+                                   right => {atom_lit, #{line => 3,
+                                                         spec => one,
+                                                         type => {type, #{line => 3,
+                                                                          source => inferred,
+                                                                          spec => atom}}}}}}},
+    ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_greater_than_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 1 > 2 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 1,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '>',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 2,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_greater_than_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { 2 > 1.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
+                                                       spec => 2,
+                                                       type => {type, #{line => 3,
+                                                                        source => inferred,
+                                                                        spec => int}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '>',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 1.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_greater_than_binary_op_with_unsupported_operand_type_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { :two > :one }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
+                                                        spec => two,
+                                                        type => {type, #{line => 3,
+                                                                         source => inferred,
+                                                                         spec => atom}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '>',
+                                   right => {atom_lit, #{line => 3,
+                                                         spec => one,
+                                                         type => {type, #{line => 3,
+                                                                          source => inferred,
+                                                                          spec => atom}}}}}}},
+    ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_greater_than_or_equal_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 1 >= 2 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 1,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '>=',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 2,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).
+
+
+typecheck_and_annotate_greater_than_or_equal_binary_op_with_mismatched_operands_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { 2 >= 1.0 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
+                                                       spec => 2,
+                                                       type => {type, #{line => 3,
+                                                                        source => inferred,
+                                                                        spec => int}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '>=',
+                                   right => {float_lit, #{line => 3,
+                                                          spec => 1.0,
+                                                          type => {type, #{line => 3,
+                                                                           source => inferred,
+                                                                           spec => float}}}}}}},
+    ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_greater_than_or_equal_binary_op_with_unsupported_operand_type_test() ->
+    RufusText = "
+    module example
+    func Broken() bool { :two >= :one }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
+                                                        spec => two,
+                                                        type => {type, #{line => 3,
+                                                                         source => inferred,
+                                                                         spec => atom}}}},
+                                   line => 3,
+                                   locals => #{},
+                                   op => '>=',
+                                   right => {atom_lit, #{line => 3,
+                                                         spec => one,
+                                                         type => {type, #{line => 3,
+                                                                          source => inferred,
+                                                                          spec => atom}}}}}}},
+    ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -4,7 +4,7 @@
 
 %% Mathematical operators
 
-typecheck_and_annotate_arithmetic_binary_op_with_ints_test() ->
+typecheck_and_annotate_mathematical_operator_with_ints_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 19 + 23 }
@@ -37,7 +37,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_arithmetic_binary_op_with_floats_test() ->
+typecheck_and_annotate_mathematical_operator_with_floats_test() ->
     RufusText = "
     module example
     func Pi() float { 1.0 + 2.14159265359 }
@@ -70,7 +70,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_floats_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_arithmetic_binary_op_with_float_and_int_test() ->
+typecheck_and_annotate_mathematical_operator_with_float_and_int_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 19.0 + 23 }
@@ -93,7 +93,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_float_and_int_test() ->
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_arithmetic_binary_op_with_float_and_float_and_int_test() ->
+typecheck_and_annotate_mathematical_operator_with_float_and_float_and_int_test() ->
     RufusText = "
     module example
     func FortyTwo() int { 13.0 + 6.0 + 23 }
@@ -126,7 +126,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_float_and_float_and_int_test() 
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_arithmetic_binary_op_with_bools_test() ->
+typecheck_and_annotate_mathematical_operator_with_bools_test() ->
     RufusText = "
     module example
     func Concat() bool { true + false }
@@ -149,7 +149,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_bools_test() ->
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_arithmetic_binary_op_with_strings_test() ->
+typecheck_and_annotate_mathematical_operator_with_strings_test() ->
     RufusText = "
     module example
     func Concat() string { \"port\" + \"manteau\" }
@@ -172,7 +172,7 @@ typecheck_and_annotate_arithmetic_binary_op_with_strings_test() ->
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-typecheck_and_annotate_remainder_arithmetic_binary_op_with_ints_test() ->
+typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
     RufusText = "
     module example
     func Six() int { 27 % 7 }
@@ -205,7 +205,7 @@ typecheck_and_annotate_remainder_arithmetic_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_remainder_arithmetic_binary_op_with_floats_test() ->
+typecheck_and_annotate_remainder_mathematical_operator_with_floats_test() ->
     RufusText = "
     module example
     func Six() int { 27.0 % 7.0 }
@@ -230,7 +230,7 @@ typecheck_and_annotate_remainder_arithmetic_binary_op_with_floats_test() ->
 
 %% Conditional operators
 
-typecheck_and_annotate_boolean_binary_op_with_bools_test() ->
+typecheck_and_annotate_conditional_operator_with_bools_test() ->
     RufusText = "
     module example
     func Falsy() bool { true and false }
@@ -263,7 +263,7 @@ typecheck_and_annotate_boolean_binary_op_with_bools_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_boolean_binary_op_with_nested_bools_test() ->
+typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
     RufusText = "
     module example
     func Falsy() bool { false or true and true }
@@ -338,7 +338,7 @@ typecheck_and_annotate_boolean_binary_op_with_nested_bools_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_boolean_binary_op_with_bool_and_int_test() ->
+typecheck_and_annotate_conditional_operator_with_bool_and_int_test() ->
     RufusText = "
     module example
     func Falsy() bool { true and 0 }
@@ -363,7 +363,7 @@ typecheck_and_annotate_boolean_binary_op_with_bool_and_int_test() ->
 
 %% Comparison operators
 
-typecheck_and_annotate_equal_binary_op_with_ints_test() ->
+typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 1 == 2 }
@@ -396,7 +396,7 @@ typecheck_and_annotate_equal_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_equal_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_equality_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { 1 == 2.0 }
@@ -418,7 +418,7 @@ typecheck_and_annotate_equal_binary_op_with_mismatched_operands_test() ->
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_inequal_binary_op_with_ints_test() ->
+typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 1 != 1 }
@@ -451,7 +451,7 @@ typecheck_and_annotate_inequal_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_inequal_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_inequality_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { :two != 2.0 }
@@ -473,7 +473,7 @@ typecheck_and_annotate_inequal_binary_op_with_mismatched_operands_test() ->
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_less_than_binary_op_with_ints_test() ->
+typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 2 < 1 }
@@ -506,7 +506,7 @@ typecheck_and_annotate_less_than_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_less_than_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_less_than_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { 2 < 1.0 }
@@ -528,7 +528,7 @@ typecheck_and_annotate_less_than_binary_op_with_mismatched_operands_test() ->
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_less_than_binary_op_with_unsupported_operand_type_test() ->
+typecheck_and_annotate_less_than_comparison_operator_with_unsupported_operand_type_test() ->
     RufusText = "
     module example
     func Broken() bool { :two < :one }
@@ -550,7 +550,7 @@ typecheck_and_annotate_less_than_binary_op_with_unsupported_operand_type_test() 
                                                                           spec => atom}}}}}}},
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_less_than_or_equal_binary_op_with_ints_test() ->
+typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 2 <= 1 }
@@ -583,7 +583,7 @@ typecheck_and_annotate_less_than_or_equal_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_less_than_or_equal_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_less_than_or_equal_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { 2 <= 1.0 }
@@ -605,7 +605,7 @@ typecheck_and_annotate_less_than_or_equal_binary_op_with_mismatched_operands_tes
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_less_than_or_equal_binary_op_with_unsupported_operand_type_test() ->
+typecheck_and_annotate_less_than_or_equal_comparison_operator_with_unsupported_operand_type_test() ->
     RufusText = "
     module example
     func Broken() bool { :two <= :one }
@@ -627,7 +627,7 @@ typecheck_and_annotate_less_than_or_equal_binary_op_with_unsupported_operand_typ
                                                                           spec => atom}}}}}}},
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_greater_than_binary_op_with_ints_test() ->
+typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 1 > 2 }
@@ -660,7 +660,7 @@ typecheck_and_annotate_greater_than_binary_op_with_ints_test() ->
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_greater_than_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_greater_than_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { 2 > 1.0 }
@@ -682,7 +682,7 @@ typecheck_and_annotate_greater_than_binary_op_with_mismatched_operands_test() ->
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_greater_than_binary_op_with_unsupported_operand_type_test() ->
+typecheck_and_annotate_greater_than_comparison_operator_with_unsupported_operand_type_test() ->
     RufusText = "
     module example
     func Broken() bool { :two > :one }
@@ -704,7 +704,7 @@ typecheck_and_annotate_greater_than_binary_op_with_unsupported_operand_type_test
                                                                           spec => atom}}}}}}},
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_greater_than_or_equal_binary_op_with_ints_test() ->
+typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test() ->
     RufusText = "
     module example
     func Falsy() bool { 1 >= 2 }
@@ -738,7 +738,7 @@ typecheck_and_annotate_greater_than_or_equal_binary_op_with_ints_test() ->
     ?assertEqual(Expected, AnnotatedForms).
 
 
-typecheck_and_annotate_greater_than_or_equal_binary_op_with_mismatched_operands_test() ->
+typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_mismatched_operands_test() ->
     RufusText = "
     module example
     func Broken() bool { 2 >= 1.0 }
@@ -760,7 +760,7 @@ typecheck_and_annotate_greater_than_or_equal_binary_op_with_mismatched_operands_
                                                                            spec => float}}}}}}},
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_greater_than_or_equal_binary_op_with_unsupported_operand_type_test() ->
+typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_unsupported_operand_type_test() ->
     RufusText = "
     module example
     func Broken() bool { :two >= :one }

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% arithmetic binary_op expressions
+%% Mathematical operators
 
 typecheck_and_annotate_arithmetic_binary_op_with_ints_test() ->
     RufusText = "
@@ -172,8 +172,6 @@ typecheck_and_annotate_arithmetic_binary_op_with_strings_test() ->
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-%% arithmetic binary_op expressions with the remainder operator
-
 typecheck_and_annotate_remainder_arithmetic_binary_op_with_ints_test() ->
     RufusText = "
     module example
@@ -230,7 +228,7 @@ typecheck_and_annotate_remainder_arithmetic_binary_op_with_floats_test() ->
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
-%% boolean binary_op expressions
+%% Conditional operators
 
 typecheck_and_annotate_boolean_binary_op_with_bools_test() ->
     RufusText = "
@@ -362,3 +360,38 @@ typecheck_and_annotate_boolean_binary_op_with_bool_and_int_test() ->
                                                                              spec => int}}}}}}},
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
+
+%% Comparison operators
+
+typecheck_and_annotate_equal_binary_op_with_ints_test() ->
+    RufusText = "
+    module example
+    func Falsy() bool { 1 == 2 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [{module, #{line => 2,
+                           spec => example}},
+                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
+                                                                     spec => 1,
+                                                                     type => {type, #{line => 3,
+                                                                                      source => inferred,
+                                                                                      spec => int}}}},
+                                                 line => 3,
+                                                 op => '==',
+                                                 right => {int_lit, #{line => 3,
+                                                                      spec => 2,
+                                                                      type => {type, #{line => 3,
+                                                                                       source => inferred,
+                                                                                       spec => int}}}},
+                                                 type => {type, #{line => 3,
+                                                                  source => inferred,
+                                                                  spec => bool}}}}],
+                         line => 3,
+                         params => [],
+                         return_type => {type, #{line => 3,
+                                                 source => rufus_text,
+                                                 spec => bool}},
+                         spec => 'Falsy'}}],
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_raw_tokenize_binary_op_test.erl
+++ b/rf/test/rufus_raw_tokenize_binary_op_test.erl
@@ -2,6 +2,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Mathematical operators
+
 string_with_binary_op_expression_using_plus_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 + 5"),
     ?assertEqual([
@@ -42,6 +44,8 @@ string_with_binary_op_expression_using_remainder_operator_test() ->
         {int_lit, 1, 5}
     ], Tokens).
 
+%% Conditional operators
+
 string_with_binary_op_expression_using_and_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true and false"),
     ?assertEqual([
@@ -57,6 +61,8 @@ string_with_binary_op_expression_using_or_operator_test() ->
         {'or', 1},
         {bool_lit, 1, false}
     ], Tokens).
+
+%% Comparison operators
 
 string_with_binary_op_expression_using_equal_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true == false"),


### PR DESCRIPTION
`rufus_type:resolve/2` typechecks and resolves `binary_op` expressions with comparison operators `==`, `!=`, `<`, `<=`, `>` and `>=`. `rufus_expr:typecheck_and_annotate/1` uses this new support for boolean operators to annotate boolean `binary_op` expressions with type information.