### PR TITLE
compiler: Compile binary_op expressions with == != < <= > >= comparison operators

### DIFF
--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -160,6 +160,12 @@ rufus_operator_to_erlang_operator('and', bool) ->
     'andalso';
 rufus_operator_to_erlang_operator('or', bool) ->
     'orelse';
+rufus_operator_to_erlang_operator('==', _) ->
+    '=:=';
+rufus_operator_to_erlang_operator('!=', _) ->
+    '=/=';
+rufus_operator_to_erlang_operator('<=', _) ->
+    '=<';
 rufus_operator_to_erlang_operator(Op, _) ->
     Op.
 

--- a/rf/test/rufus_compile_binary_op_test.erl
+++ b/rf/test/rufus_compile_binary_op_test.erl
@@ -188,3 +188,59 @@ forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
     ?assertEqual({ok, example}, Result),
     ?assertEqual(false, example:'Falsy'()),
     ?assertEqual(true, example:'Truthy'()).
+
+%% Comparison operators
+
+forms_for_function_with_an_equality_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { :truth == :truth }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+forms_for_function_with_an_inequality_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { :truth != :fiction }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+forms_for_function_with_a_less_than_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 1 < 2 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+forms_for_function_with_a_less_than_or_greater_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 1 <= 2 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+forms_for_function_with_a_greater_than_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 2 > 1 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).
+
+forms_for_function_with_a_greater_than_or_greater_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 2 >= 1 }
+    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual(true, example:'Truthy'()).

--- a/rf/test/rufus_erlang_binary_op_test.erl
+++ b/rf/test/rufus_erlang_binary_op_test.erl
@@ -336,3 +336,95 @@ forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
         {function, 3, 'Truthy', 0, [{clause, 3, [], [], [OrBinaryOp]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+%% Comparison operators
+
+forms_for_function_with_an_equality_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { :truth == :truth }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=:=', {atom, 3, truth}, {atom, 3, truth}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_an_inequality_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { :truth != :fiction }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=/=', {atom, 3, truth}, {atom, 3, fiction}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_a_less_than_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 1 < 2 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '<', {integer, 3, 1}, {integer, 3, 2}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_a_less_than_or_equal_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 1 <= 2 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=<', {integer, 3, 1}, {integer, 3, 2}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_a_greater_than_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 2 > 1 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '>', {integer, 3, 2}, {integer, 3, 1}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_a_greater_than_or_equal_comparison_operation_test() ->
+    RufusText = "
+    module example
+    func Truthy() bool { 2 >= 1 }
+    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '>=', {integer, 3, 2}, {integer, 3, 1}}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).


### PR DESCRIPTION
`==`, `!=`, `<`, `<=`, `>` and `>=` `binary_op` expressions are compiled to equivalent expressions in Erlang.