### PR TITLE
compiler: New rufus_form:each/2 and rufus_form:map/2 functions for walking Rufus forms

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -29,7 +29,7 @@ typecheck_and_annotate(RufusForms) ->
     {ok, Globals} = rufus_form:globals(RufusForms),
     try
         {ok, _Locals, AnnotatedForms} = typecheck_and_annotate([], Globals, #{}, RufusForms),
-        rufus_form:map(AnnotatedForms, fun sanity_check/1),
+        ok = rufus_form:each(AnnotatedForms, fun sanity_check/1),
         {ok, AnnotatedForms}
     catch
         {error, Code, Data} ->
@@ -42,12 +42,12 @@ typecheck_and_annotate(RufusForms) ->
 %% sanity_check, Data}` error triple is thrown if a form doesn't have type
 %% information, otherwise `ok` is returned.
 -spec sanity_check(rufus_form()) -> ok | no_return().
-sanity_check(Form = {func, _Context}) ->
-    Form;
-sanity_check(Form = {module, _Context}) ->
-    Form;
-sanity_check(Form = {_FormType, #{type := _Type}}) ->
-    Form;
+sanity_check({func, _Context}) ->
+    ok;
+sanity_check({module, _Context}) ->
+    ok;
+sanity_check({_FormType, #{type := _Type}}) ->
+    ok;
 sanity_check(Form) ->
     Data = #{form => Form,
              error => missing_type_information},

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -233,7 +233,12 @@ map(Acc, [{call, Context = #{args := Args}}|T], Fun) ->
     map([AnnotatedForm|Acc], T, Fun);
 map(Acc, [{cons, Context = #{head := Head, tail := Tail}}|T], Fun) ->
     AnnotatedHead = Fun(Head),
-    AnnotatedTail = map(Tail, Fun),
+    AnnotatedTail = case Tail of
+        Tail when is_list(Tail) ->
+            map(Tail, Fun);
+        Tail ->
+            Fun(Tail)
+    end,
     AnnotatedForm = Fun({cons, Context#{head => AnnotatedHead, tail => AnnotatedTail}}),
     map([AnnotatedForm|Acc], T, Fun);
 map(Acc, [{func, Context = #{params := Params, exprs := Exprs}}|T], Fun) ->

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -236,6 +236,16 @@ map_with_cons_test() ->
                            annotated := true}}],
                  rufus_form:map([Form], fun annotate/1)).
 
+map_with_cons_and_tail_identifier_test() ->
+    Line = 17,
+    Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),
+    TailForm = rufus_form:make_identifier('tail', 3),
+    Form = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), TailForm, Line),
+    ?assertMatch([{cons, #{head := {_, #{annotated := true}},
+                           tail := {identifier, #{spec := tail}},
+                           annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
 map_with_func_test() ->
     Type = rufus_form:make_type(bool, 81),
     Param = rufus_form:make_literal(bool, true, 81),

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -154,22 +154,32 @@ make_literal_test() ->
                  rufus_form:make_literal(string, <<"hello">>, 9)).
 
 make_binary_op_test() ->
-    Operand = {int_lit, #{spec => 2, line => 4}},
-    ?assertEqual({binary_op, #{op => '+', left => Operand, right => Operand, line => 4}},
-                 rufus_form:make_binary_op('+', Operand, Operand, 4)).
+    Left = rufus_form:make_literal(int, 2, 13),
+    Right = rufus_form:make_literal(int, 3, 13),
+    Form = rufus_form:make_binary_op('+', Left, Right, 13),
+    ?assertEqual({binary_op, #{op => '+', left => Left, right => Right, line => 13}}, Form).
+
+make_call_test() ->
+    Line = 3,
+    Spec = 'Echo',
+    Args = [rufus_form:make_literal(string, <<"hello">>, 3)],
+    Expected = {call, #{spec => Spec, args => Args, line => Line}},
+    ?assertEqual(Expected, rufus_form:make_call(Spec, Args, Line)).
 
 make_cons_test() ->
     Line = 3,
     Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),
-    Head = 1,
+    Head = rufus_form:make_literal(int, 5, 3),
     Tail = [],
     Expected = {cons, #{type => Type, head => Head, tail => Tail, line => Line}},
     ?assertEqual(Expected, rufus_form:make_cons(Type, Head, Tail, Line)).
 
 make_func_test() ->
     Type = rufus_form:make_type(bool, 81),
-    ?assertEqual({func, #{spec => 'True', params => [], return_type => Type, exprs => [], line => 81}},
-                 rufus_form:make_func('True', [], Type, [], 81)).
+    Param = rufus_form:make_literal(bool, true, 81),
+    Value = rufus_form:make_literal(bool, true, 81),
+    ?assertEqual({func, #{spec => 'True', params => [Param], return_type => Type, exprs => [Value], line => 81}},
+                 rufus_form:make_func('True', [Param], Type, [Value], 81)).
 
 make_param_test() ->
     Type = rufus_form:make_type(int, 52),
@@ -186,3 +196,73 @@ make_match_test() ->
     Right = rufus_form:make_identifier(m, 3),
     ?assertEqual({match, #{left => Left, right => Right, line => 3}},
                  rufus_form:make_match(Left, Right, 3)).
+
+map_with_empty_input_test() ->
+    ?assertEqual([], rufus_form:map([], fun annotate/1)).
+
+map_with_noop_function_test() ->
+    Form = rufus_form:make_literal(bool, true, 7),
+    ?assertEqual([Form], rufus_form:map([Form], fun(F) -> F end)).
+
+map_test() ->
+    Form = rufus_form:make_literal(bool, true, 7),
+    Expected1 = {bool_lit, Context = #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
+    ?assertEqual(Expected1, Form),
+    [AnnotatedForm] = rufus_form:map([Form], fun annotate/1),
+    Expected2 = {bool_lit, Context#{annotated => true}},
+    ?assertEqual(Expected2, AnnotatedForm).
+
+map_with_binary_op_test() ->
+    Left = rufus_form:make_literal(int, 2, 13),
+    Right = rufus_form:make_literal(int, 3, 13),
+    Form = rufus_form:make_binary_op('+', Left, Right, 13),
+    ?assertMatch([{binary_op, #{left := {_, #{annotated := true}}, right := {_, #{annotated := true}}, annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+map_with_call_test() ->
+    Args = [rufus_form:make_literal(string, <<"hello">>, 3)],
+    Form = rufus_form:make_call('Echo', Args, 13),
+    ?assertMatch([{call, #{args := [{_, #{annotated := true}}], annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+map_with_cons_test() ->
+    Line = 17,
+    Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),
+    TailForm = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), [], Line),
+    Form = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), [TailForm], Line),
+    ?assertMatch([{cons, #{head := {_, #{annotated := true}},
+                           tail := [{cons, #{head := {_, #{annotated := true}},
+                                             tail := [], annotated := true}}],
+                           annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+map_with_func_test() ->
+    Type = rufus_form:make_type(bool, 81),
+    Param = rufus_form:make_literal(bool, true, 81),
+    Value = rufus_form:make_literal(bool, true, 81),
+    Form = rufus_form:make_func('True', [Param], Type, [Value], 81),
+    ?assertMatch([{func, #{params := [{bool_lit, #{annotated := true}}],
+                           exprs := [{bool_lit, #{annotated := true}}],
+                           annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+map_with_list_lit_test() ->
+    ElementType = rufus_form:make_type(bool, 81),
+    Type = rufus_form:make_type(list, ElementType, 81),
+    Value = rufus_form:make_literal(bool, true, 81),
+    Form = rufus_form:make_literal(list, Type, [Value], 81),
+    ?assertMatch([{list_lit, #{elements := [{bool_lit, #{annotated := true}}],
+                               annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+map_with_match_test() ->
+    Left = rufus_form:make_identifier(n, 3),
+    Right = rufus_form:make_identifier(m, 3),
+    Form = rufus_form:make_match(Left, Right, 3),
+    ?assertMatch([{match, #{left := {_, #{annotated := true}},
+                            right := {_, #{annotated := true}},
+                            annotated := true}}],
+                 rufus_form:map([Form], fun annotate/1)).
+
+annotate({FormType, Context}) ->
+    {FormType, Context#{annotated => true}}.


### PR DESCRIPTION
New `rufus_form:each/2` and `rufus_form:map/2` functions iterate over Rufus forms and apply a function. `rufus_expr:sanity_check/1` has been refactored to work with with `rufus_form:each/2`.