### PR TITLE
build: Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/rufus-lang/rufus.svg?branch=master)](https://travis-ci.com/rufus-lang/rufus)
+[![Build Status](https://travis-ci.com/rufus-lang/rufus.svg?branch=main)](https://travis-ci.com/rufus-lang/rufus)
 # Rufus
 
 Rufus is a programming language for teams that build and operate fault tolerant

--- a/rf/README.md
+++ b/rf/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/rufus-lang/rufus.svg?branch=master)](https://travis-ci.com/rufus-lang/rufus)
+[![Build Status](https://travis-ci.com/rufus-lang/rufus.svg?branch=main)](https://travis-ci.com/rufus-lang/rufus)
 # rf
 
 `rf` provides tools for working with Rufus programs.


### PR DESCRIPTION
The `master` branch has been renamed to `main`. References to the old branch name have been updated.