### PR TITLE
misc: Use erlfmt to format source code

### DIFF
--- a/rf/rebar.config
+++ b/rf/rebar.config
@@ -1,24 +1,13 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 
-%% escript
-{escript_incl_apps, [rf]}.
-{escript_main_app, rf}.
-{escript_name, rf}.
-{escript_emu_args, "%%! +sbtu +A0\n"}.
-
 %% profiles
 {profiles, [
     {test, [{erl_opts, [debug_info]}]}
 ]}.
 
-%% leex options
-{xrl_opts, []}.
-{xrl_first_files, []}.
-
-%% yecc options
-{yrl_opts, [warnings_as_errors]}.
-{yrl_first_files, []}.
+%% plugins
+{plugins, [erlfmt]}.
 
 %% dialyzer options
 {dialyzer, [
@@ -32,3 +21,23 @@
     {base_plt_location, global}, % global | "/my/file/name"
     {base_plt_prefix, "rebar3"}
 ]}.
+
+%% erlfmt options
+{erlfmt, [
+    write,
+    {files, "{src,include,test}/*.{hrl,erl}"}
+]}.
+
+%% escript options
+{escript_incl_apps, [rf]}.
+{escript_main_app, rf}.
+{escript_name, rf}.
+{escript_emu_args, "%%! +sbtu +A0\n"}.
+
+%% leex options
+{xrl_opts, []}.
+{xrl_first_files, []}.
+
+%% yecc options
+{yrl_opts, [warnings_as_errors]}.
+{yrl_first_files, []}.

--- a/rf/src/rf.erl
+++ b/rf/src/rf.erl
@@ -10,12 +10,13 @@
 -spec main(list()) -> no_return().
 main(Args) ->
     ok = application:start(rf),
-    ExitCode = case Args of
-        [Command|CommandArgs] ->
-            run(Command, CommandArgs);
-        [] ->
-            run("help", [])
-    end,
+    ExitCode =
+        case Args of
+            [Command | CommandArgs] ->
+                run(Command, CommandArgs);
+            [] ->
+                run("help", [])
+        end,
     ok = application:stop(rf),
     erlang:halt(ExitCode).
 
@@ -23,10 +24,11 @@ main(Args) ->
 
 -spec run(string(), list(string())) -> integer().
 run("compile", _Args) ->
-    RufusText ="
-    module example
-    func Numbers() list[int] { list[int]{17, 9, 31, 48} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{17, 9, 31, 48} }\n"
+        "    ",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, example} = rufus_compile:eval(RufusText),
     io:format("example:Numbers() =>~n~n    ~p~n", [example:'Numbers'()]),
@@ -35,7 +37,10 @@ run("debug:erlang-forms", [Filename]) ->
     {ok, BinaryContents} = file:read_file(Filename),
     io:format("ErlangText =>~n~n~s~n", [binary_to_list(BinaryContents)]),
     Tokens = scan(erl_scan:tokens([], binary_to_list(BinaryContents), 1), []),
-    Parse = fun(X) -> {ok,Y} = erl_parse:parse_form(X), Y end,
+    Parse = fun(X) ->
+        {ok, Y} = erl_parse:parse_form(X),
+        Y
+    end,
     Forms = [Parse(X) || X <- Tokens],
     io:format("ErlangForms =>~n~n    ~p~n", [Forms]),
     0;
@@ -44,18 +49,21 @@ run("debug:rufus-forms", [Filename]) ->
     io:format("RufusText =>~n~n~s~n", [binary_to_list(BinaryContents)]),
 
     Tokens = scan(erl_scan:tokens([], binary_to_list(BinaryContents), 1), []),
-    Parse = fun(X) -> {ok,Y} = erl_parse:parse_form(X), Y end,
+    Parse = fun(X) ->
+        {ok, Y} = erl_parse:parse_form(X),
+        Y
+    end,
     Forms = [Parse(X) || X <- Tokens],
     io:format("RufusForms =>~n~n    ~p~n", [Forms]),
     0;
 run("debug:parse", _Args) ->
-    RufusText = "
-    module rand
-
-    func Int() int {
-        42
-    }
-",
+    RufusText =
+        "\n"
+        "    module rand\n"
+        "\n"
+        "    func Int() int {\n"
+        "        42\n"
+        "    }\n",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     io:format("Tokens =>~n~n    ~p~n~n", [Tokens]),
@@ -73,13 +81,13 @@ run("debug:parse", _Args) ->
             -1
     end;
 run("debug:tokenize", _Args) ->
-    RufusText = "
-    module example
-
-    func Greet(name string) string {
-        \"Hello \" + name
-    }
-",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "\n"
+        "    func Greet(name string) string {\n"
+        "        \"Hello \" + name\n"
+        "    }\n",
     io:format("RufusText =>~n    ~s~n", [RufusText]),
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     io:format("Tokens =>~n~n    ~p~n", [Tokens]),
@@ -166,6 +174,6 @@ warn(Command, _Args) ->
     io:format("Unknown command: ~s~n", [Command]).
 
 scan({done, {ok, Token, Line}, CharSpec}, Rest) ->
-    scan(erl_scan:tokens([], CharSpec, Line), [Token|Rest]);
+    scan(erl_scan:tokens([], CharSpec, Line), [Token | Rest]);
 scan(_, Res) ->
     lists:reverse(Res).

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -36,7 +36,7 @@ eval(RufusText) ->
 %% treated as an error. The output from one compilation stage is provided as
 %% input to the next. Processing stops if a compilation stage returns an error.
 -spec eval_stages(any(), list(fun((_) -> any()))) -> ok_tuple() | error_tuple() | error_triple().
-eval_stages(Input, [H|T]) ->
+eval_stages(Input, [H | T]) ->
     case H(Input) of
         {ok, Forms} ->
             eval_stages(Forms, T);
@@ -63,7 +63,9 @@ compile(ErlangForms) ->
     end.
 
 %% load creates or overwrites a module with a code binary.
--spec load(atom(), binary()) -> {ok, atom()} | {error, badarg | badfile | nofile | not_purged | on_load_failure | sticky_directory}.
+-spec load(atom(), binary()) ->
+    {ok, atom()} |
+    {error, badarg | badfile | nofile | not_purged | on_load_failure | sticky_directory}.
 load(Module, BinaryOrCode) ->
     case code:load_binary(Module, "nofile", BinaryOrCode) of
         {module, Module} ->

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -49,40 +49,43 @@ safety_check({module, _Context}) ->
 safety_check({_FormType, #{type := _Type}}) ->
     ok;
 safety_check(Form) ->
-    Data = #{form => Form,
-             error => missing_type_information},
+    Data = #{
+        form => Form,
+        error => missing_type_information
+    },
     throw({error, safety_check, Data}).
 
 %% typecheck_and_annotate iterates over RufusForms and adds type information
 %% from the current scope to each form. An `{error, Reason, Data}` error triple
 %% is thrown at the first error.
--spec typecheck_and_annotate(list(rufus_form()), globals(), locals(), list(rufus_form())) -> {ok, locals(), list(rufus_form())}.
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {binary_op, _Context}|T]) ->
+-spec typecheck_and_annotate(list(rufus_form()), globals(), locals(), list(rufus_form())) ->
+    {ok, locals(), list(rufus_form())}.
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {binary_op, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_binary_op(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, Locals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {call, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, Locals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {call, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_call(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, Locals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {cons, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, Locals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {cons, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_cons(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, Locals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {func, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, Locals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {func, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_func(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, Locals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {identifier, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, Locals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {identifier, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_identifier(Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, Locals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {list_lit, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, Locals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {list_lit, _Context} | T]) ->
     {ok, NewLocals, AnnotatedForm} = typecheck_and_annotate_list_lit(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, NewLocals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {match, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, NewLocals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {match, _Context} | T]) ->
     {ok, NewLocals, AnnotatedForm} = typecheck_and_annotate_match(Globals, Locals, Form),
-    typecheck_and_annotate([AnnotatedForm|Acc], Globals, NewLocals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [Form = {param, _Context}|T]) ->
+    typecheck_and_annotate([AnnotatedForm | Acc], Globals, NewLocals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [Form = {param, _Context} | T]) ->
     {ok, NewLocals} = push_local(Locals, Form),
-    typecheck_and_annotate([Form|Acc], Globals, NewLocals, T);
-typecheck_and_annotate(Acc, Globals, Locals, [H|T]) ->
-    typecheck_and_annotate([H|Acc], Globals, Locals, T);
+    typecheck_and_annotate([Form | Acc], Globals, NewLocals, T);
+typecheck_and_annotate(Acc, Globals, Locals, [H | T]) ->
+    typecheck_and_annotate([H | Acc], Globals, Locals, T);
 typecheck_and_annotate(Acc, _Globals, Locals, []) ->
     {ok, Locals, lists:reverse(Acc)}.
 
@@ -109,16 +112,24 @@ push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
 %%   mixed with a `float` operand. `Form` contains the illegal operands.
 %% - `{error, unsupported_operand_type, Form}` is thrown if a type other than an
 %%   int is used as an operand. `Form` contains the illegal operands.
--spec typecheck_and_annotate_binary_op(globals(), locals(), binary_op_form()) -> {ok, binary_op_form()} | no_return().
-typecheck_and_annotate_binary_op(Globals, Locals, {binary_op, Context = #{left := Left, right := Right}}) ->
+-spec typecheck_and_annotate_binary_op(globals(), locals(), binary_op_form()) ->
+    {ok, binary_op_form()} | no_return().
+typecheck_and_annotate_binary_op(
+    Globals,
+    Locals,
+    {binary_op, Context = #{left := Left, right := Right}}
+) ->
     {ok, Locals, [AnnotatedLeft]} = typecheck_and_annotate([], Globals, Locals, [Left]),
     {ok, Locals, [AnnotatedRight]} = typecheck_and_annotate([], Globals, Locals, [Right]),
     Form = {binary_op, Context#{left => AnnotatedLeft, right => AnnotatedRight, locals => Locals}},
     case rufus_type:resolve(Globals, Form) of
         {ok, TypeForm} ->
-            AnnotatedForm = {binary_op, Context#{left => AnnotatedLeft,
-                                                 right => AnnotatedRight,
-                                                 type => TypeForm}},
+            AnnotatedForm =
+                {binary_op, Context#{
+                    left => AnnotatedLeft,
+                    right => AnnotatedRight,
+                    type => TypeForm
+                }},
             {ok, AnnotatedForm};
         Error ->
             throw(Error)
@@ -128,7 +139,8 @@ typecheck_and_annotate_binary_op(Globals, Locals, {binary_op, Context = #{left :
 
 %% typecheck_and_annotate_call resolves the return type for a function call and
 %% returns a call form annotated with type information.
--spec typecheck_and_annotate_call(globals(), locals(), call_form()) -> {ok, call_form()} | no_return().
+-spec typecheck_and_annotate_call(globals(), locals(), call_form()) ->
+    {ok, call_form()} | no_return().
 typecheck_and_annotate_call(Globals, Locals, {call, Context1 = #{args := Args}}) ->
     {ok, _NewLocals, AnnotatedArgs} = typecheck_and_annotate([], Globals, Locals, Args),
     Form = {call, Context2 = Context1#{args => AnnotatedArgs}},
@@ -147,16 +159,20 @@ typecheck_and_annotate_call(Globals, Locals, {call, Context1 = #{args := Args}})
 %% - `{ok, AnnotatedForm}` if no issues are found.
 %% - `{error, unexpected_element_type, Data}` is thrown if either the head or
 %%   tail elements have type issues.
--spec typecheck_and_annotate_cons(globals(), locals(), cons_form()) -> {ok, cons_form()} | no_return().
+-spec typecheck_and_annotate_cons(globals(), locals(), cons_form()) ->
+    {ok, cons_form()} | no_return().
 typecheck_and_annotate_cons(Globals, Locals, {cons, Context = #{head := Head, tail := Tail}}) ->
     {ok, NewLocals1, [AnnotatedHead]} = typecheck_and_annotate([], Globals, Locals, [Head]),
     {ok, _NewLocals2, [AnnotatedTail]} = typecheck_and_annotate([], Globals, NewLocals1, [Tail]),
     AnnotatedForm1 = {cons, Context#{head => AnnotatedHead, tail => AnnotatedTail}},
     case rufus_type:resolve(Globals, AnnotatedForm1) of
         {ok, TypeForm} ->
-            AnnotatedForm2 = {cons, Context#{head => AnnotatedHead,
-                                             tail => AnnotatedTail,
-                                             type => TypeForm}},
+            AnnotatedForm2 =
+                {cons, Context#{
+                    head => AnnotatedHead,
+                    tail => AnnotatedTail,
+                    type => TypeForm
+                }},
             {ok, AnnotatedForm2};
         Error ->
             throw(Error)
@@ -167,7 +183,8 @@ typecheck_and_annotate_cons(Globals, Locals, {cons, Context = #{head := Head, ta
 %% typecheck_and_annotate_func adds all parameters to the local scope. It also
 %% resolves and annotates types for all expressions in the function body to
 %% ensure they satisfy type constraints.
--spec typecheck_and_annotate_func(globals(), locals(), func_form()) -> {ok, func_form()} | no_return().
+-spec typecheck_and_annotate_func(globals(), locals(), func_form()) ->
+    {ok, func_form()} | no_return().
 typecheck_and_annotate_func(Globals, Locals, {func, Context = #{params := Params, exprs := Exprs}}) ->
     {ok, NewLocals1, AnnotatedParams} = typecheck_and_annotate([], Globals, Locals, Params),
     {ok, _NewLocals2, AnnotatedExprs} = typecheck_and_annotate([], Globals, NewLocals1, Exprs),
@@ -222,7 +239,8 @@ typecheck_and_annotate_identifier(Locals, Form = {identifier, Context = #{spec :
 %%   its elements are annotated with type information.
 %% - `{error, unexpected_element_type, Data}` is thrown if an element is found
 %%   with a differing type.
--spec typecheck_and_annotate_list_lit(globals(), locals(), list_lit_form()) -> {ok, locals(), list_lit_form()} | no_return().
+-spec typecheck_and_annotate_list_lit(globals(), locals(), list_lit_form()) ->
+    {ok, locals(), list_lit_form()} | no_return().
 typecheck_and_annotate_list_lit(Globals, Locals, {list_lit, Context = #{elements := Elements}}) ->
     {ok, NewLocals, AnnotatedElements} = typecheck_and_annotate([], Globals, Locals, Elements),
     AnnotatedForm1 = {list_lit, Context#{elements => AnnotatedElements}},
@@ -248,16 +266,25 @@ typecheck_and_annotate_list_lit(Globals, Locals, {list_lit, Context = #{elements
 %%   operands are unbound.
 %% - `{error, unmarched_types, Data}` is thrown when the left and right operand
 %%   have differing types.
--spec typecheck_and_annotate_match(globals(), locals(), match_form()) -> {ok, locals(), match_form()} | no_return().
+-spec typecheck_and_annotate_match(globals(), locals(), match_form()) ->
+    {ok, locals(), match_form()} | no_return().
 typecheck_and_annotate_match(Globals, Locals, {match, Context = #{left := Left}}) ->
     {ok, NewLocals1, [AnnotatedLeft1]} = typecheck_and_annotate([], Globals, Locals, [Left]),
     AnnotatedForm1 = {match, Context#{left => AnnotatedLeft1}},
     case rufus_form:has_type(AnnotatedLeft1) of
         true ->
             ok = validate_pattern(Globals, NewLocals1, AnnotatedForm1),
-            typecheck_and_annotate_match_with_bound_left_operand(Globals, NewLocals1, AnnotatedForm1);
+            typecheck_and_annotate_match_with_bound_left_operand(
+                Globals,
+                NewLocals1,
+                AnnotatedForm1
+            );
         false ->
-            typecheck_and_annotate_match_with_unbound_left_operand(Globals, NewLocals1, AnnotatedForm1)
+            typecheck_and_annotate_match_with_unbound_left_operand(
+                Globals,
+                NewLocals1,
+                AnnotatedForm1
+            )
     end.
 
 %% typecheck_and_annotate_match_with_bound_left_operand typechecks match
@@ -268,25 +295,35 @@ typecheck_and_annotate_match(Globals, Locals, {match, Context = #{left := Left}}
 %%   unbound.
 %% - `{error, unmarched_types, Data}` is thrown when the left and right operand
 %%   have differing types.
--spec typecheck_and_annotate_match_with_bound_left_operand(globals(), locals(), match_form()) -> {ok, locals(), match_form()} | no_return().
-typecheck_and_annotate_match_with_bound_left_operand(Globals, Locals, {match, Context = #{left := Left, right := Right}}) ->
+-spec typecheck_and_annotate_match_with_bound_left_operand(globals(), locals(), match_form()) ->
+    {ok, locals(), match_form()} | no_return().
+typecheck_and_annotate_match_with_bound_left_operand(
+    Globals,
+    Locals,
+    {match, Context = #{left := Left, right := Right}}
+) ->
     try
         {ok, NewLocals, [AnnotatedRight]} = typecheck_and_annotate([], Globals, Locals, [Right]),
         case rufus_form:type_spec(Left) == rufus_form:type_spec(AnnotatedRight) of
             true ->
                 RightType = rufus_form:type(AnnotatedRight),
-                AnnotatedForm = {match, Context#{left => Left,
-                                                 right => AnnotatedRight,
-                                                 type => RightType}},
+                AnnotatedForm =
+                    {match, Context#{
+                        left => Left,
+                        right => AnnotatedRight,
+                        type => RightType
+                    }},
                 {ok, NewLocals, AnnotatedForm};
             false ->
                 case AnnotatedRight of
                     {identifier, _Context2} ->
                         case rufus_form:has_type(AnnotatedRight) of
                             false ->
-                                Data2 = #{globals => Globals,
-                                          locals => Locals,
-                                          form => AnnotatedRight},
+                                Data2 = #{
+                                    globals => Globals,
+                                    locals => Locals,
+                                    form => AnnotatedRight
+                                },
                                 throw({error, unbound_variable, Data2});
                             true ->
                                 ok
@@ -295,14 +332,17 @@ typecheck_and_annotate_match_with_bound_left_operand(Globals, Locals, {match, Co
                         ok
                 end,
 
-                Data3 = #{globals => Globals,
-                          locals => Locals,
-                          left => Left,
-                          right => AnnotatedRight},
+                Data3 = #{
+                    globals => Globals,
+                    locals => Locals,
+                    left => Left,
+                    right => AnnotatedRight
+                },
                 throw({error, unmatched_types, Data3})
         end
-    catch {error, unknown_identifier, Data1} ->
-        throw({error, unbound_variable, Data1})
+    catch
+        {error, unknown_identifier, Data1} ->
+            throw({error, unbound_variable, Data1})
     end.
 
 %% typecheck_and_annotate_match_with_unbound_left_operand typechecks match
@@ -312,8 +352,13 @@ typecheck_and_annotate_match_with_bound_left_operand(Globals, Locals, {match, Co
 %%   and its operands are annotated with type information.
 %% - `{error, unbound_variables, Data}` is thrown if both the left and right
 %%   operands are unbound.
--spec typecheck_and_annotate_match_with_unbound_left_operand(globals(), locals(), match_form()) -> {ok, locals(), match_form()} | no_return().
-typecheck_and_annotate_match_with_unbound_left_operand(Globals, Locals, {match, Context = #{left := Left, right := Right}}) ->
+-spec typecheck_and_annotate_match_with_unbound_left_operand(globals(), locals(), match_form()) ->
+    {ok, locals(), match_form()} | no_return().
+typecheck_and_annotate_match_with_unbound_left_operand(
+    Globals,
+    Locals,
+    {match, Context = #{left := Left, right := Right}}
+) ->
     {ok, NewLocals1, [AnnotatedRight]} = typecheck_and_annotate([], Globals, Locals, [Right]),
     case rufus_form:has_type(AnnotatedRight) of
         true ->
@@ -322,15 +367,20 @@ typecheck_and_annotate_match_with_unbound_left_operand(Globals, Locals, {match, 
             AnnotatedLeft1 = {LeftType, LeftContext#{type => RightType}},
             {ok, NewLocals2} = push_local(NewLocals1, AnnotatedLeft1),
             {ok, AnnotatedLeft2} = annotate_locals(NewLocals2, AnnotatedLeft1),
-            AnnotatedForm = {match, Context#{left => AnnotatedLeft2,
-                                             right => AnnotatedRight,
-                                             type => RightType}},
+            AnnotatedForm =
+                {match, Context#{
+                    left => AnnotatedLeft2,
+                    right => AnnotatedRight,
+                    type => RightType
+                }},
             {ok, NewLocals2, AnnotatedForm};
         false ->
-            Data = #{globals => Globals,
-                     locals => Locals,
-                     left => Left,
-                     right => AnnotatedRight},
+            Data = #{
+                globals => Globals,
+                locals => Locals,
+                left => Left,
+                right => AnnotatedRight
+            },
             throw({error, unbound_variables, Data})
     end.
 
@@ -341,9 +391,11 @@ typecheck_and_annotate_match_with_unbound_left_operand(Globals, Locals, {match, 
 %% TODO(jkakar) Figure out why Dialyzer doesn't like this spec:
 %% -spec validate_pattern(globals(), locals(), match_form()) -> ok | no_return().
 validate_pattern(Globals, Locals, Form = {match, _Context}) ->
-    Data = #{globals => Globals,
-             locals => Locals,
-             form => Form},
+    Data = #{
+        globals => Globals,
+        locals => Locals,
+        form => Form
+    },
     validate_pattern(Data, Form).
 
 %% validate_pattern inspects the left hand operand of a match form to ensure
@@ -365,7 +417,7 @@ validate_pattern(_Data, {string_lit, _Context}) ->
     ok;
 validate_pattern(_Data, {identifier, _Context}) ->
     ok;
-validate_pattern(Data, Form={binary_op, _Context}) ->
+validate_pattern(Data, Form = {binary_op, _Context}) ->
     case is_constant_expr(Form) of
         true ->
             ok;

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -116,20 +116,29 @@ make_import(Spec, Line) ->
 
 %% make_inferred_type creates a type form with 'inferred' as the 'source' value,
 %% to indicate that the type has been inferred by the compiler.
--spec make_inferred_type(type_spec(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
+-spec make_inferred_type(type_spec(), integer()) ->
+    {type, #{spec => atom(), source => type_source(), line => integer()}}.
 make_inferred_type(Spec, Line) ->
     make_type_with_source(Spec, inferred, Line).
 
 %% make_inferred_type creates a list type form with 'inferred' as the 'source'
 %% value, to indicate that the type of the list has been inferred by the
 %% compiler.
--spec make_inferred_type(list, type_form(), integer()) -> {type, #{collection_type => list, element_type => {type, map()}, line => integer(), source => type_source(), spec => atom()}}.
+-spec make_inferred_type(list, type_form(), integer()) ->
+    {type, #{
+        collection_type => list,
+        element_type => {type, map()},
+        line => integer(),
+        source => type_source(),
+        spec => atom()
+    }}.
 make_inferred_type(list, ElementType, Line) ->
     make_type_with_source(list, ElementType, inferred, Line).
 
 %% make_type returns a type form with 'rufus_text' as the 'source' value, to
 %% indicate that the type came from source code.
--spec make_type(atom(), integer()) -> {type, #{spec => atom(), source => type_source(), line => integer()}}.
+-spec make_type(atom(), integer()) ->
+    {type, #{spec => atom(), source => type_source(), line => integer()}}.
 make_type(Spec, Line) ->
     make_type_with_source(Spec, rufus_text, Line).
 
@@ -150,26 +159,43 @@ make_type_with_source(Spec, Source, Line) ->
 make_type_with_source(_CollectionSpec, ElementType, Source, Line) ->
     {type, #{spec := Spec}} = ElementType,
     TypeSpec = list_to_atom(unicode:characters_to_list(["list[", atom_to_list(Spec), "]"])),
-    {type, #{collection_type => list,
-             element_type => ElementType,
-             spec => TypeSpec,
-             source => Source,
-             line => Line}}.
+    {type, #{
+        collection_type => list,
+        element_type => ElementType,
+        spec => TypeSpec,
+        source => Source,
+        line => Line
+    }}.
 
 %% Function form builder API
 
 %% make_func returns a form for a function declaration.
--spec make_func(atom(), list(param_form()), type_form(), list(), integer()) -> {func, #{spec => atom(), params => list(param_form), return_type => type_form(), exprs => list(), line => integer()}}.
+-spec make_func(atom(), list(param_form()), type_form(), list(), integer()) ->
+    {func, #{
+        spec => atom(),
+        params => list(param_form),
+        return_type => type_form(),
+        exprs => list(),
+        line => integer()
+    }}.
 make_func(Spec, Params, ReturnType, Exprs, Line) ->
-    {func, #{spec => Spec, params => Params, return_type => ReturnType, exprs => Exprs, line => Line}}.
+    {func, #{
+        spec => Spec,
+        params => Params,
+        return_type => ReturnType,
+        exprs => Exprs,
+        line => Line
+    }}.
 
 %% make_param returns a form for a function parameter declaration.
--spec make_param(atom(), type_form(), integer()) -> {param, #{spec => atom(), type => type_form(), line => integer()}}.
+-spec make_param(atom(), type_form(), integer()) ->
+    {param, #{spec => atom(), type => type_form(), line => integer()}}.
 make_param(Spec, Type, Line) ->
     {param, #{spec => Spec, type => Type, line => Line}}.
 
 %% make_call returns a form for a function call.
--spec make_call(atom(), list(), integer()) -> {call, #{spec => atom(), args => list(), line => integer()}}.
+-spec make_call(atom(), list(), integer()) ->
+    {call, #{spec => atom(), args => list(), line => integer()}}.
 make_call(Spec, Args, Line) ->
     {call, #{spec => Spec, args => Args, line => Line}}.
 
@@ -186,15 +212,19 @@ make_identifier(Spec, Line) ->
 -spec make_literal(literal(), atom(), term()) -> literal_form().
 make_literal(TypeSpec, Spec, Line) ->
     FormSpec = list_to_atom(unicode:characters_to_list([atom_to_list(TypeSpec), "_lit"])),
-    {FormSpec, #{spec => Spec,
-                 type => make_inferred_type(TypeSpec, Line),
-                 line => Line}}.
+    {FormSpec, #{
+        spec => Spec,
+        type => make_inferred_type(TypeSpec, Line),
+        line => Line
+    }}.
 
 -spec make_literal(list, type_form(), list(), term()) -> literal_form().
 make_literal(list, Type, Elements, Line) ->
-    {list_lit, #{elements => Elements,
-                 type => Type,
-                 line => Line}}.
+    {list_lit, #{
+        elements => Elements,
+        type => Type,
+        line => Line
+    }}.
 
 %% make_cons returns a form for a cons expression.
 -spec make_cons(type_form(), rufus_form(), list_lit_form(), integer()) -> cons_form().
@@ -204,14 +234,16 @@ make_cons(Type, Head, Tail, Line) ->
 %% binary_op form builder API
 
 %% make_binary_op returns a form for a binary operation.
--spec make_binary_op(atom(), rufus_form(), rufus_form(), integer()) -> {binary_op, #{op => atom(), left => rufus_form(), right => rufus_form(), line => integer()}}.
+-spec make_binary_op(atom(), rufus_form(), rufus_form(), integer()) ->
+    {binary_op, #{op => atom(), left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_binary_op(Op, Left, Right, Line) ->
     {binary_op, #{op => Op, left => Left, right => Right, line => Line}}.
 
 %% match form builder API
 
 %% make_match returns a form for a match expression.
--spec make_match(rufus_form(), rufus_form(), integer()) -> {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
+-spec make_match(rufus_form(), rufus_form(), integer()) ->
+    {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_match(Left, Right, Line) ->
     {match, #{left => Left, right => Right, line => Line}}.
 
@@ -219,16 +251,16 @@ make_match(Left, Right, Line) ->
 
 %% each invokes Fun with each form in Forms. It always returns ok.
 -spec each(list(rufus_form()), fun((rufus_form()) -> any())) -> ok | no_return().
-each([Form = {binary_op, #{left := Left, right := Right}}|T], Fun) ->
+each([Form = {binary_op, #{left := Left, right := Right}} | T], Fun) ->
     Fun(Left),
     Fun(Right),
     Fun(Form),
     each(T, Fun);
-each([Form = {call, #{args := Args}}|T], Fun) ->
+each([Form = {call, #{args := Args}} | T], Fun) ->
     each(Args, Fun),
     Fun(Form),
     each(T, Fun);
-each([Form = {cons, #{head := Head, tail := Tail}}|T], Fun) ->
+each([Form = {cons, #{head := Head, tail := Tail}} | T], Fun) ->
     Fun(Head),
     case Tail of
         Tail when is_list(Tail) ->
@@ -238,21 +270,21 @@ each([Form = {cons, #{head := Head, tail := Tail}}|T], Fun) ->
     end,
     Fun(Form),
     each(T, Fun);
-each([Form = {func, #{params := Params, exprs := Exprs}}|T], Fun) ->
+each([Form = {func, #{params := Params, exprs := Exprs}} | T], Fun) ->
     each(Params, Fun),
     each(Exprs, Fun),
     Fun(Form),
     each(T, Fun);
-each([Form = {list_lit, #{elements := Elements}}|T], Fun) ->
+each([Form = {list_lit, #{elements := Elements}} | T], Fun) ->
     each(Elements, Fun),
     Fun(Form),
     each(T, Fun);
-each([Form = {match, #{left := Left, right := Right}}|T], Fun) ->
+each([Form = {match, #{left := Left, right := Right}} | T], Fun) ->
     Fun(Left),
     Fun(Right),
     Fun(Form),
     each(T, Fun);
-each([Form|T], Fun) ->
+each([Form | T], Fun) ->
     Fun(Form),
     each(T, Fun);
 each([], _Fun) ->
@@ -263,53 +295,55 @@ each([], _Fun) ->
 map(Forms, Fun) ->
     map([], Forms, Fun).
 
--spec map(list(rufus_form()), list(rufus_form()), fun((rufus_form()) -> rufus_form())) -> list(rufus_form()).
-map(Acc, [{binary_op, Context = #{left := Left, right := Right}}|T], Fun) ->
+-spec map(list(rufus_form()), list(rufus_form()), fun((rufus_form()) -> rufus_form())) ->
+    list(rufus_form()).
+map(Acc, [{binary_op, Context = #{left := Left, right := Right}} | T], Fun) ->
     AnnotatedLeft = Fun(Left),
     AnnotatedRight = Fun(Right),
     AnnotatedForm = Fun({binary_op, Context#{left => AnnotatedLeft, right => AnnotatedRight}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [{call, Context = #{args := Args}}|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{call, Context = #{args := Args}} | T], Fun) ->
     AnnotatedArgs = map(Args, Fun),
     AnnotatedForm = Fun({call, Context#{args => AnnotatedArgs}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [{cons, Context = #{head := Head, tail := Tail}}|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{cons, Context = #{head := Head, tail := Tail}} | T], Fun) ->
     AnnotatedHead = Fun(Head),
-    AnnotatedTail = case Tail of
-        Tail when is_list(Tail) ->
-            map(Tail, Fun);
-        Tail ->
-            Fun(Tail)
-    end,
+    AnnotatedTail =
+        case Tail of
+            Tail when is_list(Tail) ->
+                map(Tail, Fun);
+            Tail ->
+                Fun(Tail)
+        end,
     AnnotatedForm = Fun({cons, Context#{head => AnnotatedHead, tail => AnnotatedTail}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [{func, Context = #{params := Params, exprs := Exprs}}|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{func, Context = #{params := Params, exprs := Exprs}} | T], Fun) ->
     AnnotatedParams = map(Params, Fun),
     AnnotatedExprs = map(Exprs, Fun),
     AnnotatedForm = Fun({func, Context#{params => AnnotatedParams, exprs => AnnotatedExprs}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [{list_lit, Context = #{elements := Elements}}|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{list_lit, Context = #{elements := Elements}} | T], Fun) ->
     AnnotatedElements = map(Elements, Fun),
     AnnotatedForm = Fun({list_lit, Context#{elements => AnnotatedElements}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [{match, Context = #{left := Left, right := Right}}|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{match, Context = #{left := Left, right := Right}} | T], Fun) ->
     AnnotatedLeft = Fun(Left),
     AnnotatedRight = Fun(Right),
     AnnotatedForm = Fun({match, Context#{left => AnnotatedLeft, right => AnnotatedRight}}),
-    map([AnnotatedForm|Acc], T, Fun);
-map(Acc, [Form|T], Fun) ->
+    map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [Form | T], Fun) ->
     AnnotatedForm = Fun(Form),
-    map([AnnotatedForm|Acc], T, Fun);
+    map([AnnotatedForm | Acc], T, Fun);
 map(Acc, [], _Fun) ->
     lists:reverse(Acc).
 
 %% Private API
 
 -spec globals(map(), list(rufus_form())) -> {ok, #{atom() => list(rufus_form())}}.
-globals(Acc, [Form = {func, #{spec := Spec}}|T]) ->
+globals(Acc, [Form = {func, #{spec := Spec}} | T]) ->
     Forms = maps:get(Spec, Acc, []),
     globals(Acc#{Spec => Forms ++ [Form]}, T);
-globals(Acc, [_H|T]) ->
+globals(Acc, [_H | T]) ->
     globals(Acc, T);
 globals(Acc, []) ->
     {ok, Acc}.

--- a/rf/src/rufus_tokenize.erl
+++ b/rf/src/rufus_tokenize.erl
@@ -39,10 +39,10 @@ string(RufusText) ->
 make_semicolon_token(TokenLine) ->
     {';', TokenLine}.
 
-terminate(Acc=[{';', _TokenLine1}|_T], _TokenLine2) ->
+terminate(Acc = [{';', _TokenLine1} | _T], _TokenLine2) ->
     Acc;
 terminate(Acc, TokenLine) ->
-    [make_semicolon_token(TokenLine)|Acc].
+    [make_semicolon_token(TokenLine) | Acc].
 
 %% insert_semicolons inserts `;` tokens after some `eol` tokens to terminate
 %% expressions. All `eol` tokens are discarded in the resulting list of tokens.
@@ -54,44 +54,44 @@ insert_semicolons(Tokens) ->
 
 %% insert_semicolons inserts a semicolon when the following tokens are the last
 %% on a line or the last in the source text. The `eol` token is always discarded.
-insert_semicolons(Acc, {identifier, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {identifier, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {identifier, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {atom_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {atom_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {atom_lit, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {bool_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {bool_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {bool_lit, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {float_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {float_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {float_lit, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {int_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {int_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {int_lit, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {string_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {string_lit, TokenLine, _TokenChars}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {string_lit, TokenLine, _TokenChars}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {')', TokenLine}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {')', TokenLine}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {')', TokenLine}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
-insert_semicolons(Acc, {'}', TokenLine}, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, {'}', TokenLine}, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(terminate(Acc, TokenLine), Token, T);
 insert_semicolons(Acc, {'}', TokenLine}, []) ->
     insert_semicolons(terminate(Acc, TokenLine), undefined, []);
 %% insert_semicolons discards `eol` tokens.
-insert_semicolons(Acc, _LastToken, [Token = {eol, _TokenLine}|T]) ->
+insert_semicolons(Acc, _LastToken, [Token = {eol, _TokenLine} | T]) ->
     insert_semicolons(Acc, Token, T);
 %% insert_semicolons keeps all other tokens.
-insert_semicolons(Acc, _LastToken, [Token|T]) ->
-    insert_semicolons([Token|Acc], Token, T);
+insert_semicolons(Acc, _LastToken, [Token | T]) ->
+    insert_semicolons([Token | Acc], Token, T);
 %% insert_semicolons terminates when all tokens have been processed.
 insert_semicolons(Acc, _LastToken, []) ->
     lists:reverse(Acc).

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -39,20 +39,20 @@
 -type cons_form() :: {cons, context()}.
 
 -type literal_form() ::
-        atom_lit_form()
-      | bool_lit_form()
-      | float_lit_form()
-      | int_lit_form()
-      | string_lit_form()
-      | list_lit_form()
-      | cons_form().
+    atom_lit_form() |
+    bool_lit_form() |
+    float_lit_form() |
+    int_lit_form() |
+    string_lit_form() |
+    list_lit_form() |
+    cons_form().
 
 -type literal() ::
-        atom
-      | bool
-      | float
-      | int
-      | string.
+    atom |
+    bool |
+    float |
+    int |
+    string.
 
 %% Operators
 
@@ -72,21 +72,21 @@
 %% Rufus forms
 
 -type rufus_form() ::
-        atom_lit_form()
-      | bool_lit_form()
-      | float_lit_form()
-      | int_lit_form()
-      | string_lit_form()
-      | list_lit_form()
-      | cons_form()
-      | module_form()
-      | func_form()
-      | param_form()
-      | identifier_form()
-      | type_form()
-      | binary_op_form()
-      | match_form()
-      | call_form().
+    atom_lit_form() |
+    bool_lit_form() |
+    float_lit_form() |
+    int_lit_form() |
+    string_lit_form() |
+    list_lit_form() |
+    cons_form() |
+    module_form() |
+    func_form() |
+    param_form() |
+    identifier_form() |
+    type_form() |
+    binary_op_form() |
+    match_form() |
+    call_form().
 
 %% Errors
 
@@ -95,10 +95,10 @@
 -type unmatched_operand_type_error() :: unmatched_operand_type.
 -type unsupported_operand_type_error() :: unsupported_operand_type.
 -type rufus_error() ::
-        unknown_variable_error()
-      | unmatched_return_type_error()
-      | unmatched_operand_type_error()
-      | unsupported_operand_type_error().
+    unknown_variable_error() |
+    unmatched_return_type_error() |
+    unmatched_operand_type_error() |
+    unsupported_operand_type_error().
 
 %% Erlang forms
 
@@ -106,8 +106,8 @@
 -type erlang4_form() :: {_, _, _, _}.
 -type erlang5_form() :: {_, _, _, _, _}.
 -type erlang_form() ::
-        erlang3_form()
-      | erlang4_form()
-      | erlang5_form().
+    erlang3_form() |
+    erlang4_form() |
+    erlang5_form().
 
 -type export_attribute_erlang_form() :: {attribute, integer(), export, list()}.

--- a/rf/test/rufus_compile_binary_op_test.erl
+++ b/rf/test/rufus_compile_binary_op_test.erl
@@ -5,28 +5,31 @@
 %% Arity-0 functions returning a sum of literal values for scalar types
 
 eval_with_function_returning_a_sum_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 19 + 23 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 19 + 23 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'FortyTwo'()).
 
 eval_with_function_returning_a_sum_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func FiftyNine() int { 19 + 23 + 17 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FiftyNine() int { 19 + 23 + 17 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(59, example:'FiftyNine'()).
 
 eval_with_function_returning_a_sum_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 1.0 + 2.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 1.0 + 2.14159265359 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'Pi'()).
@@ -34,28 +37,31 @@ eval_with_function_returning_a_sum_of_float_literals_test() ->
 %% Arity-0 functions returning a difference of literal values for scalar types
 
 eval_with_function_returning_a_difference_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 55 - 13 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 55 - 13 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'FortyTwo'()).
 
 eval_with_function_returning_a_difference_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func ThirteenThirtyFive() int { 1500 - 150 - 15 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func ThirteenThirtyFive() int { 1500 - 150 - 15 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(1335, example:'ThirteenThirtyFive'()).
 
 eval_with_function_returning_a_difference_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 4.14159265359 - 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 4.14159265359 - 1.0 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'Pi'()).
@@ -63,28 +69,31 @@ eval_with_function_returning_a_difference_of_float_literals_test() ->
 %% Arity-0 functions returning a product of literal values for scalar types
 
 eval_with_function_returning_a_product_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 3 * 14 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 3 * 14 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'FortyTwo'()).
 
 eval_with_function_returning_a_product_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func ThirteenThirtyFive() int { 3 * 5 * 89 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func ThirteenThirtyFive() int { 3 * 5 * 89 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(1335, example:'ThirteenThirtyFive'()).
 
 eval_with_function_returning_a_product_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 1.0 * 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 1.0 * 3.14159265359 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'Pi'()).
@@ -92,28 +101,31 @@ eval_with_function_returning_a_product_of_float_literals_test() ->
 %% Arity-0 functions returning a division of literal values for scalar types
 
 eval_with_function_returning_a_division_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 84 / 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 84 / 2 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'FortyTwo'()).
 
 eval_with_function_returning_a_division_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func Five() int { 100 / 10 / 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Five() int { 100 / 10 / 2 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(5, example:'Five'()).
 
 eval_with_function_returning_a_division_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func TwoPointSevenFive() float { 5.5 / 2.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func TwoPointSevenFive() float { 5.5 / 2.0 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(2.75, example:'TwoPointSevenFive'()).
@@ -121,19 +133,21 @@ eval_with_function_returning_a_division_of_float_literals_test() ->
 %% Arity-0 functions returning a division of literal values for int types
 
 eval_with_function_returning_a_remainder_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func Six() int { 27 % 7 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Six() int { 27 % 7 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(6, example:'Six'()).
 
 eval_with_function_returning_a_remainder_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func Four() int { 100 % 13 % 5 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Four() int { 100 % 13 % 5 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(4, example:'Four'()).
@@ -141,49 +155,54 @@ eval_with_function_returning_a_remainder_of_three_int_literals_test() ->
 %% Arity-0 functions returning the result of a boolean operation
 
 eval_with_function_returning_the_result_of_an_and_operation_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { true and false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { true and false }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(false, example:'Falsy'()).
 
 eval_with_function_returning_the_result_of_an_and_operation_with_a_call_operand_test() ->
-    RufusText = "
-    module example
-    func False() bool { false }
-    func Falsy() bool { true and False() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func False() bool { false }\n"
+        "    func Falsy() bool { true and False() }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(false, example:'Falsy'()).
 
 eval_with_function_returning_the_result_of_an_or_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { true or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { true or false }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 eval_with_function_returning_the_result_of_an_or_operation_with_a_call_operand_test() ->
-    RufusText = "
-    module example
-    func True() bool { true }
-    func Truthy() bool { True() or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func True() bool { true }\n"
+        "    func Truthy() bool { True() or false }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { false or false and true }
-    func Truthy() bool { true and true or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { false or false and true }\n"
+        "    func Truthy() bool { true and true or false }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(false, example:'Falsy'()),
@@ -192,55 +211,61 @@ forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
 %% Comparison operators
 
 forms_for_function_with_an_equality_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { :truth == :truth }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { :truth == :truth }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_with_an_inequality_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { :truth != :fiction }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { :truth != :fiction }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_with_a_less_than_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 1 < 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 1 < 2 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_with_a_less_than_or_greater_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 1 <= 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 1 <= 2 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_with_a_greater_than_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 2 > 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 2 > 1 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).
 
 forms_for_function_with_a_greater_than_or_greater_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 2 >= 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 2 >= 1 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Truthy'()).

--- a/rf/test/rufus_compile_call_test.erl
+++ b/rf/test/rufus_compile_call_test.erl
@@ -5,11 +5,12 @@
 %% Arity-0 functions making function calls
 
 eval_for_function_call_test() ->
-    RufusText = "
-    module example
-    func Four() int { 100 % 13 % 5 }
-    func Random() int { Four() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Four() int { 100 % 13 % 5 }\n"
+        "    func Random() int { Four() }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(4, example:'Random'()).
@@ -17,51 +18,56 @@ eval_for_function_call_test() ->
 %% Arity-1 functions making function calls
 
 eval_with_function_call_with_an_atom_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(a atom) atom { a }
-    func Random() atom { Echo(:hello) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(a atom) atom { a }\n"
+        "    func Random() atom { Echo(:hello) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(hello, example:'Random'()).
 
 eval_with_function_call_with_a_bool_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(b bool) bool { b }
-    func Random() bool { Echo(true) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    func Random() bool { Echo(true) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Random'()).
 
 eval_with_function_call_with_a_float_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n float) float { n }
-    func Random() float { Echo(4.0) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n float) float { n }\n"
+        "    func Random() float { Echo(4.0) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(4.0, example:'Random'()).
 
 eval_with_function_call_with_an_int_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    func Random() int { Echo(4) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Random() int { Echo(4) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(4, example:'Random'()).
 
 eval_with_function_call_with_a_string_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(t string) string { t }
-    func Random() string { Echo(\"hello\") }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(t string) string { t }\n"
+        "    func Random() string { Echo(\"hello\") }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"hello">>}, example:'Random'()).
@@ -69,21 +75,23 @@ eval_with_function_call_with_a_string_argument_test() ->
 %% Arity-2 functions making function calls
 
 eval_with_function_call_with_two_int_arguments_test() ->
-    RufusText = "
-    module example
-    func Sum(m int, n int) int { m + n }
-    func Random() int { Sum(1, 2) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Sum(m int, n int) int { m + n }\n"
+        "    func Random() int { Sum(1, 2) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3, example:'Random'()).
 
 eval_with_function_call_with_two_float_arguments_test() ->
-    RufusText = "
-    module example
-    func Sum(m float, n float) float { m + n }
-    func Random() float { Sum(1.2, 2.3) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Sum(m float, n float) float { m + n }\n"
+        "    func Random() float { Sum(1.2, 2.3) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.5, example:'Random'()).
@@ -91,11 +99,12 @@ eval_with_function_call_with_two_float_arguments_test() ->
 %% Function calls with binary_op arguments
 
 eval_with_function_call_with_binary_op_argument_test() ->
-    RufusText = "
-    module example
-    func double(n int) int { n * 2 }
-    func SumAndDouble(m int, n int) int { double(m + n) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func double(n int) int { n * 2 }\n"
+        "    func SumAndDouble(m int, n int) int { double(m + n) }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(20, example:'SumAndDouble'(3, 7)).
@@ -103,13 +112,14 @@ eval_with_function_call_with_binary_op_argument_test() ->
 %% Multiple function heads
 
 eval_with_function_call_with_one_argument_and_many_function_heads_test() ->
-    RufusText = "
-    module example
-    func Echo(name atom) atom { name }
-    func Echo(n float) float { n }
-    func Echo(n int) int { n }
-    func Echo(text string) string { text }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(name atom) atom { name }\n"
+        "    func Echo(n float) float { n }\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Echo(text string) string { text }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(hello, example:'Echo'(hello)),

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -5,55 +5,61 @@
 %% Arity-0 functions returning a literal value for scalar types
 
 eval_with_function_returning_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() atom { :pong }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() atom { :pong }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(pong, example:'Ping'()).
 
 eval_with_function_returning_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func True() bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func True() bool { true }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(true, example:'True'()).
 
 eval_with_function_returning_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 3.14159265359 }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(3.14159265359, example:'Pi'()).
 
 eval_with_function_returning_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func Number() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() int { 42 }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(42, example:'Number'()).
 
 eval_with_function_returning_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Greeting() string { \"Hello\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Greeting() string { \"Hello\" }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Hello">>}, example:'Greeting'()).
 
 %% Arity-0 functions with multiple function expressions
 
 forms_for_function_with_multiple_expressions_test() ->
-    RufusText = "
-    module example
-    func Multiple() atom {
-        42
-        :fortytwo
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Multiple() atom {\n"
+        "        42\n"
+        "        :fortytwo\n"
+        "    }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(fortytwo, example:'Multiple'()).
@@ -61,46 +67,51 @@ forms_for_function_with_multiple_expressions_test() ->
 %% Arity-1 functions taking an unused parameter for scalar types
 
 eval_with_function_taking_an_atom_and_returning_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping(m atom) atom { :pong }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping(m atom) atom { :pong }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(pong, example:'Ping'(hello)).
 
 eval_with_function_taking_a_bool_and_returning_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n bool) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n bool) bool { true }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'MaybeEcho'(false)).
 
 eval_with_function_taking_a_float_and_returning_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n float) float { 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n float) float { 3.14159265359 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'MaybeEcho'(3.14)).
 
 eval_with_function_taking_an_int_and_returning_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n int) int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n int) int { 42 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'MaybeEcho'(42)).
 
 eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n string) string { \"Hello\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n string) string { \"Hello\" }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"Hello">>}, example:'MaybeEcho'({string, <<"Good morning">>})).
@@ -108,46 +119,51 @@ eval_with_function_taking_a_string_and_returning_a_string_literal_test() ->
 %% Arity-1 functions taking an argument and returning it for scalar types
 
 eval_with_function_taking_an_atom_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(m atom) atom { m }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(m atom) atom { m }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(hello, example:'Echo'(hello)).
 
 eval_with_function_taking_a_bool_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(b bool) bool { b }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(false, example:'Echo'(false)).
 
 eval_with_function_taking_a_float_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(n float) float { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n float) float { n }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(3.14159265359, example:'Echo'(3.14159265359)).
 
 eval_with_function_taking_an_int_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(42, example:'Echo'(42)).
 
 eval_with_function_taking_a_string_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(s string) string { s }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(s string) string { s }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"Hello">>}, example:'Echo'({string, <<"Hello">>})).
@@ -155,45 +171,70 @@ eval_with_function_taking_a_string_and_returning_it_test() ->
 %% Type checking return values
 
 eval_with_function_having_unmatched_return_types_test() ->
-    RufusText = "
-    module example
-    func Number() float { 42 }
-    ",
-    Data = #{expr => {int_lit, #{line => 3,
-                                 spec => 42,
-                                 type => {type, #{line => 3,
-                                                  source => inferred,
-                                                  spec => int}}}},
-             return_type => {type, #{line => 3,
-                                     source => rufus_text,
-                                     spec => float}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() float { 42 }\n"
+        "    ",
+    Data = #{
+        expr =>
+            {int_lit, #{
+                line => 3,
+                spec => 42,
+                type =>
+                    {type, #{
+                        line => 3,
+                        source => inferred,
+                        spec => int
+                    }}
+            }},
+        return_type =>
+            {type, #{
+                line => 3,
+                source => rufus_text,
+                spec => float
+            }}
+    },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_compile:eval(RufusText)).
 
 %% Arity-1 functions taking and returning an argument with a mismatched return
 %% type
 
 eval_with_function_taking_a_bool_and_returning_it_with_a_mismatched_return_type_test() ->
-    RufusText = "
-    module example
-    func MismatchedReturnType(b bool) int { b }
-    ",
-    Data = #{expr => {identifier, #{line => 3,
-                                    spec => b,
-                                    type => {type, #{line => 3,
-                                                     source => rufus_text,
-                                                     spec => bool}}}},
-             return_type => {type, #{line => 3,
-                                     source => rufus_text,
-                                     spec => int}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MismatchedReturnType(b bool) int { b }\n"
+        "    ",
+    Data = #{
+        expr =>
+            {identifier, #{
+                line => 3,
+                spec => b,
+                type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => bool
+                    }}
+            }},
+        return_type =>
+            {type, #{
+                line => 3,
+                source => rufus_text,
+                spec => int
+            }}
+    },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_compile:eval(RufusText)).
 
 %% Function exports
 
 eval_with_private_function_test() ->
-    RufusText = "
-    module example
-    func echo(s string) string { s }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func echo(s string) string { s }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertError(undef, example:echo({string, <<"Hello">>})).
@@ -201,66 +242,73 @@ eval_with_private_function_test() ->
 %% Functions with parameter patterns containing literal values
 
 eval_with_function_taking_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(:ok) atom { :ok }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(:ok) atom { :ok }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(ok, example:'Echo'(ok)).
 
 eval_with_function_taking_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(true) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(true) bool { true }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(true, example:'Echo'(true)).
 
 eval_with_function_taking_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1.0) float { 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1.0) float { 1.0 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(1.0, example:'Echo'(1.0)).
 
 eval_with_function_taking_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1) int { 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1) int { 1 }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(1, example:'Echo'(1)).
 
 eval_with_function_taking_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(\"ok\") string { \"ok\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(\"ok\") string { \"ok\" }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual({string, <<"ok">>}, example:'Echo'({string, <<"ok">>})).
 
 eval_with_function_taking_an_atom_literal_in_multiple_function_heads_test() ->
-    RufusText = "
-    module example
-    func Echo(:alright) atom { :alright }
-    func Echo(:ok) atom { :ok }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(:alright) atom { :alright }\n"
+        "    func Echo(:ok) atom { :ok }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual(alright, example:'Echo'(alright)),
     ?assertEqual(ok, example:'Echo'(ok)).
 
 eval_with_function_taking_an_atom_literal_and_passing_an_invalid_value_test() ->
-    RufusText = "
-    module example
-    func Echo(:ok) atom { :ok }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(:ok) atom { :ok }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertError(function_clause, example:'Echo'(fine)).

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -3,107 +3,117 @@
 -include_lib("eunit/include/eunit.hrl").
 
 eval_for_function_returning_an_empty_list_test() ->
-    RufusText = "
-    module example
-    func Empty() list[int] { list[int]{} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Empty() list[int] { list[int]{} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([], example:'Empty'()).
 
 eval_for_function_returning_a_list_with_a_single_element_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{7} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{7} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([7], example:'Numbers'()).
 
 eval_for_function_returning_a_list_with_two_elements_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{7, 918} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{7, 918} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([7, 918], example:'Numbers'()).
 
 eval_for_function_returning_a_list_of_lists_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[list[int]] {
-        list[list[int]]{
-            list[int]{7},
-            list[int]{918, 23},
-        }
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[list[int]] {\n"
+        "        list[list[int]]{\n"
+        "            list[int]{7},\n"
+        "            list[int]{918, 23},\n"
+        "        }\n"
+        "    }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([[7], [918, 23]], example:'Numbers'()).
 
 eval_for_function_returning_a_list_with_expressions_as_elements_test() ->
-    RufusText = "
-    module example
-    func Three() int { 3 }
-    func Numbers() list[int] {
-        list[int]{
-            3 + 4,
-            5 = 5,
-            Three(),
-        }
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Three() int { 3 }\n"
+        "    func Numbers() list[int] {\n"
+        "        list[int]{\n"
+        "            3 + 4,\n"
+        "            5 = 5,\n"
+        "            Three(),\n"
+        "        }\n"
+        "    }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([7, 5, 3], example:'Numbers'()).
 
 eval_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2}} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2], example:'Numbers'()).
 
 eval_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2, 3, 4], example:'Numbers'()).
 
 eval_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] {
-        head = 1
-        tail = list[int]{2, 3, 4}
-        list[int]{head|tail}
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] {\n"
+        "        head = 1\n"
+        "        tail = list[int]{2, 3, 4}\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2, 3, 4], example:'Numbers'()).
 
 eval_for_function_taking_a_list_lit_form_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(numbers list[int]) list[int] { numbers }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(numbers list[int]) list[int] { numbers }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2, 3, 4], example:'Echo'([1, 2, 3, 4])).
 
 eval_for_function_that_prepends_a_number_to_a_list_test() ->
-    RufusText = "
-    module example
-    func Prepend(n int, numbers list[int]) list[int] { list[int]{n|numbers} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Prepend(n int, numbers list[int]) list[int] { list[int]{n|numbers} }\n"
+        "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([1, 2, 3, 4], example:'Prepend'(1, [2, 3, 4])).

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -3,465 +3,891 @@
 -include_lib("eunit/include/eunit.hrl").
 
 eval_a_function_with_a_match_that_binds_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() atom {
-        response = :pong
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() atom {\n"
+        "        response = :pong\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(pong, example:'Ping'()).
 
 eval_a_function_with_a_match_that_binds_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool {
-        response = true
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool {\n"
+        "        response = true\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(true, example:'Truthy'()).
 
 eval_a_function_with_a_match_that_binds_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Pi() float {
-        response = 3.14159265359
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float {\n"
+        "        response = 3.14159265359\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(3.14159265359, example:'Pi'()).
 
 eval_a_function_with_a_match_that_binds_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int {
-        response = 42
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int {\n"
+        "        response = 42\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(42, example:'FortyTwo'()).
 
 eval_a_function_with_a_match_that_binds_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Greeting() string {
-        response = \"hello\"
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Greeting() string {\n"
+        "        response = \"hello\"\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"hello">>}, example:'Greeting'()).
 
 %% match expressions involving binary_op expressions
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_test() ->
-    RufusText = "
-    module example
-    func Random() int {
-        n = 3
-        1 + 2 = n
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int {\n"
+        "        n = 3\n"
+        "        1 + 2 = n\n"
+        "    }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(3, example:'Random'()).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_test() ->
-    RufusText = "
-    module example
-    func Random() int { n = 1 + 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int { n = 1 + 2 }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(3, example:'Random'()).
 
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_operands_test() ->
-    RufusText = "
-    module example
-    func Random() int { 1 + 2 = 2 + 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int { 1 + 2 = 2 + 1 }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(3, example:'Random'()).
 
 %% match expressions involving function calls
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { n = Two() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { n = Two() }\n"
+        "    ",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(2, example:'Random'()).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { Two() = 2 }
-    ",
-    Data = #{form => {match, #{left => {call, #{args => [],
-                                                line => 4,
-                                                spec => 'Two',
-                                                type => {type, #{line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => int}}}},
-                               line => 4,
-                               right => {int_lit, #{line => 4,
-                                                    spec => 2,
-                                                    type => {type, #{line => 4,
-                                                                     source => inferred,
-                                                                     spec => int}}}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {call, #{args => [],
-                                                                                     line => 4,
-                                                                                     spec => 'Two'}},
-                                                                    line => 4,
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 2,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { Two() = 2 }\n"
+        "    ",
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two',
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }},
+                line => 4,
+                right =>
+                    {int_lit, #{
+                        line => 4,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 4,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int {
-        n = 3
-        1 + Two() = n
-    }
-    ",
-    Data = #{form => {match, #{left => {binary_op, #{left => {int_lit, #{line => 6,
-                                                                         spec => 1,
-                                                                         type => {type, #{line => 6,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}},
-                                                     line => 6,
-                                                     op => '+',
-                                                     right => {call, #{args => [],
-                                                                       line => 6,
-                                                                       spec => 'Two',
-                                                                       type => {type, #{line => 3,
-                                                                                        source => rufus_text,
-                                                                                        spec => int}}}},
-                                                     type => {type, #{line => 6,
-                                                                      source => inferred,
-                                                                      spec => int}}}},
-                               line => 6,
-                               right => {identifier, #{line => 6,
-                                                       spec => n}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 5,
-                                                                                           spec => n}},
-                                                                    line => 5,
-                                                                    right => {int_lit, #{line => 5,
-                                                                                         spec => 3,
-                                                                                         type =>
-                                                                                             {type, #{line => 5,
-                                                                                                      source => inferred,
-                                                                                                      spec => int}}}}}},
-                                                          {match, #{left => {binary_op, #{left => {int_lit, #{line => 6,
-                                                                                                              spec => 1,
-                                                                                                              type =>
-                                                                                                                  {type, #{line => 6,
-                                                                                                                           source => inferred,
-                                                                                                                           spec => int}}}},
-                                                                                          line => 6,
-                                                                                          op => '+',
-                                                                                          right => {call, #{args => [],
-                                                                                                            line => 6,
-                                                                                                            spec => 'Two'}}}},
-                                                                    line => 6,
-                                                                    right => {identifier, #{line => 6,
-                                                                                            spec => n}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{n => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => int}}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int {\n"
+        "        n = 3\n"
+        "        1 + Two() = n\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {binary_op, #{
+                        left =>
+                            {int_lit, #{
+                                line => 6,
+                                spec => 1,
+                                type =>
+                                    {type, #{
+                                        line => 6,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                        line => 6,
+                        op => '+',
+                        right =>
+                            {call, #{
+                                args => [],
+                                line => 6,
+                                spec => 'Two',
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            }},
+                        type =>
+                            {type, #{
+                                line => 6,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 6,
+                right =>
+                    {identifier, #{
+                        line => 6,
+                        spec => n
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => n
+                                }},
+                            line => 5,
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {binary_op, #{
+                                    left =>
+                                        {int_lit, #{
+                                            line => 6,
+                                            spec => 1,
+                                            type =>
+                                                {type, #{
+                                                    line => 6,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                    line => 6,
+                                    op => '+',
+                                    right =>
+                                        {call, #{
+                                            args => [],
+                                            line => 6,
+                                            spec => 'Two'
+                                        }}
+                                }},
+                            line => 6,
+                            right =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => n
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{
+            n =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => int
+                }}
+        }
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { Two() = Two() }
-    ",
-    Data = #{form => {match, #{left => {call, #{args => [],
-                                                line => 4,
-                                                spec => 'Two',
-                                                type => {type, #{line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => int}}}},
-                               line => 4,
-                               right => {call, #{args => [],
-                                                 line => 4,
-                                                 spec => 'Two'}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {call, #{args => [],
-                                                                                     line => 4,
-                                                                                     spec => 'Two'}},
-                                                                    line => 4,
-                                                                    right => {call, #{args => [],
-                                                                                      line => 4,
-                                                                                      spec => 'Two'}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { Two() = Two() }\n"
+        "    ",
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two',
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }},
+                line => 4,
+                right =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two'
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }},
+                            line => 4,
+                            right =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_type_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int {
-        n = \"hello\"
-        n = Two()
-    }
-    ",
-    Data = #{globals => #{'Random' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 5,
-                                                                                           spec => n}},
-                                                                    line => 5,
-                                                                    right => {string_lit, #{line => 5,
-                                                                                            spec => <<"hello">>,
-                                                                                            type => {type, #{line => 5,
-                                                                                                             source => inferred,
-                                                                                                             spec => string}}}}}},
-                                                          {match, #{left => {identifier, #{line => 6,
-                                                                                           spec => n}},
-                                                                    line => 6,
-                                                                    right => {call, #{args => [],
-                                                                                      line => 6,
-                                                                                      spec => 'Two'}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             left => {identifier, #{line => 6,
-                                    spec => n,
-                                    type => {type, #{line => 5,
-                                                     source => inferred,
-                                                     spec => string}}}},
-             locals => #{n => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => string}}},
-             right => {call, #{args => [],
-                               line => 6,
-                               spec => 'Two',
-                               type => {type, #{line => 3,
-                                                source => rufus_text,
-                                                spec => int}}}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int {\n"
+        "        n = \"hello\"\n"
+        "        n = Two()\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => n
+                                }},
+                            line => 5,
+                            right =>
+                                {string_lit, #{
+                                    line => 5,
+                                    spec => <<"hello">>,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => string
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => n
+                                }},
+                            line => 6,
+                            right =>
+                                {call, #{
+                                    args => [],
+                                    line => 6,
+                                    spec => 'Two'
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 6,
+                spec => n,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => string
+                    }}
+            }},
+        locals => #{
+            n =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => string
+                }}
+        },
+        right =>
+            {call, #{
+                args => [],
+                line => 6,
+                spec => 'Two',
+                type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => int
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_types, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_arg_type_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    func Random() int {
-        2 = Echo(:two)
-    }
-    ",
-    Data = #{args => [{atom_lit, #{line => 5,
-                                   spec => two,
-                                   type => {type, #{line => 5,
-                                                    source => inferred,
-                                                    spec => atom}}}}],
-             funcs => [{func, #{exprs => [{identifier, #{line => 3,
-                                                         spec => n}}],
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Random() int {\n"
+        "        2 = Echo(:two)\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        args => [
+            {atom_lit, #{
+                line => 5,
+                spec => two,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => atom
+                    }}
+            }}
+        ],
+        funcs => [
+            {func, #{
+                exprs => [
+                    {identifier, #{
+                        line => 3,
+                        spec => n
+                    }}
+                ],
+                line => 3,
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => n,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                params => [{param, #{line => 3,
-                                                     spec => n,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => int}}}}],
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => int}},
-                                spec => 'Echo'}}]},
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }}
+                ],
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => int
+                    }},
+                spec => 'Echo'
+            }}
+        ]
+    },
     ?assertEqual({error, unmatched_args, Data}, rufus_compile:eval(RufusText)).
 
 %% match expressions with type constraint violations
 
 typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        value = 1
-        value = unbound
-    }
-    ",
-    Data = #{form => {identifier, #{line => 5,
-                                    locals => #{value => {type, #{line => 4,
-                                                                  source => inferred,
-                                                                  spec => int}}},
-                                    spec => unbound}},
-             globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => value}},
-                                                                    line => 4,
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 1,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}},
-                                                          {match, #{left => {identifier, #{line => 5,
-                                                                                           spec => value}},
-                                                                    line => 5,
-                                                                    right => {identifier, #{line => 5,
-                                                                                            spec => unbound}}}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             locals => #{value => {type, #{line => 4,
-                                           source => inferred,
-                                           spec => int}}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        value = 1\n"
+        "        value = unbound\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        form =>
+            {identifier, #{
+                line => 5,
+                locals => #{
+                    value =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                },
+                spec => unbound
+            }},
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => value
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => value
+                                }},
+                            line => 5,
+                            right =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => unbound
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        locals => #{
+            value =>
+                {type, #{
+                    line => 4,
+                    source => inferred,
+                    spec => int
+                }}
+        }
+    },
     ?assertEqual({error, unbound_variable, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        unbound1 = unbound2
-    }
-    ",
-    Data = #{globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => unbound1}},
-                                                                    line => 4,
-                                                                    right => {identifier, #{line => 4,
-                                                                                            spec => unbound2}}}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             left => {identifier, #{line => 4,
-                                    locals => #{},
-                                    spec => unbound1}},
-             locals => #{},
-             right => {identifier, #{line => 4,
-                                     locals => #{},
-                                     spec => unbound2}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        unbound1 = unbound2\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => unbound1
+                                }},
+                            line => 4,
+                            right =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => unbound2
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 4,
+                locals => #{},
+                spec => unbound1
+            }},
+        locals => #{},
+        right =>
+            {identifier, #{
+                line => 4,
+                locals => #{},
+                spec => unbound2
+            }}
+    },
     ?assertEqual({error, unbound_variables, Data}, rufus_compile:eval(RufusText)).
 
 typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        a = :hello
-        i = 42
-        a = i
-        i
-    }
-    ",
-    Data = #{globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => a}},
-                                                                    line => 4,
-                                                                    right => {atom_lit, #{line => 4,
-                                                                                          spec => hello,
-                                                                                          type => {type, #{line => 4,
-                                                                                                           source => inferred,
-                                                                                                           spec => atom}}}}}},
-                                                          {match, #{left => {identifier, #{line => 5,
-                                                                                           spec => i}},
-                                                                    line => 5,
-                                                                    right => {int_lit, #{line => 5,
-                                                                                         spec => 42,
-                                                                                         type => {type, #{line => 5,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}},
-                                                          {match, #{left => {identifier, #{line => 6,
-                                                                                           spec => a}},
-                                                                    line => 6,
-                                                                    right => {identifier, #{line => 6,
-                                                                                            spec => i}}}},
-                                                          {identifier, #{line => 7,
-                                                                         spec => i}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             left => {identifier, #{line => 6,
-                                    spec => a,
-                                    type => {type, #{line => 4,
-                                                     source => inferred,
-                                                     spec => atom}}}},
-             locals => #{a => {type, #{line => 4,
-                                       source => inferred,
-                                       spec => atom}},
-                         i => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => int}}},
-             right => {identifier, #{line => 6,
-                                     spec => i,
-                                     type => {type, #{line => 5,
-                                                      source => inferred,
-                                                      spec => int}}}}},
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        a = :hello\n"
+        "        i = 42\n"
+        "        a = i\n"
+        "        i\n"
+        "    }\n"
+        "    ",
+    Data = #{
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => a
+                                }},
+                            line => 4,
+                            right =>
+                                {atom_lit, #{
+                                    line => 4,
+                                    spec => hello,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => atom
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => i
+                                }},
+                            line => 5,
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 42,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => a
+                                }},
+                            line => 6,
+                            right =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => i
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 7,
+                            spec => i
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 6,
+                spec => a,
+                type =>
+                    {type, #{
+                        line => 4,
+                        source => inferred,
+                        spec => atom
+                    }}
+            }},
+        locals => #{
+            a =>
+                {type, #{
+                    line => 4,
+                    source => inferred,
+                    spec => atom
+                }},
+            i =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => int
+                }}
+        },
+        right =>
+            {identifier, #{
+                line => 6,
+                spec => i,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => int
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_types, Data}, rufus_compile:eval(RufusText)).

--- a/rf/test/rufus_erlang_binary_op_test.erl
+++ b/rf/test/rufus_erlang_binary_op_test.erl
@@ -5,10 +5,11 @@
 %% Arity-0 functions returning a sum of literal values for scalar types
 
 forms_for_function_returning_a_sum_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 19 + 23 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 19 + 23 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -21,10 +22,11 @@ forms_for_function_returning_a_sum_of_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_sum_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func FiftyNine() int { 19 + 23 + 17 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FiftyNine() int { 19 + 23 + 17 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -39,10 +41,11 @@ forms_for_function_returning_a_sum_of_three_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_sum_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 1.0 + 2.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 1.0 + 2.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -57,10 +60,11 @@ forms_for_function_returning_a_sum_of_float_literals_test() ->
 %% Arity-0 functions returning a difference of literal values for scalar types
 
 forms_for_function_returning_a_difference_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 55 - 13 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 55 - 13 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -73,10 +77,11 @@ forms_for_function_returning_a_difference_of_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_difference_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func ThirteenThirtyFive() int { 1500 - 150 - 15 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func ThirteenThirtyFive() int { 1500 - 150 - 15 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -91,10 +96,11 @@ forms_for_function_returning_a_difference_of_three_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_difference_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 4.14159265359 - 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 4.14159265359 - 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -109,10 +115,11 @@ forms_for_function_returning_a_difference_of_float_literals_test() ->
 %% Arity-0 functions returning a product of literal values for scalar types
 
 forms_for_function_returning_a_product_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 3 * 14 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 3 * 14 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -125,10 +132,11 @@ forms_for_function_returning_a_product_of_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_product_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func ThirteenThirtyFive() int { 3 * 5 * 89 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func ThirteenThirtyFive() int { 3 * 5 * 89 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -143,10 +151,11 @@ forms_for_function_returning_a_product_of_three_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_product_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 1.0 * 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 1.0 * 3.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -161,10 +170,11 @@ forms_for_function_returning_a_product_of_float_literals_test() ->
 %% Arity-0 functions returning a division of literal values for scalar types
 
 forms_for_function_returning_a_division_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 84 / 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 84 / 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -177,10 +187,11 @@ forms_for_function_returning_a_division_of_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_division_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func Five() int { 100 / 10 / 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Five() int { 100 / 10 / 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -195,10 +206,11 @@ forms_for_function_returning_a_division_of_three_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_division_of_float_literals_test() ->
-    RufusText = "
-    module example
-    func TwoPointSevenFive() float { 5.5 / 2.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func TwoPointSevenFive() float { 5.5 / 2.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -213,10 +225,11 @@ forms_for_function_returning_a_division_of_float_literals_test() ->
 %% Arity-0 functions returning a remainder after dividing literal values
 
 forms_for_function_returning_a_remainder_of_int_literals_test() ->
-    RufusText = "
-    module example
-    func Six() int { 27 % 7 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Six() int { 27 % 7 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -229,10 +242,11 @@ forms_for_function_returning_a_remainder_of_int_literals_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_remainder_of_three_int_literals_test() ->
-    RufusText = "
-    module example
-    func Four() int { 100 % 13 % 5 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Four() int { 100 % 13 % 5 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -249,10 +263,11 @@ forms_for_function_returning_a_remainder_of_three_int_literals_test() ->
 %% Arity-0 functions returning the result of a boolean operation
 
 forms_for_function_returning_a_boolean_from_an_and_operation_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { true and false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { true and false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -265,15 +280,16 @@ forms_for_function_returning_a_boolean_from_an_and_operation_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_boolean_from_an_and_operation_with_a_call_operand_test() ->
-    RufusText = "
-    module example
-    func False() bool { false }
-    func Falsy() bool { true and False() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func False() bool { false }\n"
+        "    func Falsy() bool { true and False() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
-    BinaryOpExpr = {op, 4, 'andalso',  {atom, 4, true}, {call, 4, {atom, 4, 'False'}, []}},
+    BinaryOpExpr = {op, 4, 'andalso', {atom, 4, true}, {call, 4, {atom, 4, 'False'}, []}},
     Expected = [
         {attribute, 2, module, example},
         {attribute, 4, export, [{'Falsy', 0}]},
@@ -284,10 +300,11 @@ forms_for_function_returning_a_boolean_from_an_and_operation_with_a_call_operand
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_boolean_from_an_or_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { true or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { true or false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -300,11 +317,12 @@ forms_for_function_returning_a_boolean_from_an_or_operation_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_boolean_from_an_or_operation_with_a_call_test() ->
-    RufusText = "
-    module example
-    func True() bool { true }
-    func Truthy() bool { True() or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func True() bool { true }\n"
+        "    func Truthy() bool { True() or false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -320,10 +338,11 @@ forms_for_function_returning_a_boolean_from_an_or_operation_with_a_call_test() -
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { true and true or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { true and true or false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -340,91 +359,109 @@ forms_for_function_returning_a_boolean_from_a_nested_boolean_operation_test() ->
 %% Comparison operators
 
 forms_for_function_with_an_equality_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { :truth == :truth }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { :truth == :truth }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=:=', {atom, 3, truth}, {atom, 3, truth}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '=:=', {atom, 3, truth}, {atom, 3, truth}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_an_inequality_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { :truth != :fiction }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { :truth != :fiction }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=/=', {atom, 3, truth}, {atom, 3, fiction}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '=/=', {atom, 3, truth}, {atom, 3, fiction}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_less_than_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 1 < 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 1 < 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '<', {integer, 3, 1}, {integer, 3, 2}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '<', {integer, 3, 1}, {integer, 3, 2}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_less_than_or_equal_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 1 <= 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 1 <= 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '=<', {integer, 3, 1}, {integer, 3, 2}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '=<', {integer, 3, 1}, {integer, 3, 2}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_greater_than_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 2 > 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 2 > 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '>', {integer, 3, 2}, {integer, 3, 1}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '>', {integer, 3, 2}, {integer, 3, 1}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_greater_than_or_equal_comparison_operation_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool { 2 >= 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool { 2 >= 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
-        {function, 3, 'Truthy', 0,  [{clause, 3, [], [],  [{op, 3, '>=', {integer, 3, 2}, {integer, 3, 1}}]}]}
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [{op, 3, '>=', {integer, 3, 2}, {integer, 3, 1}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_call_test.erl
+++ b/rf/test/rufus_erlang_call_test.erl
@@ -5,11 +5,12 @@
 %% Arity-0 functions being called
 
 forms_for_function_call_test() ->
-    RufusText = "
-    module example
-    func Four() int { 4 }
-    func Random() int { Four() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Four() int { 4 }\n"
+        "    func Random() int { Four() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -26,11 +27,12 @@ forms_for_function_call_test() ->
 %% Arity-1 functions being called
 
 forms_for_function_call_with_an_atom_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(a atom) atom { a }
-    func Random() atom { Echo(:hello) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(a atom) atom { a }\n"
+        "    func Random() atom { Echo(:hello) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -39,19 +41,26 @@ forms_for_function_call_with_an_atom_argument_test() ->
         {attribute, 2, module, example},
         {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1, [{clause, 3, [{var, 3, a}], [
-                [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, a}]}]
-            ], [{var, 3, a}]}]},
-        {function, 4, 'Random', 0, [{clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{atom, 4, hello}]}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, a}],
+                [
+                    [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, a}]}]
+                ],
+                [{var, 3, a}]}
+        ]},
+        {function, 4, 'Random', 0, [
+            {clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{atom, 4, hello}]}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_call_with_a_bool_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(b bool) bool { b }
-    func Random() bool { Echo(true) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    func Random() bool { Echo(true) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -61,64 +70,31 @@ forms_for_function_call_with_a_bool_argument_test() ->
         {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Echo', 1}]},
         {function, 3, 'Echo', 1, [
-            {clause, 3, [{var, 3, b}], [
-                [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+            {clause, 3, [{var, 3, b}],
+                [
+                    [
+                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [
+                            {var, 3, b}
+                        ]}
+                    ]
+                ],
                 [{var, 3, b}]}
-            ]},
+        ]},
         {function, 4, 'Random', 0, [
             {clause, 4, [], [], [
-                {call, 4, {atom, 4, 'Echo'}, [{atom, 4, true}]}]}]}
+                {call, 4, {atom, 4, 'Echo'}, [{atom, 4, true}]}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_call_with_a_float_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n float) float { n }
-    func Random() float { Echo(4.0) }
-    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [
-        {attribute, 2, module, example},
-        {attribute, 4, export, [{'Random', 0}]},
-        {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1, [{clause, 3, [{var, 3, n}], [
-                [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]
-            ], [{var, 3, n}]}]},
-        {function, 4, 'Random', 0, [{clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{float, 4, 4.0}]}]}]}
-    ],
-    ?assertEqual(Expected, ErlangForms).
-
-forms_for_function_call_with_an_int_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    func Random() int { Echo(4) }
-    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [
-        {attribute, 2, module, example},
-        {attribute, 4, export, [{'Random', 0}]},
-        {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1, [{clause, 3, [{var, 3, n}], [
-                [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]
-            ], [{var, 3, n}]}]},
-        {function, 4, 'Random', 0, [{clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{integer, 4, 4}]}]}]}
-    ],
-    ?assertEqual(Expected, ErlangForms).
-
-forms_for_function_call_with_a_string_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(t string) string { t }
-    func Random() string { Echo(\"hello\") }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n float) float { n }\n"
+        "    func Random() float { Echo(4.0) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -128,22 +104,92 @@ forms_for_function_call_with_a_string_argument_test() ->
         {attribute, 4, export, [{'Random', 0}]},
         {attribute, 3, export, [{'Echo', 1}]},
         {function, 3, 'Echo', 1, [
-                {clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, t}]}], [], [{tuple, 3, [{atom, 3, string}, {var, 3, t}]}]}
-            ]},
+            {clause, 3, [{var, 3, n}],
+                [
+                    [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]
+                ],
+                [{var, 3, n}]}
+        ]},
         {function, 4, 'Random', 0, [
-                {clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{tuple, 4, [{atom, 4, string}, {bin, 4, [{bin_element, 4, {string, 4, "hello"}, default, default}]}]}]}]}
+            {clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{float, 4, 4.0}]}]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_call_with_an_int_argument_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Random() int { Echo(4) }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 4, export, [{'Random', 0}]},
+        {attribute, 3, export, [{'Echo', 1}]},
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, n}],
+                [
+                    [
+                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [
+                            {var, 3, n}
+                        ]}
+                    ]
+                ],
+                [{var, 3, n}]}
+        ]},
+        {function, 4, 'Random', 0, [
+            {clause, 4, [], [], [{call, 4, {atom, 4, 'Echo'}, [{integer, 4, 4}]}]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_call_with_a_string_argument_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(t string) string { t }\n"
+        "    func Random() string { Echo(\"hello\") }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 4, export, [{'Random', 0}]},
+        {attribute, 3, export, [{'Echo', 1}]},
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, t}]}], [], [
+                {tuple, 3, [{atom, 3, string}, {var, 3, t}]}
             ]}
+        ]},
+        {function, 4, 'Random', 0, [
+            {clause, 4, [], [], [
+                {call, 4, {atom, 4, 'Echo'}, [
+                    {tuple, 4, [
+                        {atom, 4, string},
+                        {bin, 4, [{bin_element, 4, {string, 4, "hello"}, default, default}]}
+                    ]}
+                ]}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 %% Arity-2 functions being called
 
 forms_for_function_call_with_two_int_arguments_test() ->
-    RufusText = "
-    module example
-    func Sum(m int, n int) int { m + n }
-    func Random() int { Sum(1, 2) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Sum(m int, n int) int { m + n }\n"
+        "    func Random() int { Sum(1, 2) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -152,28 +198,35 @@ forms_for_function_call_with_two_int_arguments_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Sum', 2}]},
         {attribute, 4, export, [{'Random', 0}]},
-        {function, 4, 'Random', 0,
-            [{clause, 4,
-                 [],
-                 [],
-                 [{call, 4, {atom, 4, 'Sum'}, [{integer, 4, 1}, {integer, 4, 2}]}]}]
-        },
-        {function, 3, 'Sum', 2,
-            [{clause, 3,
-                 [{var, 3, m}, {var, 3, n}],
-                 [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}],
-                  [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, m}]}]],
-                 [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}]
-        }
+        {function, 4, 'Random', 0, [
+            {clause, 4, [], [], [{call, 4, {atom, 4, 'Sum'}, [{integer, 4, 1}, {integer, 4, 2}]}]}
+        ]},
+        {function, 3, 'Sum', 2, [
+            {clause, 3, [{var, 3, m}, {var, 3, n}],
+                [
+                    [
+                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [
+                            {var, 3, n}
+                        ]}
+                    ],
+                    [
+                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [
+                            {var, 3, m}
+                        ]}
+                    ]
+                ],
+                [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_call_with_two_float_arguments_test() ->
-    RufusText = "
-    module example
-    func Sum(m float, n float) float { m + n }
-    func Random() float { Sum(1.2, 2.3) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Sum(m float, n float) float { m + n }\n"
+        "    func Random() float { Sum(1.2, 2.3) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -182,18 +235,16 @@ forms_for_function_call_with_two_float_arguments_test() ->
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Sum', 2}]},
         {attribute, 4, export, [{'Random', 0}]},
-        {function, 4, 'Random', 0,
-            [{clause, 4,
-                 [],
-                 [],
-                 [{call, 4, {atom, 4, 'Sum'}, [{float, 4, 1.2}, {float, 4, 2.3}]}]}]
-        },
-        {function, 3, 'Sum', 2,
-            [{clause, 3,
-                 [{var, 3, m}, {var, 3, n}],
-                 [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}],
-                  [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, m}]}]],
-                 [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}]
-        }
+        {function, 4, 'Random', 0, [
+            {clause, 4, [], [], [{call, 4, {atom, 4, 'Sum'}, [{float, 4, 1.2}, {float, 4, 2.3}]}]}
+        ]},
+        {function, 3, 'Sum', 2, [
+            {clause, 3, [{var, 3, m}, {var, 3, n}],
+                [
+                    [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}],
+                    [{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, m}]}]
+                ],
+                [{op, 3, '+', {var, 3, m}, {var, 3, n}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -5,10 +5,11 @@
 %% Arity-0 functions returning a literal value for scalar types
 
 forms_for_function_returning_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() atom { :pong }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() atom { :pong }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -21,10 +22,11 @@ forms_for_function_returning_an_atom_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func False() bool { false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func False() bool { false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -36,10 +38,11 @@ forms_for_function_returning_a_bool_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 3.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -51,10 +54,11 @@ forms_for_function_returning_a_float_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func Number() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -66,10 +70,11 @@ forms_for_function_returning_an_int_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Greeting() string { \"Hello\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Greeting() string { \"Hello\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -85,13 +90,14 @@ forms_for_function_returning_a_string_literal_test() ->
 %% Arity-0 functions with multiple function expressions
 
 forms_for_function_with_multiple_expressions_test() ->
-    RufusText = "
-    module example
-    func Multiple() atom {
-        42;
-        :fortytwo;
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Multiple() atom {\n"
+        "        42;\n"
+        "        :fortytwo;\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -104,14 +110,15 @@ forms_for_function_with_multiple_expressions_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
-    RufusText = "
-    module example
-    func Multiple() atom {
-        42;
-
-        :fortytwo;
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Multiple() atom {\n"
+        "        42;\n"
+        "\n"
+        "        :fortytwo;\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -126,10 +133,11 @@ forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
 %% Arity-1 functions taking an unused argument
 
 forms_for_function_taking_an_unused_atom_and_returning_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping(m atom) atom { :pong }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping(m atom) atom { :pong }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -138,16 +146,19 @@ forms_for_function_taking_an_unused_atom_and_returning_an_atom_literal_test() ->
         {attribute, 3, export, [{'Ping', 1}]},
         {function, 3, 'Ping', 1, [
             {clause, 3, [{var, 3, m}],
-                        [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, m}]}]],
-                        [{atom, 3, pong}]}]}
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, m}]}]], [
+                    {atom, 3, pong}
+                ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_unused_bool_and_returning_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(b bool) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(b bool) bool { true }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -155,18 +166,20 @@ forms_for_function_taking_an_unused_bool_and_returning_a_bool_literal_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
-        {function, 3, 'MaybeEcho', 1,
-            [{clause, 3, [{var, 3, b}],
-                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
-                         [{atom, 3, true}]}]}
+        {function, 3, 'MaybeEcho', 1, [
+            {clause, 3, [{var, 3, b}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+                [{atom, 3, true}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_unused_float_and_returning_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n float) float { 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n float) float { 3.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -175,34 +188,39 @@ forms_for_function_taking_an_unused_float_and_returning_a_float_literal_test() -
         {attribute, 3, export, [{'MaybeEcho', 1}]},
         {function, 3, 'MaybeEcho', 1, [
             {clause, 3, [{var, 3, n}],
-                        [[{call,3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]],
-                        [{float, 3, 3.14159265359}]}]}
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]], [
+                    {float, 3, 3.14159265359}
+                ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_unused_int_and_returning_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n int) int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n int) int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
-        {function, 3, 'MaybeEcho', 1,
-            [{clause, 3, [{var, 3, n}],
-                         [[{call,3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
-                         [{integer, 3, 42}]}]}
+        {function, 3, 'MaybeEcho', 1, [
+            {clause, 3, [{var, 3, n}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
+                [{integer, 3, 42}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_unused_string_and_returning_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(s string) string { \"Hello\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(s string) string { \"Hello\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -210,20 +228,22 @@ forms_for_function_taking_an_unused_string_and_returning_a_string_literal_test()
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
-        {function, 3, 'MaybeEcho', 1,
-            [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
-                         [],
-                         [{tuple, 3, [{atom, 3, string}, {bin, 3, [StringExpr]}]}]}]}
+        {function, 3, 'MaybeEcho', 1, [
+            {clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}], [], [
+                {tuple, 3, [{atom, 3, string}, {bin, 3, [StringExpr]}]}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 %% Arity-1 functions taking and using an argument
 
 forms_for_function_taking_an_atom_and_returning_an_atom_test() ->
-    RufusText = "
-    module example
-    func Echo(m atom) atom { m }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(m atom) atom { m }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -231,18 +251,21 @@ forms_for_function_taking_an_atom_and_returning_an_atom_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-            [{clause, 3, [{var, 3, m}],
-                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, m}]}]],
-                         [{var, 3, m}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, m}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_atom}}, [{var, 3, m}]}]], [
+                    {var, 3, m}
+                ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
-    RufusText = "
-    module example
-    func Echo(b bool) bool { b }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -250,18 +273,20 @@ forms_for_function_taking_a_bool_and_returning_a_bool_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-            [{clause, 3, [{var, 3, b}],
-                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
-                         [{var, 3, b}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, b}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_boolean}}, [{var, 3, b}]}]],
+                [{var, 3, b}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_float_and_returning_a_float_test() ->
-    RufusText = "
-    module example
-    func Echo(n float) float { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n float) float { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -269,18 +294,21 @@ forms_for_function_taking_a_float_and_returning_a_float_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-            [{clause, 3, [{var, 3, n}],
-                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]],
-                         [{var, 3, n}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, n}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_float}}, [{var, 3, n}]}]], [
+                    {var, 3, n}
+                ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_int_and_returning_an_int_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -288,18 +316,20 @@ forms_for_function_taking_an_int_and_returning_an_int_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-            [{clause, 3, [{var, 3, n}],
-                         [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
-                         [{var, 3, n}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{var, 3, n}],
+                [[{call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [{var, 3, n}]}]],
+                [{var, 3, n}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_string_and_returning_a_string_test() ->
-    RufusText = "
-    module example
-    func Echo(s string) string { s }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(s string) string { s }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -307,40 +337,44 @@ forms_for_function_taking_a_string_and_returning_a_string_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-            [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
-                         [],
-                         [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}], [], [
+                {tuple, 3, [{atom, 3, string}, {var, 3, s}]}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 %% Function exports
 
 forms_for_private_functions_with_leading_lowercase_character_are_not_exported_test() ->
-    RufusText = "
-    module example
-    func echo(s string) string { s }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func echo(s string) string { s }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
-        {function, 3, 'echo', 1,
-            [{clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}],
-                         [],
-                         [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}]}]}
+        {function, 3, 'echo', 1, [
+            {clause, 3, [{tuple, 3, [{atom, 3, string}, {var, 3, s}]}], [], [
+                {tuple, 3, [{atom, 3, string}, {var, 3, s}]}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 %% Functions with parameter patterns containing literal values
 
 forms_for_function_taking_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(:ok) atom { :ok }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(:ok) atom { :ok }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -353,10 +387,11 @@ forms_for_function_taking_an_atom_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(true) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(true) bool { true }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -369,10 +404,11 @@ forms_for_function_taking_a_bool_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1.0) float { 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1.0) float { 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -385,10 +421,11 @@ forms_for_function_taking_a_float_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1) int { 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1) int { 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -401,10 +438,11 @@ forms_for_function_taking_an_int_literal_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(\"ok\") string { \"ok\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(\"ok\") string { \"ok\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -412,9 +450,20 @@ forms_for_function_taking_a_string_literal_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Echo', 1}]},
-        {function, 3, 'Echo', 1,
-         [{clause, 3, [{tuple, 3, [{atom, 3, string}, {bin, 3, [{bin_element, 3, {string, 3, "ok"}, default, default}]}]}],
-           [],
-           [{tuple, 3, [{atom, 3, string}, {bin, 3, [{bin_element, 3, {string, 3, "ok"}, default, default}]}]}]}]}
+        {function, 3, 'Echo', 1, [
+            {clause, 3,
+                [
+                    {tuple, 3, [
+                        {atom, 3, string},
+                        {bin, 3, [{bin_element, 3, {string, 3, "ok"}, default, default}]}
+                    ]}
+                ],
+                [], [
+                    {tuple, 3, [
+                        {atom, 3, string},
+                        {bin, 3, [{bin_element, 3, {string, 3, "ok"}, default, default}]}
+                    ]}
+                ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_list_test.erl
+++ b/rf/test/rufus_erlang_list_test.erl
@@ -3,10 +3,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 forms_for_function_returning_an_empty_list_lit_form_test() ->
-    RufusText = "
-    module example
-    func Empty() list[int] { list[int]{} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Empty() list[int] { list[int]{} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -19,10 +20,11 @@ forms_for_function_returning_an_empty_list_lit_form_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
-    RufusText = "
-    module example
-    func Empty() list[bool] { list[bool]{true} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Empty() list[bool] { list[bool]{true} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -30,16 +32,16 @@ forms_for_function_returning_a_list_lit_form_with_a_single_item_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
-        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {atom, 3, true},
-                                                         {nil, 3}}]}]}
+        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {atom, 3, true}, {nil, 3}}]}]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_list_lit_form_with_two_items_test() ->
-    RufusText = "
-    module example
-    func Empty() list[float] { list[float]{3.1, 4.1} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Empty() list[float] { list[float]{3.1, 4.1} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -47,17 +49,18 @@ forms_for_function_returning_a_list_lit_form_with_two_items_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Empty', 0}]},
-        {function, 3, 'Empty', 0, [{clause, 3, [], [], [{cons, 3, {float, 3, 3.1},
-                                                         {cons, 3, {float, 3, 4.1},
-                                                          {nil, 3}}}]}]}
+        {function, 3, 'Empty', 0, [
+            {clause, 3, [], [], [{cons, 3, {float, 3, 3.1}, {cons, 3, {float, 3, 4.1}, {nil, 3}}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_taking_a_list_lit_form_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(numbers list[int]) list[int] { numbers }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(numbers list[int]) list[int] { numbers }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -70,10 +73,11 @@ forms_for_function_taking_a_list_lit_form_and_returning_it_test() ->
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -81,17 +85,18 @@ forms_for_function_returning_a_cons_literal_with_literal_pair_values_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Numbers', 0}]},
-        {function, 3, 'Numbers', 0, [{clause, 3, [], [], [{cons, 3, {integer, 3, 1},
-                                                           {cons, 3, {integer, 3, 2},
-                                                            {nil, 3}}}]}]}
+        {function, 3, 'Numbers', 0, [
+            {clause, 3, [], [], [{cons, 3, {integer, 3, 1}, {cons, 3, {integer, 3, 2}, {nil, 3}}}]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -99,24 +104,26 @@ forms_for_function_returning_a_cons_literal_with_multiple_literal_pair_values_te
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Numbers', 0}]},
-        {function, 3, 'Numbers', 0, [{clause, 3, [], [],
-                                      [{cons, 3, {integer, 3, 1},
-                                        {cons, 3, {integer, 3, 2},
-                                         {cons, 3, {integer, 3, 3},
-                                          {cons, 3, {integer, 3, 4},
-                                           {nil, 3}}}}}]}]}
+        {function, 3, 'Numbers', 0, [
+            {clause, 3, [], [], [
+                {cons, 3, {integer, 3, 1},
+                    {cons, 3, {integer, 3, 2},
+                        {cons, 3, {integer, 3, 3}, {cons, 3, {integer, 3, 4}, {nil, 3}}}}}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] {
-        head = 1
-        tail = list[int]{2, 3, 4}
-        list[int]{head|tail}
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] {\n"
+        "        head = 1\n"
+        "        tail = list[int]{2, 3, 4}\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
@@ -124,17 +131,14 @@ forms_for_function_returning_a_cons_literal_with_variable_pair_values_test() ->
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Numbers', 0}]},
-        {function, 3, 'Numbers', 0,
-         [{clause, 3, [], [],
-           [{match, 4, {var, 4, head}, {integer, 4, 1}},
-            {match, 5,
-             {var, 5, tail},
-             {cons, 5, {integer, 5, 2},
-              {cons, 5, {integer, 5, 3},
-               {cons, 5, {integer, 5, 4},
-                {nil, 5}}}}},
-            {cons, 6,
-             {var, 6, head},
-             {var, 6, tail}}]}]}
+        {function, 3, 'Numbers', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {var, 4, head}, {integer, 4, 1}},
+                {match, 5, {var, 5, tail},
+                    {cons, 5, {integer, 5, 2},
+                        {cons, 5, {integer, 5, 3}, {cons, 5, {integer, 5, 4}, {nil, 5}}}}},
+                {cons, 6, {var, 6, head}, {var, 6, tail}}
+            ]}
+        ]}
     ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_match_test.erl
+++ b/rf/test/rufus_erlang_match_test.erl
@@ -3,100 +3,130 @@
 -include_lib("eunit/include/eunit.hrl").
 
 forms_for_function_with_a_match_that_binds_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() atom {
-        response = :pong
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() atom {\n"
+        "        response = :pong\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [{attribute, 2, module, example},
-                {attribute, 3, export, [{'Ping', 0}]},
-                {function, 3, 'Ping', 0,
-                 [{clause, 3, [], [], [{match, 4, {var, 4, response}, {atom, 4, pong}},
-                                       {var, 5, response}]}]}],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Ping', 0}]},
+        {function, 3, 'Ping', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {var, 4, response}, {atom, 4, pong}},
+                {var, 5, response}
+            ]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_match_that_binds_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool {
-        response = true
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool {\n"
+        "        response = true\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [{attribute, 2, module, example},
-                  {attribute, 3, export, [{'Truthy', 0}]},
-                  {function, 3, 'Truthy', 0, [
-                      {clause, 3, [], [], [{match, 4, {var, 4, response}, {atom, 4, true}},
-                                           {var, 5, response}]}]}],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Truthy', 0}]},
+        {function, 3, 'Truthy', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {var, 4, response}, {atom, 4, true}},
+                {var, 5, response}
+            ]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_match_that_binds_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Pi() float {
-        response = 3.14159265359
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float {\n"
+        "        response = 3.14159265359\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [{attribute, 2, module, example},
-                  {attribute, 3, export, [{'Pi', 0}]},
-                  {function, 3, 'Pi', 0, [
-                      {clause, 3, [], [], [{match, 4, {var, 4, response},
-                                                      {float, 4, 3.14159265359}},
-                                                      {var, 5, response}]}]}],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Pi', 0}]},
+        {function, 3, 'Pi', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {var, 4, response}, {float, 4, 3.14159265359}},
+                {var, 5, response}
+            ]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_match_that_binds_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int {
-        response = 42
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int {\n"
+        "        response = 42\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [{attribute, 2, module, example},
-                  {attribute, 3, export, [{'FortyTwo', 0}]},
-                  {function, 3, 'FortyTwo', 0, [
-                      {clause, 3, [], [], [{match, 4, {var, 4, response},
-                                                      {integer, 4, 42}},
-                                                      {var, 5, response}]}]}],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'FortyTwo', 0}]},
+        {function, 3, 'FortyTwo', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {var, 4, response}, {integer, 4, 42}},
+                {var, 5, response}
+            ]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_with_a_match_that_binds_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Greeting() string {
-        response = \"hello\"
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Greeting() string {\n"
+        "        response = \"hello\"\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [{attribute, 2, module, example},
-                {attribute, 3, export, [{'Greeting', 0}]},
-                {function, 3, 'Greeting', 0,
-                 [{clause, 3, [], [], [{match, 4, {tuple, 4, [{atom, 4, string}, {var, 4, response}]},
-                                        {tuple, 4, [{atom, 4, string},
-                                                    {bin, 4, [{bin_element, 4, {string, 4, "hello"}, default, default}]}]}},
-                                       {tuple, 5, [{atom, 5, string}, {var, 5, response}]}]}]}],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Greeting', 0}]},
+        {function, 3, 'Greeting', 0, [
+            {clause, 3, [], [], [
+                {match, 4, {tuple, 4, [{atom, 4, string}, {var, 4, response}]},
+                    {tuple, 4, [
+                        {atom, 4, string},
+                        {bin, 4, [{bin_element, 4, {string, 4, "hello"}, default, default}]}
+                    ]}},
+                {tuple, 5, [{atom, 5, string}, {var, 5, response}]}
+            ]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -5,779 +5,1445 @@
 %% Mathematical operators
 
 typecheck_and_annotate_mathematical_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 19 + 23 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 19 + 23 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{params => [],
-                         exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 19,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '+',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 23,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => int}}}}],
-                         line => 3,
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 19,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '+',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 23,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_mathematical_operator_with_floats_test() ->
-    RufusText = "
-    module example
-    func Pi() float { 1.0 + 2.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Pi() float { 1.0 + 2.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{params => [],
-                         exprs => [{binary_op, #{left => {float_lit, #{line => 3,
-                                                                       spec => 1.0,
-                                                                       type => {type, #{line => 3,
-                                                                                        source => inferred,
-                                                                                        spec => float}}}},
-                                                 line => 3,
-                                                 op => '+',
-                                                 right => {float_lit, #{line => 3,
-                                                                        spec => 2.14159265359,
-                                                                        type => {type, #{line => 3,
-                                                                                         source => inferred,
-                                                                                         spec => float}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => float}}}}],
-                         line => 3,
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => float}},
-                         spec => 'Pi'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {float_lit, #{
+                            line => 3,
+                            spec => 1.0,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => float
+                                }}
+                        }},
+                    line => 3,
+                    op => '+',
+                    right =>
+                        {float_lit, #{
+                            line => 3,
+                            spec => 2.14159265359,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => float
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => float
+                }},
+            spec => 'Pi'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_mathematical_operator_with_float_and_int_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 19.0 + 23 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 19.0 + 23 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {float_lit, #{line => 3,
-                                                             spec => 19.0,
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => float}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => '+',
-                                       right => {int_lit, #{line => 3,
-                                                            spec => 23,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => int}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 19.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '+',
+                right =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 23,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }}
+    },
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 typecheck_and_annotate_mathematical_operator_with_float_and_float_and_int_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int { 13.0 + 6.0 + 23 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int { 13.0 + 6.0 + 23 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {binary_op, #{left => {float_lit, #{line => 3,
-                                                                                   spec => 13.0,
-                                                                                   type => {type, #{line => 3,
-                                                                                                    source => inferred,
-                                                                                                    spec => float}}}},
-                                                             line => 3,
-                                                             op => '+',
-                                                             right => {float_lit, #{line => 3,
-                                                                                    spec => 6.0,
-                                                                                    type => {type, #{line => 3,
-                                                                                                     source => inferred,
-                                                                                                     spec => float}}}},
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => float}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => '+',
-                                       right => {int_lit, #{line => 3,
-                                                            spec => 23,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => int}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {binary_op, #{
+                        left =>
+                            {float_lit, #{
+                                line => 3,
+                                spec => 13.0,
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => float
+                                    }}
+                            }},
+                        line => 3,
+                        op => '+',
+                        right =>
+                            {float_lit, #{
+                                line => 3,
+                                spec => 6.0,
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => float
+                                    }}
+                            }},
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '+',
+                right =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 23,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }}
+    },
     {error, unmatched_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 typecheck_and_annotate_mathematical_operator_with_bools_test() ->
-    RufusText = "
-    module example
-    func Concat() bool { true + false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Concat() bool { true + false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {bool_lit, #{line => 3,
-                                                            spec => true,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => bool}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => '+',
-                                       right => {bool_lit, #{line => 3,
-                                                             spec => false,
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => bool}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {bool_lit, #{
+                        line => 3,
+                        spec => true,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => bool
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '+',
+                right =>
+                    {bool_lit, #{
+                        line => 3,
+                        spec => false,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => bool
+                            }}
+                    }}
+            }}
+    },
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 typecheck_and_annotate_mathematical_operator_with_strings_test() ->
-    RufusText = "
-    module example
-    func Concat() string { \"port\" + \"manteau\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Concat() string { \"port\" + \"manteau\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {string_lit, #{line => 3,
-                                                              spec => <<"port">>,
-                                                              type => {type, #{line => 3,
-                                                                               source => inferred,
-                                                                               spec => string}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => '+',
-                                       right => {string_lit, #{line => 3,
-                                                               spec => <<"manteau">>,
-                                                               type => {type, #{line => 3,
-                                                                                source => inferred,
-                                                                                spec => string}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {string_lit, #{
+                        line => 3,
+                        spec => <<"port">>,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => string
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '+',
+                right =>
+                    {string_lit, #{
+                        line => 3,
+                        spec => <<"manteau">>,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => string
+                            }}
+                    }}
+            }}
+    },
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Six() int { 27 % 7 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Six() int { 27 % 7 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{params => [],
-                         exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 27,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '%',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 7,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => int}}}}],
-                         line => 3,
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Six'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 27,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '%',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 7,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Six'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_remainder_mathematical_operator_with_floats_test() ->
-    RufusText = "
-    module example
-    func Six() int { 27.0 % 7.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Six() int { 27.0 % 7.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {float_lit, #{line => 3,
-                                                             spec => 27.0,
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => float}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => '%',
-                                       right => {float_lit, #{line => 3,
-                                                              spec => 7.0,
-                                                              type => {type, #{line => 3,
-                                                                               source => inferred,
-                                                                               spec => float}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 27.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '%',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 7.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 %% Conditional operators
 
 typecheck_and_annotate_conditional_operator_with_bools_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { true and false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { true and false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{params => [],
-                         exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 3,
-                                                 op => 'and',
-                                                 right => {bool_lit, #{line => 3,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 3,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 3,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 3,
+                    op => 'and',
+                    right =>
+                        {bool_lit, #{
+                            line => 3,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { false or true and true }
-    func Truthy() bool { true and true or false }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { false or true and true }\n"
+        "    func Truthy() bool { true and true or false }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 3,
-                                                                      spec => false,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 3,
-                                                 op => 'or',
-                                                 right => {binary_op, #{left => {bool_lit, #{line => 3,
-                                                                                             spec => true,
-                                                                                             type => {type, #{line => 3,
-                                                                                                              source => inferred,
-                                                                                                              spec => bool}}}},
-                                                                        line => 3,
-                                                                        op => 'and',
-                                                                        right => {bool_lit, #{line => 3,
-                                                                                              spec => true,
-                                                                                              type => {type, #{line => 3,
-                                                                                                               source => inferred,
-                                                                                                               spec => bool}}}},
-                                                                        type => {type, #{line => 3,
-                                                                                         source => inferred,
-                                                                                         spec => bool}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}},
-                {func, #{exprs => [{binary_op, #{left => {binary_op, #{left => {bool_lit, #{line => 4,
-                                                                                            spec => true,
-                                                                                            type => {type, #{line => 4,
-                                                                                                             source => inferred,
-                                                                                                             spec => bool}}}},
-                                                                       line => 4,
-                                                                       op => 'and',
-                                                                       right => {bool_lit, #{line => 4,
-                                                                                             spec => true,
-                                                                                             type => {type, #{line => 4,
-                                                                                                              source => inferred,
-                                                                                                              spec => bool}}}},
-                                                                       type => {type, #{line => 4,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}},
-                                                 line => 4,
-                                                 op => 'or',
-                                                 right => {bool_lit, #{line => 4,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 4,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}},
-                                                 type => {type, #{line => 4,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 4,
-                         params => [],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Truthy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 3,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 3,
+                    op => 'or',
+                    right =>
+                        {binary_op, #{
+                            left =>
+                                {bool_lit, #{
+                                    line => 3,
+                                    spec => true,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => bool
+                                        }}
+                                }},
+                            line => 3,
+                            op => 'and',
+                            right =>
+                                {bool_lit, #{
+                                    line => 3,
+                                    spec => true,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => bool
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            left =>
+                                {bool_lit, #{
+                                    line => 4,
+                                    spec => true,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => bool
+                                        }}
+                                }},
+                            line => 4,
+                            op => 'and',
+                            right =>
+                                {bool_lit, #{
+                                    line => 4,
+                                    spec => true,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => bool
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 4,
+                    op => 'or',
+                    right =>
+                        {bool_lit, #{
+                            line => 4,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Truthy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_conditional_operator_with_bool_and_int_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { true and 0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { true and 0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = #{form => {binary_op, #{left => {bool_lit, #{line => 3,
-                                                            spec => true,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => bool}}}},
-                                       line => 3,
-                                       locals => #{},
-                                       op => 'and',
-                                       right => {int_lit, #{line => 3,
-                                                            spec => 0,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => int}}}}}}},
+    Expected = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {bool_lit, #{
+                        line => 3,
+                        spec => true,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => bool
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => 'and',
+                right =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }}
+    },
     {error, unsupported_operand_type, Data} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, Data).
 
 %% Comparison operators
 
 typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 1 == 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 1 == 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 1,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '==',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '==',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_equality_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { 1 == 2.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { 1 == 2.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
-                                                       spec => 1,
-                                                       type => {type, #{line => 3,
-                                                                        source => inferred,
-                                                                        spec => int}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '==',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 2.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 1,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '==',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 2.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 1 != 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 1 != 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 1,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '!=',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 1,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '!=',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_inequality_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { :two != 2.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { :two != 2.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
-                                                        spec => two,
-                                                        type => {type, #{line => 3,
-                                                                         source => inferred,
-                                                                         spec => atom}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '!=',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 2.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => two,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '!=',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 2.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 2 < 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 2 < 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 2,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '<',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 1,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '<',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_less_than_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { 2 < 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { 2 < 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
-                                                       spec => 2,
-                                                       type => {type, #{line => 3,
-                                                                        source => inferred,
-                                                                        spec => int}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '<',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 1.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '<',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 1.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_less_than_comparison_operator_with_unsupported_operand_type_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { :two < :one }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { :two < :one }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
-                                                        spec => two,
-                                                        type => {type, #{line => 3,
-                                                                         source => inferred,
-                                                                         spec => atom}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '<',
-                                   right => {atom_lit, #{line => 3,
-                                                         spec => one,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => atom}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => two,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '<',
+                right =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => one,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 2 <= 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 2 <= 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 2,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '<=',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 1,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '<=',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_less_than_or_equal_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { 2 <= 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { 2 <= 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
-                                                       spec => 2,
-                                                       type => {type, #{line => 3,
-                                                                        source => inferred,
-                                                                        spec => int}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '<=',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 1.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '<=',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 1.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_less_than_or_equal_comparison_operator_with_unsupported_operand_type_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { :two <= :one }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { :two <= :one }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
-                                                        spec => two,
-                                                        type => {type, #{line => 3,
-                                                                         source => inferred,
-                                                                         spec => atom}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '<=',
-                                   right => {atom_lit, #{line => 3,
-                                                         spec => one,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => atom}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => two,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '<=',
+                right =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => one,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 1 > 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 1 > 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 1,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '>',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '>',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_greater_than_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { 2 > 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { 2 > 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
-                                                       spec => 2,
-                                                       type => {type, #{line => 3,
-                                                                        source => inferred,
-                                                                        spec => int}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '>',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 1.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '>',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 1.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_greater_than_comparison_operator_with_unsupported_operand_type_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { :two > :one }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { :two > :one }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
-                                                        spec => two,
-                                                        type => {type, #{line => 3,
-                                                                         source => inferred,
-                                                                         spec => atom}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '>',
-                                   right => {atom_lit, #{line => 3,
-                                                         spec => one,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => atom}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => two,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '>',
+                right =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => one,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test() ->
-    RufusText = "
-    module example
-    func Falsy() bool { 1 >= 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Falsy() bool { 1 >= 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                     spec => 1,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 3,
-                                                 op => '>=',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '>=',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     ?assertEqual(Expected, AnnotatedForms).
 
-
 typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_mismatched_operands_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { 2 >= 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { 2 >= 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {int_lit, #{line => 3,
-                                                       spec => 2,
-                                                       type => {type, #{line => 3,
-                                                                        source => inferred,
-                                                                        spec => int}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '>=',
-                                   right => {float_lit, #{line => 3,
-                                                          spec => 1.0,
-                                                          type => {type, #{line => 3,
-                                                                           source => inferred,
-                                                                           spec => float}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {int_lit, #{
+                        line => 3,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '>=',
+                right =>
+                    {float_lit, #{
+                        line => 3,
+                        spec => 1.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_unsupported_operand_type_test() ->
-    RufusText = "
-    module example
-    func Broken() bool { :two >= :one }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() bool { :two >= :one }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {binary_op, #{left => {atom_lit, #{line => 3,
-                                                        spec => two,
-                                                        type => {type, #{line => 3,
-                                                                         source => inferred,
-                                                                         spec => atom}}}},
-                                   line => 3,
-                                   locals => #{},
-                                   op => '>=',
-                                   right => {atom_lit, #{line => 3,
-                                                         spec => one,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => atom}}}}}}},
+    Data = #{
+        form =>
+            {binary_op, #{
+                left =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => two,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                locals => #{},
+                op => '>=',
+                right =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => one,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }}
+            }}
+    },
     ?assertEqual({error, unsupported_operand_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -3,10 +3,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 typecheck_and_annotate_with_function_calling_an_unknown_function_test() ->
-    RufusText = "
-    module example
-    func Echo(text string) string { Ping() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(text string) string { Ping() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Result = rufus_expr:typecheck_and_annotate(Forms),
@@ -14,299 +15,595 @@ typecheck_and_annotate_with_function_calling_an_unknown_function_test() ->
     ?assertEqual({error, unknown_func, Data}, Result).
 
 typecheck_and_annotate_with_function_calling_a_function_with_a_missing_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n string) string { \"Hello\" }
-    func Broken() string { Echo() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n string) string { \"Hello\" }\n"
+        "    func Broken() string { Echo() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Result = rufus_expr:typecheck_and_annotate(Forms),
-    Data = #{args => [],
-             funcs => [{func, #{params => [{param, #{line => 3,
-                                                     spec => n,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => string}}}}],
-                                exprs => [{string_lit, #{line => 3,
-                                                         spec => <<"Hello">>,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => string}}}}],
+    Data = #{
+        args => [],
+        funcs => [
+            {func, #{
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => n,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => string}},
-                                spec => 'Echo'}}]},
+                                source => rufus_text,
+                                spec => string
+                            }}
+                    }}
+                ],
+                exprs => [
+                    {string_lit, #{
+                        line => 3,
+                        spec => <<"Hello">>,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => string
+                            }}
+                    }}
+                ],
+                line => 3,
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => string
+                    }},
+                spec => 'Echo'
+            }}
+        ]
+    },
     ?assertEqual({error, unknown_arity, Data}, Result).
 
 typecheck_and_annotate_with_function_calling_a_function_with_a_mismatched_argument_type_test() ->
-    RufusText = "
-    module example
-    func Echo(n string) string { \"Hello\" }
-    func Broken() string { Echo(42) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n string) string { \"Hello\" }\n"
+        "    func Broken() string { Echo(42) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Result = rufus_expr:typecheck_and_annotate(Forms),
-    Data = #{args => [{int_lit, #{line => 4,
-                                       spec => 42,
-                                       type => {type, #{line => 4,
-                                                        source => inferred,
-                                                        spec => int}}}}],
-             funcs => [{func, #{params => [{param, #{line => 3,
-                                                     spec => n,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => string}}}}],
-                                exprs => [{string_lit, #{line => 3,
-                                                         spec => <<"Hello">>,
-                                                         type => {type, #{line => 3,
-                                                                          source => inferred,
-                                                                          spec => string}}}}],
+    Data = #{
+        args => [
+            {int_lit, #{
+                line => 4,
+                spec => 42,
+                type =>
+                    {type, #{
+                        line => 4,
+                        source => inferred,
+                        spec => int
+                    }}
+            }}
+        ],
+        funcs => [
+            {func, #{
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => n,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => string}},
-                                spec => 'Echo'}}]},
+                                source => rufus_text,
+                                spec => string
+                            }}
+                    }}
+                ],
+                exprs => [
+                    {string_lit, #{
+                        line => 3,
+                        spec => <<"Hello">>,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => string
+                            }}
+                    }}
+                ],
+                line => 3,
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => string
+                    }},
+                spec => 'Echo'
+            }}
+        ]
+    },
     ?assertEqual({error, unmatched_args, Data}, Result).
 
 typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test() ->
-    RufusText = "
-    module math
-    func Echo(text string) string { text }
-    func Greeting() string { Echo(\"hello\") }
-    ",
+    RufusText =
+        "\n"
+        "    module math\n"
+        "    func Echo(text string) string { text }\n"
+        "    func Greeting() string { Echo(\"hello\") }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => math}},
-                {func, #{exprs => [{identifier, #{line => 3,
-                                                  spec => text,
-                                                  type => {type, #{line => 3,
-                                                                   source => rufus_text,
-                                                                   spec => string}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => text,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => string}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Echo'}},
-                {func, #{exprs => [{call, #{args => [{string_lit, #{line => 4,
-                                                                    spec => <<"hello">>,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => string}}}}],
-                                            line => 4,
-                                            spec => 'Echo',
-                                            type => {type, #{line => 3,
-                                                             source => rufus_text,
-                                                             spec => string}}}}],
-                         line => 4,
-                         params => [],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Greeting'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => math
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => text,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => text,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }},
+        {func, #{
+            exprs => [
+                {call, #{
+                    args => [
+                        {string_lit, #{
+                            line => 4,
+                            spec => <<"hello">>,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => string
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    spec => 'Echo',
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Greeting'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test() ->
-    RufusText = "
-    module math
-    func Sum(m int, n int) int { m + n }
-    func Random() int { Sum(1, 2) }
-    ",
+    RufusText =
+        "\n"
+        "    module math\n"
+        "    func Sum(m int, n int) int { m + n }\n"
+        "    func Random() int { Sum(1, 2) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => math}},
-                {func, #{exprs => [{binary_op, #{left => {identifier, #{line => 3,
-                                                                        spec => m,
-                                                                        type => {type, #{line => 3,
-                                                                                         source => rufus_text,
-                                                                                         spec => int}}}},
-                                                 line => 3,
-                                                 op => '+',
-                                                 right => {identifier, #{line => 3,
-                                                                         spec => n,
-                                                                         type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => rufus_text,
-                                                                  spec => int}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => m,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}},
-                                    {param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Sum'}},
-                {func, #{exprs => [{call, #{args => [{int_lit, #{line => 4,
-                                                                 spec => 1,
-                                                                 type => {type, #{line => 4,
-                                                                                  source => inferred,
-                                                                                  spec => int}}}},
-                                                     {int_lit, #{line => 4,
-                                                                 spec => 2,
-                                                                 type => {type, #{line => 4,
-                                                                                  source => inferred,
-                                                                                  spec => int}}}}],
-                                            line => 4,
-                                            spec => 'Sum',
-                                            type => {type, #{line => 3,
-                                                             source => rufus_text,
-                                                             spec => int}}}}],
-                         line => 4,
-                         params => [],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
-    ?assertEqual(Expected,  AnnotatedForms).
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => math
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => m,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '+',
+                    right =>
+                        {identifier, #{
+                            line => 3,
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => m,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }},
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Sum'
+        }},
+        {func, #{
+            exprs => [
+                {call, #{
+                    args => [
+                        {int_lit, #{
+                            line => 4,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                        {int_lit, #{
+                            line => 4,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    spec => 'Sum',
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
 
 %% Function calls with binary_op arguments
 
 eval_with_function_call_with_binary_op_argument_test() ->
-    RufusText = "
-    module example
-    func double(n int) int { n * 2 }
-    func SumAndDouble(m int, n int) int { double(m + n) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func double(n int) int { n * 2 }\n"
+        "    func SumAndDouble(m int, n int) int { double(m + n) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
 
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{binary_op, #{left => {identifier, #{line => 3,
-                                                                        spec => n,
-                                                                        type => {type, #{line => 3,
-                                                                                         source => rufus_text,
-                                                                                         spec => int}}}},
-                                                 line => 3,
-                                                 op => '*',
-                                                 right => {int_lit, #{line => 3,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}},
-                                                 type => {type, #{line => 3,
-                                                                  source => rufus_text,
-                                                                  spec => int}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => double}},
-                {func, #{exprs => [{call, #{args => [{binary_op, #{left => {identifier, #{line => 4,
-                                                                                          spec => m,
-                                                                                          type => {type, #{line => 4,
-                                                                                                           source => rufus_text,
-                                                                                                           spec => int}}}},
-                                                                   line => 4,
-                                                                   op => '+',
-                                                                   right => {identifier, #{line => 4,
-                                                                                           spec => n,
-                                                                                           type => {type, #{line => 4,
-                                                                                                            source => rufus_text,
-                                                                                                            spec => int}}}},
-                                                                   type => {type, #{line => 4,
-                                                                                    source => rufus_text,
-                                                                                    spec => int}}}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    op => '*',
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => double
+        }},
+        {func, #{
+            exprs => [
+                {call, #{
+                    args => [
+                        {binary_op, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => m,
+                                    type =>
+                                        {type, #{
                                             line => 4,
-                                            spec => double,
-                                            type => {type, #{line => 3,
-                                                             source => rufus_text,
-                                                             spec => int}}}}],
-                         line => 4,
-                         params => [{param, #{line => 4,
-                                              spec => m,
-                                              type => {type, #{line => 4,
-                                                               source => rufus_text,
-                                                               spec => int}}}},
-                                    {param, #{line => 4,
-                                              spec => n,
-                                              type => {type, #{line => 4,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'SumAndDouble'}}],
-    ?assertEqual(Expected,  AnnotatedForms).
+                                            source => rufus_text,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            op => '+',
+                            right =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => n,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    spec => double,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [
+                {param, #{
+                    line => 4,
+                    spec => m,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }},
+                {param, #{
+                    line => 4,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'SumAndDouble'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
 
 %% Function calls with match arguments
 
 eval_with_function_call_with_match_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    func Random() int { 42 = Echo(42) }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Random() int { 42 = Echo(42) }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{identifier, #{line => 3,
-                                                  spec => n,
-                                                  type =>
-                                                      {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Echo'}},
-                {func, #{exprs => [{match, #{left => {int_lit, #{line => 4,
-                                                                 spec => 42,
-                                                                 type => {type, #{line => 4,
-                                                                                  source => inferred,
-                                                                                  spec => int}}}},
-                                             line => 4,
-                                             right => {call, #{args => [{int_lit, #{line => 4,
-                                                                                    spec => 42,
-                                                                                    type => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => int}}}}],
-                                                               line => 4,
-                                                               spec => 'Echo',
-                                                               type => {type, #{line => 3,
-                                                                                source => rufus_text,
-                                                                                spec => int}}}},
-                                             type => {type, #{line => 3,
-                                                              source => rufus_text,
-                                                              spec => int}}}}],
-                         line => 4,
-                         params => [],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
-    ?assertEqual(Expected,  AnnotatedForms).
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Echo'
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {int_lit, #{
+                            line => 4,
+                            spec => 42,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {call, #{
+                            args => [
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 42,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 4,
+                            spec => 'Echo',
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -5,596 +5,1069 @@
 %% typecheck_and_annotate tests
 
 typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
-    RufusText = "
-    module example
-    func Echo(n string) string {
-        a = n
-        a
-    }
-    func Broken() string { a }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n string) string {\n"
+        "        a = n\n"
+        "        a\n"
+        "    }\n"
+        "    func Broken() string { a }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Result = rufus_expr:typecheck_and_annotate(Forms),
-    Data = #{form => {identifier, #{line => 7,
-                                    locals => #{},
-                                    spec => a}},
-             globals => #{'Broken' => [{func, #{exprs => [{identifier, #{line => 7,
-                                                                         spec => a}}],
-                                                line => 7,
-                                                params => [],
-                                                return_type => {type, #{line => 7,
-                                                                        source => rufus_text,
-                                                                        spec => string}},
-                                                spec => 'Broken'}}],
-                          'Echo' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                         spec => a}},
-                                                                  line => 4,
-                                                                  right => {identifier, #{line => 4,
-                                                                                          spec => n}}}},
-                                                        {identifier, #{line => 5,
-                                                                       spec => a}}],
-                                              line => 3,
-                                              params => [{param, #{line => 3,
-                                                                   spec => n,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => rufus_text,
-                                                                                    spec => string}}}}],
-                                              return_type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => string}},
-                                              spec => 'Echo'}}]},
-             locals => #{}},
+    Data = #{
+        form =>
+            {identifier, #{
+                line => 7,
+                locals => #{},
+                spec => a
+            }},
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {identifier, #{
+                            line => 7,
+                            spec => a
+                        }}
+                    ],
+                    line => 7,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 7,
+                            source => rufus_text,
+                            spec => string
+                        }},
+                    spec => 'Broken'
+                }}
+            ],
+            'Echo' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => a
+                                }},
+                            line => 4,
+                            right =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => n
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 5,
+                            spec => a
+                        }}
+                    ],
+                    line => 3,
+                    params => [
+                        {param, #{
+                            line => 3,
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => string
+                                }}
+                        }}
+                    ],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }},
+                    spec => 'Echo'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, unknown_identifier, Data}, Result).
 
 typecheck_and_annotate_test() ->
-    RufusText = "
-    module example
-    func Number() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
         {module, #{line => 2, spec => example}},
-        {func, #{params => [],
-                 exprs => [{int_lit, #{line => 3, spec => 42,
-                                       type => {type, #{line => 3, spec => int, source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3, spec => int, source => rufus_text}},
-                 spec => 'Number'}}
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 42,
+                    type => {type, #{line => 3, spec => int, source => inferred}}
+                }}
+            ],
+            line => 3,
+            return_type => {type, #{line => 3, spec => int, source => rufus_text}},
+            spec => 'Number'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 %% Arity-1 functions taking an argument and returning a literal
 
 typecheck_and_annotate_for_function_taking_an_atom_and_returning_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping(m atom) atom { :pong }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping(m atom) atom { :pong }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => m,
-                                      type => {type, #{line => 3,
-                                                       spec => atom,
-                                                       source => rufus_text}}}}],
-                 exprs => [{atom_lit, #{line => 3,
-                                        spec => pong,
-                                        type => {type, #{line => 3,
-                                                         spec => atom,
-                                                         source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => atom,
-                                         source => rufus_text}},
-                 spec => 'Ping'}}
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => m,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => atom,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {atom_lit, #{
+                    line => 3,
+                    spec => pong,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => atom,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => atom,
+                    source => rufus_text
+                }},
+            spec => 'Ping'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_bool_and_returning_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(b bool) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(b bool) bool { true }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => b,
-                                      type => {type, #{line => 3,
-                                                       spec => bool,
-                                                       source => rufus_text}}}}],
-                 exprs => [{bool_lit, #{line => 3,
-                                        spec => true,
-                                        type => {type, #{line => 3,
-                                                         spec => bool,
-                                                         source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => bool,
-                                         source => rufus_text}},
-                 spec => 'MaybeEcho'}
-        }
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => b,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => bool,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {bool_lit, #{
+                    line => 3,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => bool,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => bool,
+                    source => rufus_text
+                }},
+            spec => 'MaybeEcho'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_float_and_returning_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n float) float { 3.14159265359 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n float) float { 3.14159265359 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => n,
-                                      type => {type, #{line => 3,
-                                                       spec => float,
-                                                       source => rufus_text}}}}],
-                 exprs => [{float_lit, #{line => 3,
-                                         spec => 3.14159265359,
-                                         type => {type, #{line => 3,
-                                                          spec => float,
-                                                          source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => float,
-                                         source => rufus_text}},
-                 spec => 'MaybeEcho'}}
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => float,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {float_lit, #{
+                    line => 3,
+                    spec => 3.14159265359,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => float,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => float,
+                    source => rufus_text
+                }},
+            spec => 'MaybeEcho'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_an_int_and_returning_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n int) int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n int) int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => n,
-                                      type => {type, #{line => 3,
-                                                       spec => int,
-                                                       source => rufus_text}}}}],
-                 exprs => [{int_lit, #{line => 3,
-                                       spec => 42,
-                                       type => {type, #{line => 3,
-                                                        spec => int,
-                                                        source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => int,
-                                         source => rufus_text}},
-                 spec => 'MaybeEcho'}}
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => int,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => int,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'MaybeEcho'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_string_and_returning_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(s string) string { \"Hello\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(s string) string { \"Hello\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => s,
-                                      type => {type, #{line => 3,
-                                                       spec => string,
-                                                       source => rufus_text}}}}],
-                 exprs => [{string_lit, #{line => 3,
-                                          spec => <<"Hello">>,
-                                          type => {type, #{line => 3,
-                                                           spec => string,
-                                                           source => inferred}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => string,
-                                         source => rufus_text}},
-                 spec => 'MaybeEcho'}}
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => s,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => string,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {string_lit, #{
+                    line => 3,
+                    spec => <<"Hello">>,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => string,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => string,
+                    source => rufus_text
+                }},
+            spec => 'MaybeEcho'
+        }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_test() ->
-    RufusText = "
-    module example
-    func MaybeEcho(n list[int]) list[int] { list[int]{42} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func MaybeEcho(n list[int]) list[int] { list[int]{42} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{list_lit, #{elements => [{int_lit, #{line => 3,
-                                                                         spec => 42,
-                                                                         type => {type, #{line => 3,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}}],
-                                                line => 3,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{collection_type => list,
-                                                               element_type => {type, #{line => 3,
-                                                                                        source => rufus_text,
-                                                                                        spec => int}},
-                                                               line => 3,
-                                                               source => rufus_text,
-                                                               spec => 'list[int]'}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'MaybeEcho'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 42,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'MaybeEcho'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 %% Arity-1 functions taking and returning an argument
 
 typecheck_and_annotate_for_function_taking_an_atom_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(b atom) atom { b }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b atom) atom { b }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => b,
-                                      type => {type, #{line => 3,
-                                                       spec => atom,
-                                                       source => rufus_text}}}}],
-                 exprs => [{identifier, #{line => 3,
-                                          spec => b,
-                                          type => {type, #{line => 3,
-                                                           source => rufus_text,
-                                                           spec => atom}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => atom,
-                                         source => rufus_text}},
-                 spec => 'Echo'}}],
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => b,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => atom,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => b,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => atom,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_bool_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(b bool) bool { b }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => b,
-                                      type => {type, #{line => 3,
-                                                       spec => bool,
-                                                       source => rufus_text}}}}],
-                 exprs => [{identifier, #{line => 3,
-                                          spec => b,
-                                          type => {type, #{line => 3,
-                                                           source => rufus_text,
-                                                           spec => bool}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => bool,
-                                         source => rufus_text}},
-                 spec => 'Echo'}}],
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => b,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => bool,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => b,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => bool,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_float_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(n float) float { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n float) float { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => n,
-                                      type => {type, #{line => 3,
-                                                       spec => float,
-                                                       source => rufus_text}}}}],
-                 exprs => [{identifier, #{line => 3,
-                                          spec => n,
-                                          type => {type, #{line => 3,
-                                                           source => rufus_text,
-                                                           spec => float}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => float,
-                                         source => rufus_text}},
-                 spec => 'Echo'}}],
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => float,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => float
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => float,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_an_int_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
-        {module, #{line => 2,
-                   spec => example}},
-        {func, #{params => [{param, #{line => 3,
-                                      spec => n,
-                                      type => {type, #{line => 3,
-                                                       spec => int,
-                                                       source => rufus_text}}}}],
-                 exprs => [{identifier, #{line => 3,
-                                          spec => n,
-                                          type => {type, #{line => 3,
-                                                           source => rufus_text,
-                                                           spec => int}}}}],
-                 line => 3,
-                 return_type => {type, #{line => 3,
-                                         spec => int,
-                                         source => rufus_text}},
-                 spec => 'Echo'}}],
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            spec => int,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_string_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(s string) string { s }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(s string) string { s }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{identifier, #{line => 3,
-                                                  spec => s,
-                                                  type => {type, #{line => 3,
-                                                                   source => rufus_text,
-                                                                   spec => string}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => s,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => string}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => s,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => s,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
-    RufusText = "
-    module example
-    func Echo(n list[int]) list[int] { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n list[int]) list[int] { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{identifier, #{line => 3,
-                                                  spec => n,
-                                                  type => {type, #{collection_type => list,
-                                                                   element_type =>
-                                                                       {type, #{line => 3,
-                                                                                source => rufus_text,
-                                                                                spec => int}},
-                                                                   line => 3,
-                                                                   source => rufus_text,
-                                                                   spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{collection_type => list,
-                                                               element_type =>
-                                                                   {type, #{line => 3,
-                                                                            source => rufus_text,
-                                                                            spec => int}},
-                                                               line => 3,
-                                                               source => rufus_text,
-                                                               spec => 'list[int]'}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 %% func expressions that have various return value and return type combinations
 
 typecheck_and_annotate_function_with_literal_return_value_test() ->
-    RufusText = "
-    module example
-    func Number() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     ?assertEqual({ok, Forms}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_unmatched_return_types_test() ->
-    RufusText = "
-    module example
-    func Number() int { 42.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Number() int { 42.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = {error, unmatched_return_type, #{expr => {float_lit, #{line => 3,
-                                                                      spec => 42.0,
-                                                                      type => {type, #{line => 3,
-                                                                                       source => inferred,
-                                                                                       spec => float}}}},
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}}}},
+    Expected =
+        {error, unmatched_return_type, #{
+            expr =>
+                {float_lit, #{
+                    line => 3,
+                    spec => 42.0,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => float
+                        }}
+                }},
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }}
+        }},
     ?assertEqual(Expected, rufus_expr:typecheck_and_annotate(Forms)).
 
 %% Functions with parameter patterns containing literal values
 
 typecheck_and_annotate_for_function_taking_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(:ok) atom { :ok }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(:ok) atom { :ok }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2, spec => example}},
-                {func, #{exprs => [{atom_lit, #{line => 3,
-                                                spec => ok,
-                                                type => {type, #{line => 3,
-                                                                 source => inferred,
-                                                                 spec => atom}}}}],
-                         line => 3,
-                         params => [{atom_lit, #{line => 3,
-                                                 spec => ok,
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => atom}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {atom_lit, #{
+                    line => 3,
+                    spec => ok,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {atom_lit, #{
+                    line => 3,
+                    spec => ok,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(true) bool { true }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(true) bool { true }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2, spec => example}},
-                {func, #{exprs => [{bool_lit, #{line => 3,
-                                                spec => true,
-                                                type => {type, #{line => 3,
-                                                                 source => inferred,
-                                                                 spec => bool}}}}],
-                         line => 3,
-                         params => [{bool_lit, #{line => 3,
-                                                 spec => true,
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {bool_lit, #{
+                    line => 3,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {bool_lit, #{
+                    line => 3,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1.0) float { 1.0 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1.0) float { 1.0 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2, spec => example}},
-                {func, #{exprs => [{float_lit, #{line => 3,
-                                                 spec => 1.0,
-                                                 type => {type, #{line => 3,
-                                                                  source => inferred,
-                                                                  spec => float}}}}],
-                         line => 3,
-                         params => [{float_lit, #{line => 3,
-                                                  spec => 1.0,
-                                                  type => {type, #{line => 3,
-                                                                   source => inferred,
-                                                                   spec => float}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => float}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {float_lit, #{
+                    line => 3,
+                    spec => 1.0,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {float_lit, #{
+                    line => 3,
+                    spec => 1.0,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => float
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(1) int { 1 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(1) int { 1 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2, spec => example}},
-                {func, #{exprs => [{int_lit, #{line => 3,
-                                               spec => 1,
-                                               type => {type, #{line => 3,
-                                                                source => inferred,
-                                                                spec => int}}}}],
-                         line => 3,
-                         params => [{int_lit, #{line => 3,
-                                                spec => 1,
-                                                type => {type, #{line => 3,
-                                                                 source => inferred,
-                                                                 spec => int}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 1,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 1,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_for_function_taking_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Echo(\"ok\") string { \"ok\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(\"ok\") string { \"ok\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2, spec => example}},
-                {func, #{exprs => [{string_lit, #{line => 3,
-                                                  spec => <<"ok">>,
-                                                  type => {type, #{line => 3,
-                                                                   source => inferred,
-                                                                   spec => string}}}}],
-                         line => 3,
-                         params => [{string_lit, #{line => 3,
-                                                   spec => <<"ok">>,
-                                                   type => {type, #{line => 3,
-                                                                    source => inferred,
-                                                                    spec => string}}}}],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {string_lit, #{
+                    line => 3,
+                    spec => <<"ok">>,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {string_lit, #{
+                    line => 3,
+                    spec => <<"ok">>,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => string
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -3,650 +3,1252 @@
 -include_lib("eunit/include/eunit.hrl").
 
 typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{list_lit, #{elements => [],
-                                                line => 3,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{10} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{10} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{list_lit, #{elements => [{int_lit, #{line => 3,
-                                                                         spec => 10,
-                                                                         type => {type, #{line => 3,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}}],
-                                                line => 3,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 10,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{10 + 2} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{10 + 2} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{list_lit, #{elements => [{binary_op, #{left => {int_lit, #{line => 3,
-                                                                                               spec => 10,
-                                                                                               type => {type, #{line => 3,
-                                                                                                                source => inferred,
-                                                                                                                spec => int}}}},
-                                                                           line => 3,
-                                                                           op => '+',
-                                                                           right => {int_lit, #{line => 3,
-                                                                                                spec => 2,
-                                                                                                type => {type, #{line => 3,
-                                                                                                                 source => inferred,
-                                                                                                                 spec => int}}}},
-                                                                           type => {type, #{line => 3,
-                                                                                            source => inferred,
-                                                                                            spec => int}}}}],
-                                                line => 3,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 10,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 3,
+                            op => '+',
+                            right =>
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_list_of_int_with_mismatched_element_type_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1, 42.0, 6} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1, 42.0, 6} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {list_lit, #{elements => [{int_lit, #{line => 3,
-                                                           spec => 1,
-                                                           type => {type, #{line => 3,
-                                                                            source => inferred,
-                                                                            spec => int}}}},
-                                               {float_lit, #{line => 3,
-                                                             spec => 42.0,
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => float}}}},
-                                               {int_lit, #{line => 3,
-                                                           spec => 6,
-                                                           type => {type, #{line => 3,
-                                                                            source => inferred,
-                                                                            spec => int}}}}],
-                                  line => 3,
-                                  type => {type, #{collection_type => list,
-                                                   element_type => {type, #{line => 3,
-                                                                            source => rufus_text,
-                                                                            spec => int}},
-                                                   line => 3,
-                                                   source => rufus_text,
-                                                   spec => 'list[int]'}}}}},
+    Data = #{
+        form =>
+            {list_lit, #{
+                elements => [
+                    {int_lit, #{
+                        line => 3,
+                        spec => 1,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                    {float_lit, #{
+                        line => 3,
+                        spec => 42.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }},
+                    {int_lit, #{
+                        line => 3,
+                        spec => 6,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+                ],
+                line => 3,
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 3,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() ->
-    RufusText = "
-    module example
-    func Echo(numbers list[int]) list[int] { numbers }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(numbers list[int]) list[int] { numbers }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{identifier, #{line => 3,
-                                                  spec => numbers,
-                                                  type => {type, #{collection_type => list,
-                                                                   element_type => {type, #{line => 3,
-                                                                                            source => rufus_text,
-                                                                                            spec => int}},
-                                                                   line => 3,
-                                                                   source => rufus_text,
-                                                                   spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => numbers,
-                                              type => {type, #{collection_type => list,
-                                                               element_type => {type, #{line => 3,
-                                                                                        source => rufus_text,
-                                                                                        spec => int}},
-                                                               line => 3,
-                                                               source => rufus_text,
-                                                               spec => 'list[int]'}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => numbers,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => numbers,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_test() ->
-    RufusText = "
-    module example
-    func ToList(n int) list[int] { list[int]{n} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func ToList(n int) list[int] { list[int]{n} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{list_lit, #{elements => [{identifier, #{line => 3,
-                                                                            spec => n,
-                                                                            type => {type, #{line => 3,
-                                                                                             source => rufus_text,
-                                                                                             spec => int}}}}],
-                                                line => 3,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 3,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [{param, #{line => 3,
-                                              spec => n,
-                                              type => {type, #{line => 3,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'ToList'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {identifier, #{
+                            line => 3,
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'ToList'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_variable_as_an_element_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{unknown} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{unknown} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {identifier, #{line => 3,
-                                    locals => #{},
-                                    spec => unknown}},
-             globals => #{'Numbers' => [{func, #{exprs => [{list_lit, #{elements => [{identifier, #{line => 3,
-                                                                                                    spec => unknown}}],
-                                                                        line => 3,
-                                                                        type => {type, #{collection_type => list,
-                                                                                         element_type => {type, #{line => 3,
-                                                                                                                  source => rufus_text,
-                                                                                                                  spec => int}},
-                                                                                         line => 3,
-                                                                                         source => rufus_text,
-                                                                                         spec => 'list[int]'}}}}],
-                                                 line => 3,
-                                                 params => [],
-                                                 return_type => {type, #{collection_type => list,
-                                                                         element_type => {type, #{line => 3,
-                                                                                                  source => rufus_text,
-                                                                                                  spec => int}},
-                                                                         line => 3,
-                                                                         source => rufus_text,
-                                                                         spec => 'list[int]'}},
-                                                 spec => 'Numbers'}}]},
-             locals => #{}},
+    Data = #{
+        form =>
+            {identifier, #{
+                line => 3,
+                locals => #{},
+                spec => unknown
+            }},
+        globals => #{
+            'Numbers' => [
+                {func, #{
+                    exprs => [
+                        {list_lit, #{
+                            elements => [
+                                {identifier, #{
+                                    line => 3,
+                                    spec => unknown
+                                }}
+                            ],
+                            line => 3,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }},
+                    spec => 'Numbers'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, unknown_identifier, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{cons, #{head => {int_lit, #{line => 3,
-                                                                spec => 1,
-                                                                type => {type, #{line => 3,
-                                                                                 source => inferred,
-                                                                                 spec => int}}}},
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {cons, #{
+                    head =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    tail =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
                                             line => 3,
-                                            tail => {list_lit, #{elements => [{int_lit, #{line => 3,
-                                                                                          spec => 2,
-                                                                                          type => {type, #{line => 3,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}}],
-                                                                 line => 3,
-                                                                 type => {type, #{collection_type => list,
-                                                                                  element_type => {type, #{line => 3,
-                                                                                                           source => rufus_text,
-                                                                                                           spec => int}},
-                                                                                  line => 3,
-                                                                                  source => rufus_text,
-                                                                                  spec => 'list[int]'}}}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 3,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 3,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 3,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_literal_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] { list[int]{1|{2, 3, 4}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{cons, #{head => {int_lit, #{line => 3,
-                                                                spec => 1,
-                                                                type => {type, #{line => 3,
-                                                                                 source => inferred,
-                                                                                 spec => int}}}},
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {cons, #{
+                    head =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    tail =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
                                             line => 3,
-                                            tail => {list_lit, #{elements => [{int_lit, #{line => 3,
-                                                                                          spec => 2,
-                                                                                          type => {type, #{line => 3,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}},
-                                                                              {int_lit, #{line => 3,
-                                                                                          spec => 3,
-                                                                                          type => {type, #{line => 3,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}},
-                                                                              {int_lit, #{line => 3,
-                                                                                          spec => 4,
-                                                                                          type => {type, #{line => 3,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}}],
-                                                                 line => 3,
-                                                                 type => {type, #{collection_type => list,
-                                                                                  element_type => {type, #{line => 3,
-                                                                                                           source => rufus_text,
-                                                                                                           spec => int}},
-                                                                                  line => 3,
-                                                                                  source => rufus_text,
-                                                                                  spec => 'list[int]'}}}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 3,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 3,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 4,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 3,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair_values_test() ->
-    RufusText = "
-    module example
-    func Numbers() list[int] {
-        head = 1
-        tail = list[int]{2, 3, 4}
-        list[int]{head|tail}
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Numbers() list[int] {\n"
+        "        head = 1\n"
+        "        tail = list[int]{2, 3, 4}\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{head => {type, #{line => 4,
-                                                                                                 source => inferred,
-                                                                                                 spec => int}}},
-                                                                    spec => head,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             line => 4,
-                                             right => {int_lit, #{line => 4,
-                                                                  spec => 1,
-                                                                  type => {type, #{line => 4,
-                                                                                   source => inferred,
-                                                                                   spec => int}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}},
-                                   {match, #{left => {identifier, #{line => 5, locals => #{head => {type, #{line => 4,
-                                                                                                            source => inferred,
-                                                                                                            spec => int}},
-                                                                                           tail => {type, #{collection_type => list,
-                                                                                                            element_type => {type, #{line => 5,
-                                                                                                                                     source => rufus_text,
-                                                                                                                                     spec => int}},
-                                                                                                            line => 5,
-                                                                                                            source => rufus_text,
-                                                                                                            spec => 'list[int]'}}},
-                                                                    spec => tail,
-                                                                    type => {type, #{collection_type => list,
-                                                                                     element_type => {type, #{line => 5,
-                                                                                                              source => rufus_text,
-                                                                                                              spec => int}},
-                                                                                     line => 5,
-                                                                                     source => rufus_text,
-                                                                                     spec => 'list[int]'}}}},
-                                             line => 5,
-                                             right => {list_lit, #{elements => [{int_lit, #{line => 5,
-                                                                                            spec => 2,
-                                                                                            type => {type, #{line => 5,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}},
-                                                                                {int_lit, #{line => 5,
-                                                                                            spec => 3,
-                                                                                            type => {type, #{line => 5,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}},
-                                                                                {int_lit, #{line => 5,
-                                                                                            spec => 4,
-                                                                                            type => {type, #{line => 5,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}}],
-                                                                   line => 5,
-                                                                   type => {type, #{collection_type => list,
-                                                                                    element_type => {type, #{line => 5,
-                                                                                                             source => rufus_text,
-                                                                                                             spec => int}},
-                                                                                    line => 5,
-                                                                                    source => rufus_text,
-                                                                                    spec => 'list[int]'}}}},
-                                             type => {type, #{collection_type => list,
-                                                              element_type => {type, #{line => 5,
-                                                                                       source => rufus_text,
-                                                                                       spec => int}},
-                                                              line => 5,
-                                                              source => rufus_text,
-                                                              spec => 'list[int]'}}}},
-                                   {cons, #{head => {identifier, #{line => 6,
-                                                                   spec => head,
-                                                                   type => {type, #{line => 4,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}},
-                                            line => 6,
-                                            tail => {identifier, #{line => 6,
-                                                                   spec => tail,
-                                                                   type => {type, #{collection_type => list,
-                                                                                    element_type => {type, #{line => 5,
-                                                                                                             source => rufus_text,
-                                                                                                             spec => int}},
-                                                                                    line => 5,
-                                                                                    source => rufus_text,
-                                                                                    spec => 'list[int]'}}}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 6,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 6,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                head =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            },
+                            spec => head,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {int_lit, #{
+                            line => 4,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 5,
+                            locals => #{
+                                head =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => int
+                                    }},
+                                tail =>
+                                    {type, #{
+                                        collection_type => list,
+                                        element_type =>
+                                            {type, #{
+                                                line => 5,
+                                                source => rufus_text,
+                                                spec => int
+                                            }},
+                                        line => 5,
+                                        source => rufus_text,
+                                        spec => 'list[int]'
+                                    }}
+                            },
+                            spec => tail,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 5,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 5,
+                    right =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 4,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 5,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 5,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 5,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 5,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {cons, #{
+                    head =>
+                        {identifier, #{
+                            line => 6,
+                            spec => head,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 6,
+                    tail =>
+                        {identifier, #{
+                            line => 6,
+                            spec => tail,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 5,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 6,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 6,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected_head_value_type_test() ->
-    RufusText = "
-    module example
-    func Broken() list[int] { list[int]{:unexpected|{2, 3, 4}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() list[int] { list[int]{:unexpected|{2, 3, 4}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{element_type => {type, #{line => 3,
-                                      source => rufus_text,
-                                      spec => int}},
-             form => {cons, #{head => {atom_lit, #{line => 3,
-                                                   spec => unexpected,
-                                                   type => {type, #{line => 3,
-                                                                    source => inferred,
-                                                                    spec => atom}}}},
-                              line => 3,
-                              tail => {list_lit, #{elements => [{int_lit, #{line => 3,
-                                                                            spec => 2,
-                                                                            type => {type, #{line => 3,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}},
-                                                                {int_lit, #{line => 3,
-                                                                            spec => 3,
-                                                                            type => {type, #{line => 3,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}},
-                                                                {int_lit, #{line => 3,
-                                                                            spec => 4,
-                                                                            type => {type, #{line => 3,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}}],
-                                                   line => 3,
-                                                   type => {type, #{collection_type => list,
-                                                                    element_type => {type, #{line => 3,
-                                                                                             source => rufus_text,
-                                                                                             spec => int}},
-                                                                    line => 3,
-                                                                    source => rufus_text,
-                                                                    spec => 'list[int]'}}}},
-                              type => {type, #{collection_type => list,
-                                               element_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                               line => 3,
-                                               source => rufus_text,
-                                               spec => 'list[int]'}}}},
-             head_type => {type, #{line => 3,
-                                   source => inferred,
-                                   spec => atom}},
-             tail_element_type => {type, #{line => 3,
-                                           source => rufus_text,
-                                           spec => int}}},
+    Data = #{
+        element_type =>
+            {type, #{
+                line => 3,
+                source => rufus_text,
+                spec => int
+            }},
+        form =>
+            {cons, #{
+                head =>
+                    {atom_lit, #{
+                        line => 3,
+                        spec => unexpected,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 3,
+                tail =>
+                    {list_lit, #{
+                        elements => [
+                            {int_lit, #{
+                                line => 3,
+                                spec => 2,
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                            {int_lit, #{
+                                line => 3,
+                                spec => 3,
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                            {int_lit, #{
+                                line => 3,
+                                spec => 4,
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }}
+                        ],
+                        line => 3,
+                        type =>
+                            {type, #{
+                                collection_type => list,
+                                element_type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }},
+                                line => 3,
+                                source => rufus_text,
+                                spec => 'list[int]'
+                            }}
+                    }},
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 3,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }},
+        head_type =>
+            {type, #{
+                line => 3,
+                source => inferred,
+                spec => atom
+            }},
+        tail_element_type =>
+            {type, #{
+                line => 3,
+                source => rufus_text,
+                spec => int
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected_tail_element_value_type_test() ->
-    RufusText = "
-    module example
-    func Broken() list[int] { list[int]{1|{:unexpected}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() list[int] { list[int]{1|{:unexpected}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {list_lit, #{elements => [{atom_lit, #{line => 3,
-                                                            spec => unexpected,
-                                                            type => {type, #{line => 3,
-                                                                             source => inferred,
-                                                                             spec => atom}}}}],
-                                  line => 3,
-                                  type => {type, #{collection_type => list,
-                                                   element_type => {type, #{line => 3,
-                                                                            source => rufus_text,
-                                                                            spec => int}},
-                                                   line => 3,
-                                                   source => rufus_text,
-                                                   spec => 'list[int]'}}}}},
+    Data = #{
+        form =>
+            {list_lit, #{
+                elements => [
+                    {atom_lit, #{
+                        line => 3,
+                        spec => unexpected,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }}
+                ],
+                line => 3,
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 3,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected_head_identifier_type_test() ->
-    RufusText = "
-    module example
-    func Broken() list[int] {
-        unexpected = :unexpected
-        list[int]{unexpected|{2, 3, 4}} }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() list[int] {\n"
+        "        unexpected = :unexpected\n"
+        "        list[int]{unexpected|{2, 3, 4}} }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{element_type => {type, #{line => 5,
-                                      source => rufus_text,
-                                      spec => int}},
-             form => {cons, #{head => {identifier, #{line => 5,
-                                                     spec => unexpected,
-                                                     type => {type, #{line => 4,
-                                                                      source => inferred,
-                                                                      spec => atom}}}},
-                              line => 5,
-                              tail => {list_lit, #{elements => [{int_lit, #{line => 5,
-                                                                            spec => 2,
-                                                                            type => {type, #{line => 5,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}},
-                                                                {int_lit, #{line => 5,
-                                                                            spec => 3,
-                                                                            type => {type, #{line => 5,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}},
-                                                                {int_lit, #{line => 5,
-                                                                            spec => 4,
-                                                                            type => {type, #{line => 5,
-                                                                                             source => inferred,
-                                                                                             spec => int}}}}],
-                                                   line => 5,
-                                                   type => {type, #{collection_type => list,
-                                                                    element_type => {type, #{line => 5,
-                                                                                             source => rufus_text,
-                                                                                             spec => int}},
-                                                                    line => 5,
-                                                                    source => rufus_text,
-                                                                    spec => 'list[int]'}}}},
-                              type => {type, #{collection_type => list,
-                                               element_type => {type, #{line => 5,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                               line => 5,
-                                               source => rufus_text,
-                                               spec => 'list[int]'}}}},
-             head_type => {type, #{line => 4,
-                                   source => inferred,
-                                   spec => atom}},
-             tail_element_type => {type, #{line => 5,
-                                           source => rufus_text,
-                                           spec => int}}},
+    Data = #{
+        element_type =>
+            {type, #{
+                line => 5,
+                source => rufus_text,
+                spec => int
+            }},
+        form =>
+            {cons, #{
+                head =>
+                    {identifier, #{
+                        line => 5,
+                        spec => unexpected,
+                        type =>
+                            {type, #{
+                                line => 4,
+                                source => inferred,
+                                spec => atom
+                            }}
+                    }},
+                line => 5,
+                tail =>
+                    {list_lit, #{
+                        elements => [
+                            {int_lit, #{
+                                line => 5,
+                                spec => 2,
+                                type =>
+                                    {type, #{
+                                        line => 5,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                            {int_lit, #{
+                                line => 5,
+                                spec => 3,
+                                type =>
+                                    {type, #{
+                                        line => 5,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                            {int_lit, #{
+                                line => 5,
+                                spec => 4,
+                                type =>
+                                    {type, #{
+                                        line => 5,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }}
+                        ],
+                        line => 5,
+                        type =>
+                            {type, #{
+                                collection_type => list,
+                                element_type =>
+                                    {type, #{
+                                        line => 5,
+                                        source => rufus_text,
+                                        spec => int
+                                    }},
+                                line => 5,
+                                source => rufus_text,
+                                spec => 'list[int]'
+                            }}
+                    }},
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 5,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 5,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }},
+        head_type =>
+            {type, #{
+                line => 4,
+                source => inferred,
+                spec => atom
+            }},
+        tail_element_type =>
+            {type, #{
+                line => 5,
+                source => rufus_text,
+                spec => int
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected_tail_element_identifier_type_test() ->
-    RufusText = "
-    module example
-    func Broken() list[int] {
-        unexpected = list[atom]{:unexpected}
-        list[int]{1|unexpected}
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() list[int] {\n"
+        "        unexpected = list[atom]{:unexpected}\n"
+        "        list[int]{1|unexpected}\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{element_type => {type, #{line => 5,
-                                      source => rufus_text,
-                                      spec => int}},
-             form => {cons, #{head => {int_lit, #{line => 5,
-                                                  spec => 1,
-                                                  type => {type, #{line => 5,
-                                                                   source => inferred,
-                                                                   spec => int}}}},
-                              line => 5,
-                              tail => {identifier, #{line => 5,
-                                                     spec => unexpected,
-                                                     type => {type, #{collection_type => list,
-                                                                      element_type => {type, #{line => 4,
-                                                                                               source => rufus_text,
-                                                                                               spec => atom}},
-                                                                      line => 4,
-                                                                      source => rufus_text,
-                                                                      spec => 'list[atom]'}}}},
-                              type => {type, #{collection_type => list,
-                                               element_type => {type, #{line => 5,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                               line => 5,
-                                               source => rufus_text,
-                                               spec => 'list[int]'}}}},
-             head_type => {type, #{line => 5,
-                                   source => inferred,
-                                   spec => int}},
-             tail_element_type => {type, #{line => 4,
-                                           source => rufus_text,
-                                           spec => atom}}},
+    Data = #{
+        element_type =>
+            {type, #{
+                line => 5,
+                source => rufus_text,
+                spec => int
+            }},
+        form =>
+            {cons, #{
+                head =>
+                    {int_lit, #{
+                        line => 5,
+                        spec => 1,
+                        type =>
+                            {type, #{
+                                line => 5,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 5,
+                tail =>
+                    {identifier, #{
+                        line => 5,
+                        spec => unexpected,
+                        type =>
+                            {type, #{
+                                collection_type => list,
+                                element_type =>
+                                    {type, #{
+                                        line => 4,
+                                        source => rufus_text,
+                                        spec => atom
+                                    }},
+                                line => 4,
+                                source => rufus_text,
+                                spec => 'list[atom]'
+                            }}
+                    }},
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 5,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 5,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }},
+        head_type =>
+            {type, #{
+                line => 5,
+                source => inferred,
+                spec => int
+            }},
+        tail_element_type =>
+            {type, #{
+                line => 4,
+                source => rufus_text,
+                spec => atom
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -5,989 +5,1990 @@
 %% match expressions that bind variables
 
 typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() atom {
-        response = :pong
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() atom {\n"
+        "        response = :pong\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => atom}}},
-                                                                    spec => response,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => atom}}}},
-                                             line => 4,
-                                             right => {atom_lit, #{line => 4,
-                                                                   spec => pong,
-                                                                   type => {type, #{line => 4,
-                                                                                    source => inferred,
-                                                                                    spec => atom}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => atom}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{line => 4,
-                                                                   source => inferred,
-                                                                   spec => atom}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Ping'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => atom
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => atom
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {atom_lit, #{
+                            line => 4,
+                            spec => pong,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => atom
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Ping'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
-    RufusText = "
-    module example
-    func Truthy() bool {
-        response = true
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Truthy() bool {\n"
+        "        response = true\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => bool}}},
-                                                                    spec => response,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => bool}}}},
-                                             line => 4,
-                                             right => {bool_lit, #{line => 4,
-                                                                   spec => true,
-                                                                   type => {type, #{line => 4,
-                                                                                    source => inferred,
-                                                                                    spec => bool}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => bool}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{line => 4,
-                                                                   source => inferred,
-                                                                   spec => bool}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Truthy'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => bool
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {bool_lit, #{
+                            line => 4,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Truthy'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() float {
-        response = 42.0
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() float {\n"
+        "        response = 42.0\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => float}}},
-                                                                    spec => response,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => float}}}},
-                                             line => 4,
-                                             right => {float_lit, #{line => 4,
-                                                                   spec => 42.0,
-                                                                   type => {type, #{line => 4,
-                                                                                    source => inferred,
-                                                                                    spec => float}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => float}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{line => 4,
-                                                                   source => inferred,
-                                                                   spec => float}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => float}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => float
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => float
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {float_lit, #{
+                            line => 4,
+                            spec => 42.0,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => float
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => float
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => float
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() int {
-        response = 42
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() int {\n"
+        "        response = 42\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => int}}},
-                                                                    spec => response,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             line => 4,
-                                             right => {int_lit, #{line => 4,
-                                                                  spec => 42,
-                                                                  type => {type, #{line => 4,
-                                                                                   source => inferred,
-                                                                                   spec => int}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{line => 4,
-                                                                   source => inferred,
-                                                                   spec => int}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {int_lit, #{
+                            line => 4,
+                            spec => 42,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() ->
-    RufusText = "
-    module example
-    func Ping() string {
-        response = \"pong\"
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping() string {\n"
+        "        response = \"pong\"\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{line => 4,
-                                                                                                     source => inferred,
-                                                                                                     spec => string}}},
-                                                                    spec => response,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => string}}}},
-                                             line => 4,
-                                             right => {string_lit, #{line => 4,
-                                                                     spec => <<"pong">>,
-                                                                     type => {type, #{line => 4,
-                                                                                      source => inferred,
-                                                                                      spec => string}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => string}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{line => 4,
-                                                                   source => inferred,
-                                                                   spec => string}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Ping'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => string
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => string
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {string_lit, #{
+                            line => 4,
+                            spec => <<"pong">>,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => string
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => string
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Ping'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_test() ->
-    RufusText = "
-    module example
-    func FortyTwo() list[int] {
-        response = list[int]{42}
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func FortyTwo() list[int] {\n"
+        "        response = list[int]{42}\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{response => {type, #{collection_type => list,
-                                                                                                     element_type => {type, #{line => 4,
-                                                                                                                              source => rufus_text,
-                                                                                                                              spec => int}},
-                                                                                                     line => 4,
-                                                                                                     source => rufus_text,
-                                                                                                     spec => 'list[int]'}}},
-                                                                    spec => response,
-                                                                    type => {type, #{collection_type => list,
-                                                                                     element_type => {type, #{line => 4,
-                                                                                                              source => rufus_text,
-                                                                                                              spec => int}},
-                                                                                     line => 4,
-                                                                                     source => rufus_text,
-                                                                                     spec => 'list[int]'}}}},
-                                             line => 4,
-                                             right => {list_lit, #{elements => [{int_lit, #{line => 4,
-                                                                                            spec => 42,
-                                                                                            type => {type, #{line => 4,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}}],
-                                                                   line => 4,
-                                                                   type => {type, #{collection_type => list,
-                                                                                    element_type => {type, #{line => 4,
-                                                                                                             source => rufus_text,
-                                                                                                             spec => int}},
-                                                                                    line => 4,
-                                                                                    source => rufus_text,
-                                                                                    spec => 'list[int]'}}}},
-                                             type => {type, #{collection_type => list,
-                                                              element_type => {type, #{line => 4,
-                                                                                       source => rufus_text,
-                                                                                       spec => int}},
-                                                              line => 4,
-                                                              source => rufus_text,
-                                                              spec => 'list[int]'}}}},
-                                   {identifier, #{line => 5,
-                                                  spec => response,
-                                                  type => {type, #{collection_type => list,
-                                                                   element_type => {type, #{line => 4,
-                                                                                            source => rufus_text,
-                                                                                            spec => int}},
-                                                                   line => 4,
-                                                                   source => rufus_text,
-                                                                   spec => 'list[int]'}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 3,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 3,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                response =>
+                                    {type, #{
+                                        collection_type => list,
+                                        element_type =>
+                                            {type, #{
+                                                line => 4,
+                                                source => rufus_text,
+                                                spec => int
+                                            }},
+                                        line => 4,
+                                        source => rufus_text,
+                                        spec => 'list[int]'
+                                    }}
+                            },
+                            spec => response,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 42,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 4,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 4,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => response,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 4,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_with_mismatched_types_test() ->
-    RufusText = "
-    module example
-    func Random() int {
-        2.0 = 2
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int {\n"
+        "        2.0 = 2\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{globals => #{'Random' => [{func, #{exprs => [{match, #{left => {float_lit, #{line => 4,
-                                                                                          spec => 2.0,
-                                                                                          type => {type, #{line => 4,
-                                                                                                           source => inferred,
-                                                                                                           spec => float}}}},
-                                                                    line => 4,
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 2,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}]},
-             left => {float_lit, #{line => 4,
-                                   spec => 2.0,
-                                   type => {type, #{line => 4,
-                                                    source => inferred,
-                                                    spec => float}}}},
-             locals => #{},
-             right => {int_lit, #{line => 4,
-                                  spec => 2,
-                                  type => {type, #{line => 4,
-                                                   source => inferred,
-                                                   spec => int}}}}},
+    Data = #{
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {float_lit, #{
+                                    line => 4,
+                                    spec => 2.0,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => float
+                                        }}
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ]
+        },
+        left =>
+            {float_lit, #{
+                line => 4,
+                spec => 2.0,
+                type =>
+                    {type, #{
+                        line => 4,
+                        source => inferred,
+                        spec => float
+                    }}
+            }},
+        locals => #{},
+        right =>
+            {int_lit, #{
+                line => 4,
+                spec => 2,
+                type =>
+                    {type, #{
+                        line => 4,
+                        source => inferred,
+                        spec => int
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 %% match expressions involving binary_op expressions
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_test() ->
-    RufusText = "
-    module example
-    func Random() int {
-        n = 3
-        1 + 2 = n
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int {\n"
+        "        n = 3\n"
+        "        1 + 2 = n\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{n => {type, #{line => 4,
-                                                                                              source => inferred,
-                                                                                              spec => int}}},
-                                                                    spec => n,
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             line => 4,
-                                             right => {int_lit, #{line => 4,
-                                                                  spec => 3,
-                                                                  type => {type, #{line => 4,
-                                                                                   source => inferred,
-                                                                                   spec => int}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}},
-                                   {match, #{left => {binary_op, #{left => {int_lit, #{line => 5,
-                                                                                       spec => 1,
-                                                                                       type => {type, #{line => 5,
-                                                                                                        source => inferred,
-                                                                                                        spec => int}}}},
-                                                                   line => 5,
-                                                                   op => '+',
-                                                                   right => {int_lit, #{line => 5,
-                                                                                        spec => 2,
-                                                                                        type => {type, #{line => 5,
-                                                                                                         source => inferred,
-                                                                                                         spec => int}}}},
-                                                                   type => {type, #{line => 5,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}},
-                                             line => 5,
-                                             right => {identifier, #{line => 5,
-                                                                     spec => n,
-                                                                     type => {type, #{line => 4,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                n =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            },
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {int_lit, #{
+                            line => 4,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {match, #{
+                    left =>
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 5,
+                            op => '+',
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 5,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 5,
+                    right =>
+                        {identifier, #{
+                            line => 5,
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_test() ->
-    RufusText = "
-    module example
-    func Random() int { n = 1 + 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int { n = 1 + 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    locals => #{n => {type, #{line => 3,
-                                                                                              source => inferred,
-                                                                                              spec => int}}},
-                                                                    spec => n,
-                                                                    type => {type, #{line => 3,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             line => 3,
-                                             right => {binary_op, #{left => {int_lit, #{line => 3,
-                                                                                        spec => 1,
-                                                                                        type => {type, #{line => 3,
-                                                                                                         source => inferred,
-                                                                                                         spec => int}}}},
-                                                                    line => 3,
-                                                                    op => '+',
-                                                                    right => {int_lit, #{line => 3,
-                                                                                         spec => 2,
-                                                                                         type => {type, #{line => 3,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}},
-                                                                    type => {type, #{line => 3,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             type => {type, #{line => 3,
-                                                              source => inferred,
-                                                              spec => int}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                n =>
+                                    {type, #{
+                                        line => 3,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            },
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    right =>
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 3,
+                            op => '+',
+                            right =>
+                                {int_lit, #{
+                                    line => 3,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_operands_test() ->
-    RufusText = "
-    module example
-    func Random() int {
-        1 + 2 = 2 + 1
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int {\n"
+        "        1 + 2 = 2 + 1\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{match, #{left => {binary_op, #{left => {int_lit, #{line => 4,
-                                                                                       spec => 1,
-                                                                                       type => {type, #{line => 4,
-                                                                                                        source => inferred,
-                                                                                                        spec => int}}}},
-                                                                   line => 4,
-                                                                   op => '+',
-                                                                   right => {int_lit, #{line => 4,
-                                                                                        spec => 2,
-                                                                                        type => {type, #{line => 4,
-                                                                                                         source => inferred,
-                                                                                                         spec => int}}}},
-                                                                   type => {type, #{line => 4,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}},
-                                             line => 4,
-                                             right => {binary_op, #{left => {int_lit, #{line => 4,
-                                                                                        spec => 2,
-                                                                                        type => {type, #{line => 4,
-                                                                                                         source => inferred,
-                                                                                                         spec => int}}}},
-                                                                    line => 4,
-                                                                    op => '+',
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 1,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}},
-                                                                    type => {type, #{line => 4,
-                                                                                     source => inferred,
-                                                                                     spec => int}}}},
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            op => '+',
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            op => '+',
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 %% match expressions involving function calls
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { n = Two() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { n = Two() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [{module, #{line => 2,
-                           spec => example}},
-                {func, #{exprs => [{int_lit, #{line => 3,
-                                               spec => 2,
-                                               type => {type, #{line => 3,
-                                                                source => inferred,
-                                                                spec => int}}}}],
-                         line => 3,
-                         params => [],
-                         return_type => {type, #{line => 3,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Two'}},
-                {func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                    locals => #{n => {type, #{line => 3,
-                                                                                              source => rufus_text,
-                                                                                              spec => int}}},
-                                                                    spec => n,
-                                                                    type => {type, #{line => 3,
-                                                                                     source => rufus_text,
-                                                                                     spec => int}}}},
-                                             line => 4,
-                                             right => {call, #{args => [],
-                                                               line => 4,
-                                                               spec => 'Two',
-                                                               type => {type, #{line => 3,
-                                                                                source => rufus_text,
-                                                                                spec => int}}}},
-                                             type => {type, #{line => 3,
-                                                              source => rufus_text,
-                                                              spec => int}}}}],
-                         line => 4,
-                         params => [],
-                         return_type => {type, #{line => 4,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
+    Expected = [
+        {module, #{
+            line => 2,
+            spec => example
+        }},
+        {func, #{
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 2,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Two'
+        }},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                n =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            },
+                            spec => n,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {call, #{
+                            args => [],
+                            line => 4,
+                            spec => 'Two',
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 4,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
     ?assertEqual(Expected, AnnotatedForms).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { Two() = 2 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { Two() = 2 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {match, #{left => {call, #{args => [],
-                                                line => 4,
-                                                spec => 'Two',
-                                                type => {type, #{line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => int}}}},
-                               line => 4,
-                               right => {int_lit, #{line => 4,
-                                                    spec => 2,
-                                                    type => {type, #{line => 4,
-                                                                     source => inferred,
-                                                                     spec => int}}}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {call, #{args => [],
-                                                                                     line => 4,
-                                                                                     spec => 'Two'}},
-                                                                    line => 4,
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 2,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{}},
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two',
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }},
+                line => 4,
+                right =>
+                    {int_lit, #{
+                        line => 4,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 4,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int {
-        n = 3
-        1 + Two() = n
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int {\n"
+        "        n = 3\n"
+        "        1 + Two() = n\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {match, #{left => {binary_op, #{left => {int_lit, #{line => 6,
-                                                                         spec => 1,
-                                                                         type => {type, #{line => 6,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}},
-                                                     line => 6,
-                                                     op => '+',
-                                                     right => {call, #{args => [],
-                                                                       line => 6,
-                                                                       spec => 'Two',
-                                                                       type => {type, #{line => 3,
-                                                                                        source => rufus_text,
-                                                                                        spec => int}}}},
-                                                     type => {type, #{line => 6,
-                                                                      source => inferred,
-                                                                      spec => int}}}},
-                               line => 6,
-                               right => {identifier, #{line => 6,
-                                                       spec => n}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 5,
-                                                                                           spec => n}},
-                                                                    line => 5,
-                                                                    right => {int_lit, #{line => 5,
-                                                                                         spec => 3,
-                                                                                         type =>
-                                                                                             {type, #{line => 5,
-                                                                                                      source => inferred,
-                                                                                                      spec => int}}}}}},
-                                                          {match, #{left => {binary_op, #{left => {int_lit, #{line => 6,
-                                                                                                              spec => 1,
-                                                                                                              type =>
-                                                                                                                  {type, #{line => 6,
-                                                                                                                           source => inferred,
-                                                                                                                           spec => int}}}},
-                                                                                          line => 6,
-                                                                                          op => '+',
-                                                                                          right => {call, #{args => [],
-                                                                                                            line => 6,
-                                                                                                            spec => 'Two'}}}},
-                                                                    line => 6,
-                                                                    right => {identifier, #{line => 6,
-                                                                                            spec => n}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{n => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => int}}}},
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {binary_op, #{
+                        left =>
+                            {int_lit, #{
+                                line => 6,
+                                spec => 1,
+                                type =>
+                                    {type, #{
+                                        line => 6,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                        line => 6,
+                        op => '+',
+                        right =>
+                            {call, #{
+                                args => [],
+                                line => 6,
+                                spec => 'Two',
+                                type =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            }},
+                        type =>
+                            {type, #{
+                                line => 6,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 6,
+                right =>
+                    {identifier, #{
+                        line => 6,
+                        spec => n
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => n
+                                }},
+                            line => 5,
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {binary_op, #{
+                                    left =>
+                                        {int_lit, #{
+                                            line => 6,
+                                            spec => 1,
+                                            type =>
+                                                {type, #{
+                                                    line => 6,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                    line => 6,
+                                    op => '+',
+                                    right =>
+                                        {call, #{
+                                            args => [],
+                                            line => 6,
+                                            spec => 'Two'
+                                        }}
+                                }},
+                            line => 6,
+                            right =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => n
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{
+            n =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => int
+                }}
+        }
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_with_an_unbound_identifer_as_an_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int {
-        n = 1
-        1 + n = 2
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int {\n"
+        "        n = 1\n"
+        "        1 + n = 2\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {match, #{left => {binary_op, #{left => {int_lit, #{line => 5,
-                                                                         spec => 1,
-                                                                         type => {type, #{line => 5,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}},
-                                                     line => 5,
-                                                     op => '+',
-                                                     right => {identifier, #{line => 5,
-                                                                             spec => n,
-                                                                             type => {type, #{line => 4,
-                                                                                              source => inferred,
-                                                                                              spec => int}}}},
-                                                     type => {type, #{line => 5,
-                                                                      source => inferred,
-                                                                      spec => int}}}},
-                               line => 5,
-                               right => {int_lit, #{line => 5,
-                                                    spec => 2,
-                                                    type => {type, #{line => 5,
-                                                                     source => inferred,
-                                                                     spec => int}}}}}},
-             globals => #{'Two' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                        spec => n}},
-                                                                 line => 4,
-                                                                 right => {int_lit, #{line => 4,
-                                                                                      spec => 1,
-                                                                                      type => {type, #{line => 4,
-                                                                                                       source => inferred,
-                                                                                                       spec => int}}}}}},
-                                                       {match, #{left => {binary_op, #{left => {int_lit, #{line => 5,
-                                                                                                           spec => 1,
-                                                                                                           type => {type, #{line => 5,
-                                                                                                                            source => inferred,
-                                                                                                                            spec => int}}}},
-                                                                                       line => 5,
-                                                                                       op => '+',
-                                                                                       right => {identifier, #{line => 5,
-                                                                                                               spec => n}}}},
-                                                                 line => 5,
-                                                                 right => {int_lit, #{line => 5,
-                                                                                      spec => 2,
-                                                                                      type => {type, #{line => 5,
-                                                                                                       source => inferred,
-                                                                                                       spec => int}}}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{n => {type, #{line => 4,
-                                       source => inferred,
-                                       spec => int}}}},
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {binary_op, #{
+                        left =>
+                            {int_lit, #{
+                                line => 5,
+                                spec => 1,
+                                type =>
+                                    {type, #{
+                                        line => 5,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                        line => 5,
+                        op => '+',
+                        right =>
+                            {identifier, #{
+                                line => 5,
+                                spec => n,
+                                type =>
+                                    {type, #{
+                                        line => 4,
+                                        source => inferred,
+                                        spec => int
+                                    }}
+                            }},
+                        type =>
+                            {type, #{
+                                line => 5,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }},
+                line => 5,
+                right =>
+                    {int_lit, #{
+                        line => 5,
+                        spec => 2,
+                        type =>
+                            {type, #{
+                                line => 5,
+                                source => inferred,
+                                spec => int
+                            }}
+                    }}
+            }},
+        globals => #{
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => n
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {binary_op, #{
+                                    left =>
+                                        {int_lit, #{
+                                            line => 5,
+                                            spec => 1,
+                                            type =>
+                                                {type, #{
+                                                    line => 5,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                    line => 5,
+                                    op => '+',
+                                    right =>
+                                        {identifier, #{
+                                            line => 5,
+                                            spec => n
+                                        }}
+                                }},
+                            line => 5,
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{
+            n =>
+                {type, #{
+                    line => 4,
+                    source => inferred,
+                    spec => int
+                }}
+        }
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int { Two() = Two() }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int { Two() = Two() }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {match, #{left => {call, #{args => [],
-                                                line => 4,
-                                                spec => 'Two',
-                                                type => {type, #{line => 3,
-                                                                 source => rufus_text,
-                                                                 spec => int}}}},
-                               line => 4,
-                               right => {call, #{args => [],
-                                                 line => 4,
-                                                 spec => 'Two'}}}},
-             globals => #{'Random' => [{func, #{exprs => [{match, #{left => {call, #{args => [],
-                                                                                     line => 4,
-                                                                                     spec => 'Two'}},
-                                                                    line => 4,
-                                                                    right => {call, #{args => [],
-                                                                                      line => 4,
-                                                                                      spec => 'Two'}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             locals => #{}},
+    Data = #{
+        form =>
+            {match, #{
+                left =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two',
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }},
+                line => 4,
+                right =>
+                    {call, #{
+                        args => [],
+                        line => 4,
+                        spec => 'Two'
+                    }}
+            }},
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }},
+                            line => 4,
+                            right =>
+                                {call, #{
+                                    args => [],
+                                    line => 4,
+                                    spec => 'Two'
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        locals => #{}
+    },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_type_test() ->
-    RufusText = "
-    module example
-    func Two() int { 2 }
-    func Random() int {
-        n = \"hello\"
-        n = Two()
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Two() int { 2 }\n"
+        "    func Random() int {\n"
+        "        n = \"hello\"\n"
+        "        n = Two()\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{globals => #{'Random' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 5,
-                                                                                           spec => n}},
-                                                                    line => 5,
-                                                                    right => {string_lit, #{line => 5,
-                                                                                            spec => <<"hello">>,
-                                                                                            type => {type, #{line => 5,
-                                                                                                             source => inferred,
-                                                                                                             spec => string}}}}}},
-                                                          {match, #{left => {identifier, #{line => 6,
-                                                                                           spec => n}},
-                                                                    line => 6,
-                                                                    right => {call, #{args => [],
-                                                                                      line => 6,
-                                                                                      spec => 'Two'}}}}],
-                                                line => 4,
-                                                params => [],
-                                                return_type => {type, #{line => 4,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Random'}}],
-                          'Two' => [{func, #{exprs => [{int_lit, #{line => 3,
-                                                                   spec => 2,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => int}}}}],
-                                             line => 3,
-                                             params => [],
-                                             return_type => {type, #{line => 3,
-                                                                     source => rufus_text,
-                                                                     spec => int}},
-                                             spec => 'Two'}}]},
-             left => {identifier, #{line => 6,
-                                    spec => n,
-                                    type => {type, #{line => 5,
-                                                     source => inferred,
-                                                     spec => string}}}},
-             locals => #{n => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => string}}},
-             right => {call, #{args => [],
-                               line => 6,
-                               spec => 'Two',
-                               type => {type, #{line => 3,
-                                                source => rufus_text,
-                                                spec => int}}}}},
+    Data = #{
+        globals => #{
+            'Random' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => n
+                                }},
+                            line => 5,
+                            right =>
+                                {string_lit, #{
+                                    line => 5,
+                                    spec => <<"hello">>,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => string
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => n
+                                }},
+                            line => 6,
+                            right =>
+                                {call, #{
+                                    args => [],
+                                    line => 6,
+                                    spec => 'Two'
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Random'
+                }}
+            ],
+            'Two' => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 3,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Two'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 6,
+                spec => n,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => string
+                    }}
+            }},
+        locals => #{
+            n =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => string
+                }}
+        },
+        right =>
+            {call, #{
+                args => [],
+                line => 6,
+                spec => 'Two',
+                type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => int
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_arg_type_test() ->
-    RufusText = "
-    module example
-    func Echo(n int) int { n }
-    func Random() int {
-        2 = Echo(:two)
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Random() int {\n"
+        "        2 = Echo(:two)\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{args => [{atom_lit, #{line => 5,
-                                   spec => two,
-                                   type => {type, #{line => 5,
-                                                    source => inferred,
-                                                    spec => atom}}}}],
-             funcs => [{func, #{exprs => [{identifier, #{line => 3,
-                                                         spec => n}}],
+    Data = #{
+        args => [
+            {atom_lit, #{
+                line => 5,
+                spec => two,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => atom
+                    }}
+            }}
+        ],
+        funcs => [
+            {func, #{
+                exprs => [
+                    {identifier, #{
+                        line => 3,
+                        spec => n
+                    }}
+                ],
+                line => 3,
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => n,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                params => [{param, #{line => 3,
-                                                     spec => n,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => int}}}}],
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => int}},
-                                spec => 'Echo'}}]},
+                                source => rufus_text,
+                                spec => int
+                            }}
+                    }}
+                ],
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => int
+                    }},
+                spec => 'Echo'
+            }}
+        ]
+    },
     ?assertEqual({error, unmatched_args, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 %% match expressions with type constraint violations
 
 typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        value = 1
-        value = unbound
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        value = 1\n"
+        "        value = unbound\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{form => {identifier, #{line => 5,
-                                    locals => #{value => {type, #{line => 4,
-                                                                  source => inferred,
-                                                                  spec => int}}},
-                                    spec => unbound}},
-             globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => value}},
-                                                                    line => 4,
-                                                                    right => {int_lit, #{line => 4,
-                                                                                         spec => 1,
-                                                                                         type => {type, #{line => 4,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}},
-                                                          {match, #{left => {identifier, #{line => 5,
-                                                                                           spec => value}},
-                                                                    line => 5,
-                                                                    right => {identifier, #{line => 5,
-                                                                                            spec => unbound}}}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             locals => #{value => {type, #{line => 4,
-                                           source => inferred,
-                                           spec => int}}}},
+    Data = #{
+        form =>
+            {identifier, #{
+                line => 5,
+                locals => #{
+                    value =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                },
+                spec => unbound
+            }},
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => value
+                                }},
+                            line => 4,
+                            right =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => value
+                                }},
+                            line => 5,
+                            right =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => unbound
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        locals => #{
+            value =>
+                {type, #{
+                    line => 4,
+                    source => inferred,
+                    spec => int
+                }}
+        }
+    },
     ?assertEqual({error, unbound_variable, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        unbound1 = unbound2
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        unbound1 = unbound2\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => unbound1}},
-                                                                    line => 4,
-                                                                    right => {identifier, #{line => 4,
-                                                                                            spec => unbound2}}}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             left => {identifier, #{line => 4,
-                                    locals => #{},
-                                    spec => unbound1}},
-             locals => #{},
-             right => {identifier, #{line => 4,
-                                     locals => #{},
-                                     spec => unbound2}}},
+    Data = #{
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => unbound1
+                                }},
+                            line => 4,
+                            right =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => unbound2
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 4,
+                locals => #{},
+                spec => unbound1
+            }},
+        locals => #{},
+        right =>
+            {identifier, #{
+                line => 4,
+                locals => #{},
+                spec => unbound2
+            }}
+    },
     ?assertEqual({error, unbound_variables, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
 typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
-    RufusText = "
-    module example
-    func Broken() int {
-        a = :hello
-        i = 42
-        a = i
-        i
-    }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Broken() int {\n"
+        "        a = :hello\n"
+        "        i = 42\n"
+        "        a = i\n"
+        "        i\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Data = #{globals => #{'Broken' => [{func, #{exprs => [{match, #{left => {identifier, #{line => 4,
-                                                                                           spec => a}},
-                                                                    line => 4,
-                                                                    right => {atom_lit, #{line => 4,
-                                                                                          spec => hello,
-                                                                                          type => {type, #{line => 4,
-                                                                                                           source => inferred,
-                                                                                                           spec => atom}}}}}},
-                                                          {match, #{left => {identifier, #{line => 5,
-                                                                                           spec => i}},
-                                                                    line => 5,
-                                                                    right => {int_lit, #{line => 5,
-                                                                                         spec => 42,
-                                                                                         type => {type, #{line => 5,
-                                                                                                          source => inferred,
-                                                                                                          spec => int}}}}}},
-                                                          {match, #{left => {identifier, #{line => 6,
-                                                                                           spec => a}},
-                                                                    line => 6,
-                                                                    right => {identifier, #{line => 6,
-                                                                                            spec => i}}}},
-                                                          {identifier, #{line => 7,
-                                                                         spec => i}}],
-                                                line => 3,
-                                                params => [],
-                                                return_type => {type, #{line => 3,
-                                                                        source => rufus_text,
-                                                                        spec => int}},
-                                                spec => 'Broken'}}]},
-             left => {identifier, #{line => 6,
-                                    spec => a,
-                                    type => {type, #{line => 4,
-                                                     source => inferred,
-                                                     spec => atom}}}},
-             locals => #{a => {type, #{line => 4,
-                                       source => inferred,
-                                       spec => atom}},
-                         i => {type, #{line => 5,
-                                       source => inferred,
-                                       spec => int}}},
-             right => {identifier, #{line => 6,
-                                     spec => i,
-                                     type => {type, #{line => 5,
-                                                      source => inferred,
-                                                      spec => int}}}}},
+    Data = #{
+        globals => #{
+            'Broken' => [
+                {func, #{
+                    exprs => [
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => a
+                                }},
+                            line => 4,
+                            right =>
+                                {atom_lit, #{
+                                    line => 4,
+                                    spec => hello,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => atom
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => i
+                                }},
+                            line => 5,
+                            right =>
+                                {int_lit, #{
+                                    line => 5,
+                                    spec => 42,
+                                    type =>
+                                        {type, #{
+                                            line => 5,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                        }},
+                        {match, #{
+                            left =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => a
+                                }},
+                            line => 6,
+                            right =>
+                                {identifier, #{
+                                    line => 6,
+                                    spec => i
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 7,
+                            spec => i
+                        }}
+                    ],
+                    line => 3,
+                    params => [],
+                    return_type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    spec => 'Broken'
+                }}
+            ]
+        },
+        left =>
+            {identifier, #{
+                line => 6,
+                spec => a,
+                type =>
+                    {type, #{
+                        line => 4,
+                        source => inferred,
+                        spec => atom
+                    }}
+            }},
+        locals => #{
+            a =>
+                {type, #{
+                    line => 4,
+                    source => inferred,
+                    spec => atom
+                }},
+            i =>
+                {type, #{
+                    line => 5,
+                    source => inferred,
+                    spec => int
+                }}
+        },
+        right =>
+            {identifier, #{
+                line => 6,
+                spec => i,
+                type =>
+                    {type, #{
+                        line => 5,
+                        source => inferred,
+                        spec => int
+                    }}
+            }}
+    },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -9,70 +9,136 @@ globals_without_func_forms_test() ->
     ?assertEqual({ok, #{}}, rufus_form:globals(Forms)).
 
 globals_test() ->
-    RufusText = "
-    module example
-    func Echo(n string) string { n }
-    func Number() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n string) string { n }\n"
+        "    func Number() int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Echo1 = {func, #{params => [{param, #{line => 3,
-                                          spec => n,
-                                          type => {type, #{line => 3,
-                                                           source => rufus_text,
-                                                           spec => string}}}}],
-                     exprs => [{identifier, #{line => 3,
-                                              spec => n}}],
-                     line => 3,
-                     return_type => {type, #{line => 3,
-                                             source => rufus_text,
-                                             spec => string}},
-                     spec => 'Echo'}},
-    Number0 = {func, #{params => [],
-                       exprs => [{int_lit, #{line => 4,
-                                             spec => 42,
-                                             type => {type, #{line => 4,
-                                                              source => inferred,
-                                                              spec => int}}}}],
-                       line => 4,
-                       return_type => {type, #{line => 4,
-                                               source => rufus_text,
-                                               spec => int}},
-                       spec => 'Number'}},
+    Echo1 =
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }},
+    Number0 =
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 4,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 4,
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Number'
+        }},
     ?assertEqual({ok, #{'Echo' => [Echo1], 'Number' => [Number0]}}, rufus_form:globals(Forms)).
 
 globals_with_multiple_function_heads_test() ->
-    RufusText = "
-    module example
-    func Echo(n string) string { n }
-    func Echo(n int) int { n }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(n string) string { n }\n"
+        "    func Echo(n int) int { n }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    EchoString = {func, #{params => [{param, #{line => 3,
-                                               spec => n,
-                                               type => {type, #{line => 3,
-                                                                source => rufus_text,
-                                                                spec => string}}}}],
-                          exprs => [{identifier, #{line => 3,
-                                                   spec => n}}],
-                          line => 3,
-                          return_type => {type, #{line => 3,
-                                                  source => rufus_text,
-                                                  spec => string}},
-                          spec => 'Echo'}},
-    EchoInt = {func, #{params => [{param, #{line => 4,
-                                            spec => n,
-                                            type => {type, #{line => 4,
-                                                             source => rufus_text,
-                                                             spec => int}}}}],
-                       exprs => [{identifier, #{line => 4,
-                                                spec => n}}],
-                       line => 4,
-                       return_type => {type, #{line => 4,
-                                               source => rufus_text,
-                                               spec => int}},
-                       spec => 'Echo'}},
+    EchoString =
+        {func, #{
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => rufus_text,
+                            spec => string
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 3,
+                    spec => n
+                }}
+            ],
+            line => 3,
+            return_type =>
+                {type, #{
+                    line => 3,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }},
+    EchoInt =
+        {func, #{
+            params => [
+                {param, #{
+                    line => 4,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            exprs => [
+                {identifier, #{
+                    line => 4,
+                    spec => n
+                }}
+            ],
+            line => 4,
+            return_type =>
+                {type, #{
+                    line => 4,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Echo'
+        }},
     ?assertEqual({ok, #{'Echo' => [EchoString, EchoInt]}}, rufus_form:globals(Forms)).
 
 line_test() ->
@@ -144,14 +210,30 @@ make_identifier_test() ->
     ?assertEqual({identifier, #{spec => n, line => 13}}, rufus_form:make_identifier(n, 13)).
 
 make_literal_test() ->
-    ?assertEqual({bool_lit, #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
-                 rufus_form:make_literal(bool, true, 7)),
-    ?assertEqual({float_lit, #{spec => "37.103", line => 92, type => rufus_form:make_inferred_type(float, 92)}},
-                 rufus_form:make_literal(float, "37.103", 92)),
-    ?assertEqual({int_lit, #{spec => "42", line => 5, type => rufus_form:make_inferred_type(int, 5)}},
-                 rufus_form:make_literal(int, "42", 5)),
-    ?assertEqual({string_lit, #{spec => <<"hello">>, line => 9, type => rufus_form:make_inferred_type(string, 9)}},
-                 rufus_form:make_literal(string, <<"hello">>, 9)).
+    ?assertEqual(
+        {bool_lit, #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
+        rufus_form:make_literal(bool, true, 7)
+    ),
+    ?assertEqual(
+        {float_lit, #{
+            spec => "37.103",
+            line => 92,
+            type => rufus_form:make_inferred_type(float, 92)
+        }},
+        rufus_form:make_literal(float, "37.103", 92)
+    ),
+    ?assertEqual(
+        {int_lit, #{spec => "42", line => 5, type => rufus_form:make_inferred_type(int, 5)}},
+        rufus_form:make_literal(int, "42", 5)
+    ),
+    ?assertEqual(
+        {string_lit, #{
+            spec => <<"hello">>,
+            line => 9,
+            type => rufus_form:make_inferred_type(string, 9)
+        }},
+        rufus_form:make_literal(string, <<"hello">>, 9)
+    ).
 
 make_binary_op_test() ->
     Left = rufus_form:make_literal(int, 2, 13),
@@ -178,24 +260,43 @@ make_func_test() ->
     Type = rufus_form:make_type(bool, 81),
     Param = rufus_form:make_literal(bool, true, 81),
     Value = rufus_form:make_literal(bool, true, 81),
-    ?assertEqual({func, #{spec => 'True', params => [Param], return_type => Type, exprs => [Value], line => 81}},
-                 rufus_form:make_func('True', [Param], Type, [Value], 81)).
+    ?assertEqual(
+        {func, #{
+            spec => 'True',
+            params => [Param],
+            return_type => Type,
+            exprs => [Value],
+            line => 81
+        }},
+        rufus_form:make_func('True', [Param], Type, [Value], 81)
+    ).
 
 make_param_test() ->
     Type = rufus_form:make_type(int, 52),
-    ?assertEqual({param, #{spec => n, type => Type, line => 52}}, rufus_form:make_param(n, Type, 52)).
+    ?assertEqual(
+        {param, #{spec => n, type => Type, line => 52}},
+        rufus_form:make_param(n, Type, 52)
+    ).
 
 make_inferred_type_test() ->
-    ?assertEqual({type, #{spec => int, source => inferred, line => 4}}, rufus_form:make_inferred_type(int, 4)).
+    ?assertEqual(
+        {type, #{spec => int, source => inferred, line => 4}},
+        rufus_form:make_inferred_type(int, 4)
+    ).
 
 make_type_test() ->
-    ?assertEqual({type, #{spec => float, source => rufus_text, line => 37}}, rufus_form:make_type(float, 37)).
+    ?assertEqual(
+        {type, #{spec => float, source => rufus_text, line => 37}},
+        rufus_form:make_type(float, 37)
+    ).
 
 make_match_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
-    ?assertEqual({match, #{left => Left, right => Right, line => 3}},
-                 rufus_form:make_match(Left, Right, 3)).
+    ?assertEqual(
+        {match, #{left => Left, right => Right, line => 3}},
+        rufus_form:make_match(Left, Right, 3)
+    ).
 
 map_with_empty_input_test() ->
     ?assertEqual([], rufus_form:map([], fun annotate/1)).
@@ -206,7 +307,9 @@ map_with_noop_function_test() ->
 
 map_test() ->
     Form = rufus_form:make_literal(bool, true, 7),
-    Expected1 = {bool_lit, Context = #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
+    Expected1 =
+        {bool_lit,
+            Context = #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
     ?assertEqual(Expected1, Form),
     [AnnotatedForm] = rufus_form:map([Form], fun annotate/1),
     Expected2 = {bool_lit, Context#{annotated => true}},
@@ -216,63 +319,108 @@ map_with_binary_op_test() ->
     Left = rufus_form:make_literal(int, 2, 13),
     Right = rufus_form:make_literal(int, 3, 13),
     Form = rufus_form:make_binary_op('+', Left, Right, 13),
-    ?assertMatch([{binary_op, #{left := {_, #{annotated := true}}, right := {_, #{annotated := true}}, annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {binary_op, #{
+                left := {_, #{annotated := true}},
+                right := {_, #{annotated := true}},
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_call_test() ->
     Args = [rufus_form:make_literal(string, <<"hello">>, 3)],
     Form = rufus_form:make_call('Echo', Args, 13),
-    ?assertMatch([{call, #{args := [{_, #{annotated := true}}], annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [{call, #{args := [{_, #{annotated := true}}], annotated := true}}],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_cons_test() ->
     Line = 17,
     Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),
     TailForm = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), [], Line),
     Form = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), [TailForm], Line),
-    ?assertMatch([{cons, #{head := {_, #{annotated := true}},
-                           tail := [{cons, #{head := {_, #{annotated := true}},
-                                             tail := [], annotated := true}}],
-                           annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {cons, #{
+                head := {_, #{annotated := true}},
+                tail := [
+                    {cons, #{
+                        head := {_, #{annotated := true}},
+                        tail := [],
+                        annotated := true
+                    }}
+                ],
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_cons_and_tail_identifier_test() ->
     Line = 17,
     Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),
     TailForm = rufus_form:make_identifier('tail', 3),
     Form = rufus_form:make_cons(Type, rufus_form:make_literal(int, 3, Line), TailForm, Line),
-    ?assertMatch([{cons, #{head := {_, #{annotated := true}},
-                           tail := {identifier, #{spec := tail}},
-                           annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {cons, #{
+                head := {_, #{annotated := true}},
+                tail := {identifier, #{spec := tail}},
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_func_test() ->
     Type = rufus_form:make_type(bool, 81),
     Param = rufus_form:make_literal(bool, true, 81),
     Value = rufus_form:make_literal(bool, true, 81),
     Form = rufus_form:make_func('True', [Param], Type, [Value], 81),
-    ?assertMatch([{func, #{params := [{bool_lit, #{annotated := true}}],
-                           exprs := [{bool_lit, #{annotated := true}}],
-                           annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {func, #{
+                params := [{bool_lit, #{annotated := true}}],
+                exprs := [{bool_lit, #{annotated := true}}],
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_list_lit_test() ->
     ElementType = rufus_form:make_type(bool, 81),
     Type = rufus_form:make_type(list, ElementType, 81),
     Value = rufus_form:make_literal(bool, true, 81),
     Form = rufus_form:make_literal(list, Type, [Value], 81),
-    ?assertMatch([{list_lit, #{elements := [{bool_lit, #{annotated := true}}],
-                               annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {list_lit, #{
+                elements := [{bool_lit, #{annotated := true}}],
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 map_with_match_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
     Form = rufus_form:make_match(Left, Right, 3),
-    ?assertMatch([{match, #{left := {_, #{annotated := true}},
-                            right := {_, #{annotated := true}},
-                            annotated := true}}],
-                 rufus_form:map([Form], fun annotate/1)).
+    ?assertMatch(
+        [
+            {match, #{
+                left := {_, #{annotated := true}},
+                right := {_, #{annotated := true}},
+                annotated := true
+            }}
+        ],
+        rufus_form:map([Form], fun annotate/1)
+    ).
 
 annotate({FormType, Context}) ->
     {FormType, Context#{annotated => true}}.

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -8,275 +8,550 @@ parse_function_adding_two_ints_test() ->
     RufusText = "func Three() int { 1 + 2 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{line => 1,
-                                                 op => '+',
-                                                 left => {int_lit, #{line => 1,
-                                                                     spec => 1,
-                                                                     type => {type, #{line => 1,
-                                                                                      spec => int,
-                                                                                      source => inferred}}}},
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Three'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    line => 1,
+                    op => '+',
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }},
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Three'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_adding_three_ints_test() ->
     RufusText = "func Six() int { 1 + 2 + 3 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{left => {binary_op, #{op => '+',
-                                                                       left => {int_lit, #{line => 1,
-                                                                                           spec => 1,
-                                                                                           type => {type, #{line => 1,
-                                                                                                            spec => int,
-                                                                                                            source => inferred}}}},
-                                                                       right => {int_lit, #{line => 1,
-                                                                                            spec => 2,
-                                                                                            type => {type, #{line => 1,
-                                                                                                             spec => int,
-                                                                                                             source => inferred}}}},
-                                                                       line => 1}},
-                                                 line => 1,
-                                                 op => '+',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 3,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Six'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            op => '+',
+                            left =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            right =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            line => 1
+                        }},
+                    line => 1,
+                    op => '+',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Six'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_subtracting_two_ints_test() ->
     RufusText = "func One() int { 2 - 1 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{line => 1,
-                                                 op => '-',
-                                                 left => {int_lit, #{line => 1,
-                                                                     spec => 2,
-                                                                     type => {type, #{line => 1,
-                                                                                      spec => int,
-                                                                                      source => inferred}}}},
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 1,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'One'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    line => 1,
+                    op => '-',
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }},
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'One'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_subtracting_three_ints_test() ->
     RufusText = "func MinusNine() int { 3 - 5 - 7 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{left => {binary_op, #{op => '-',
-                                                                       left => {int_lit, #{line => 1,
-                                                                                           spec => 3,
-                                                                                           type => {type, #{line => 1,
-                                                                                                            spec => int,
-                                                                                                            source => inferred}}}},
-                                                                       right => {int_lit, #{line => 1,
-                                                                                            spec => 5,
-                                                                                            type => {type, #{line => 1,
-                                                                                                             spec => int,
-                                                                                                             source => inferred}}}},
-                                                                       line => 1}},
-                                                 line => 1,
-                                                 op => '-',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 7,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'MinusNine'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            op => '-',
+                            left =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            right =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 5,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            line => 1
+                        }},
+                    line => 1,
+                    op => '-',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 7,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'MinusNine'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_multiplying_two_ints_test() ->
     RufusText = "func FortyTwo() int { 2 * 21 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{line => 1,
-                                                 op => '*',
-                                                 left => {int_lit, #{line => 1,
-                                                                     spec => 2,
-                                                                     type => {type, #{line => 1,
-                                                                                      spec => int,
-                                                                                      source => inferred}}}},
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 21,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    line => 1,
+                    op => '*',
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }},
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 21,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_multiplying_three_ints_test() ->
     RufusText = "func OneTwenty() int { 4 * 5 * 6 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{left => {binary_op, #{op => '*',
-                                                                       left => {int_lit, #{line => 1,
-                                                                                           spec => 4,
-                                                                                           type => {type, #{line => 1,
-                                                                                                            spec => int,
-                                                                                                            source => inferred}}}},
-                                                                       right => {int_lit, #{line => 1,
-                                                                                            spec => 5,
-                                                                                            type => {type, #{line => 1,
-                                                                                                             spec => int,
-                                                                                                             source => inferred}}}},
-                                                                       line => 1}},
-                                                 line => 1,
-                                                 op => '*',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 6,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'OneTwenty'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            op => '*',
+                            left =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 4,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            right =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 5,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            line => 1
+                        }},
+                    line => 1,
+                    op => '*',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 6,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'OneTwenty'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_dividing_two_ints_test() ->
     RufusText = "func FortyTwo() int { 84 / 2 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{line => 1,
-                                                 op => '/',
-                                                 left => {int_lit, #{line => 1,
-                                                                     spec => 84,
-                                                                     type => {type, #{line => 1,
-                                                                                      spec => int,
-                                                                                      source => inferred}}}},
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    line => 1,
+                    op => '/',
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 84,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }},
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_dividing_three_ints_test() ->
     RufusText = "func Five() int { 100 / 10 / 2 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{left => {binary_op, #{op => '/',
-                                                                       left => {int_lit, #{line => 1,
-                                                                                           spec => 100,
-                                                                                           type => {type, #{line => 1,
-                                                                                                            spec => int,
-                                                                                                            source => inferred}}}},
-                                                                       right => {int_lit, #{line => 1,
-                                                                                            spec => 10,
-                                                                                            type => {type, #{line => 1,
-                                                                                                             spec => int,
-                                                                                                             source => inferred}}}},
-                                                                       line => 1}},
-                                                 line => 1,
-                                                 op => '/',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 2,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Five'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            op => '/',
+                            left =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 100,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            right =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 10,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            line => 1
+                        }},
+                    line => 1,
+                    op => '/',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Five'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_remaindering_two_ints_test() ->
     RufusText = "func Six() int { 27 % 7 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{line => 1,
-                                                 op => '%',
-                                                 left => {int_lit, #{line => 1,
-                                                                     spec => 27,
-                                                                     type => {type, #{line => 1,
-                                                                                      spec => int,
-                                                                                      source => inferred}}}},
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 7,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Six'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    line => 1,
+                    op => '%',
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 27,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }},
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 7,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Six'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_remaindering_three_ints_test() ->
     RufusText = "func Four() int { 100 % 13 % 5 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{binary_op, #{left => {binary_op, #{op => '%',
-                                                                       left => {int_lit, #{line => 1,
-                                                                                           spec => 100,
-                                                                                           type => {type, #{line => 1,
-                                                                                                            spec => int,
-                                                                                                            source => inferred}}}},
-                                                                       right => {int_lit, #{line => 1,
-                                                                                            spec => 13,
-                                                                                            type => {type, #{line => 1,
-                                                                                                             spec => int,
-                                                                                                             source => inferred}}}},
-                                                                       line => 1}},
-                                                 line => 1,
-                                                 op => '%',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 5,
-                                                                      type => {type, #{line => 1,
-                                                                                       spec => int,
-                                                                                       source => inferred}}}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Four'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {binary_op, #{
+                            op => '%',
+                            left =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 100,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            right =>
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 13,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            spec => int,
+                                            source => inferred
+                                        }}
+                                }},
+                            line => 1
+                        }},
+                    line => 1,
+                    op => '%',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 5,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    spec => int,
+                                    source => inferred
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Four'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 %% Conditional operators
@@ -285,48 +560,94 @@ parse_function_anding_two_bools_test() ->
     RufusText = "func Falsy() bool { true and false }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 1,
-                                                 op => 'and',
-                                                 right => {bool_lit, #{line => 1,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 1,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 1,
+                    op => 'and',
+                    right =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_oring_two_bools_test() ->
     RufusText = "func Truthy() bool { true or false }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 1,
-                                                 op => 'or',
-                                                 right => {bool_lit, #{line => 1,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 1,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Truthy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 1,
+                    op => 'or',
+                    right =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Truthy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 %% Comparison operators
@@ -335,142 +656,280 @@ parse_function_comparing_two_bools_for_equality_test() ->
     RufusText = "func Falsy() bool { true == false }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 1,
-                                                 op => '==',
-                                                 right => {bool_lit, #{line => 1,
-                                                                       spec => false,
-                                                                       type => {type, #{line => 1,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 1,
+                    op => '==',
+                    right =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => false,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_comparing_two_bools_for_inequality_test() ->
     RufusText = "func Falsy() bool { true != true }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {bool_lit, #{line => 1,
-                                                                      spec => true,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => bool}}}},
-                                                 line => 1,
-                                                 op => '!=',
-                                                 right => {bool_lit, #{line => 1,
-                                                                       spec => true,
-                                                                       type => {type, #{line => 1,
-                                                                                        source => inferred,
-                                                                                        spec => bool}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }},
+                    line => 1,
+                    op => '!=',
+                    right =>
+                        {bool_lit, #{
+                            line => 1,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_comparing_two_ints_to_determine_which_is_lesser_test() ->
     RufusText = "func Falsy() bool { 5 < 3 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
-                                                                     spec => 5,
-                                                                     type => {type, #{line => 1,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 1,
-                                                 op => '<',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 3,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 5,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 1,
+                    op => '<',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_comparing_two_ints_to_determine_which_is_lesser_or_equal_test() ->
     RufusText = "func Falsy() bool { 5 <= 3 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
-                                                                     spec => 5,
-                                                                     type => {type, #{line => 1,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 1,
-                                                 op => '<=',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 3,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 5,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 1,
+                    op => '<=',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_comparing_two_ints_to_determine_which_is_greater_test() ->
     RufusText = "func Falsy() bool { 3 > 5 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
-                                                                     spec => 3,
-                                                                     type => {type, #{line => 1,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 1,
-                                                 op => '>',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 5,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 1,
+                    op => '>',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 5,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_comparing_two_ints_to_determine_which_is_greater_or_equal_test() ->
     RufusText = "func Falsy() bool { 3 >= 5 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{binary_op, #{left => {int_lit, #{line => 1,
-                                                                     spec => 3,
-                                                                     type => {type, #{line => 1,
-                                                                                      source => inferred,
-                                                                                      spec => int}}}},
-                                                 line => 1,
-                                                 op => '>=',
-                                                 right => {int_lit, #{line => 1,
-                                                                      spec => 5,
-                                                                      type => {type, #{line => 1,
-                                                                                       source => inferred,
-                                                                                       spec => int}}}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Falsy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 3,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 1,
+                    op => '>=',
+                    right =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 5,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Falsy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_call_test.erl
+++ b/rf/test/rufus_parse_call_test.erl
@@ -8,15 +8,26 @@ parse_function_calling_a_function_without_arguments_test() ->
     RufusText = "func Random() int { Four() }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{call, #{args => [],
-                                            line => 1,
-                                            spec => 'Four'}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Random'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {call, #{
+                    args => [],
+                    line => 1,
+                    spec => 'Four'
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Random'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 %% Arity-0 functions calling an arity-1 function
@@ -25,17 +36,35 @@ parse_function_calling_a_function_with_an_argument_test() ->
     RufusText = "func Echo() string { Echo(\"Hello\") }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{call, #{args => [{string_lit, #{line => 1,
-                                                                    spec => <<"Hello">>,
-                                                                    type => {type, #{line => 1,
-                                                                                     source => inferred,
-                                                                                     spec => string}}}}],
-                                            line => 1,
-                                            spec => 'Echo'}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {call, #{
+                    args => [
+                        {string_lit, #{
+                            line => 1,
+                            spec => <<"Hello">>,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => string
+                                }}
+                        }}
+                    ],
+                    line => 1,
+                    spec => 'Echo'
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -8,164 +8,293 @@ parse_function_returning_an_atom_test() ->
     RufusText = "func Color() atom { :indigo }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{atom_lit, #{line => 1,
-                                                spec => indigo,
-                                                type => {type, #{line => 1,
-                                                                 spec => atom,
-                                                                 source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => atom,
-                                                 source => rufus_text}},
-                         spec => 'Color'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {atom_lit, #{
+                    line => 1,
+                    spec => indigo,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => atom,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => atom,
+                    source => rufus_text
+                }},
+            spec => 'Color'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_a_bool_test() ->
     RufusText = "func True() bool { true }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{bool_lit, #{line => 1,
-                                                spec => true,
-                                                type => {type, #{line => 1,
-                                                                 spec => bool,
-                                                                 source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => bool,
-                                                 source => rufus_text}},
-                         spec => 'True'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {bool_lit, #{
+                    line => 1,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => bool,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => bool,
+                    source => rufus_text
+                }},
+            spec => 'True'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_a_float_test() ->
     RufusText = "func Pi() float { 3.14159265359 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{float_lit, #{line => 1,
-                                                 spec => 3.14159265359,
-                                                 type => {type, #{line => 1,
-                                                                  spec => float,
-                                                                  source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => float,
-                                                 source => rufus_text}},
-                         spec => 'Pi'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {float_lit, #{
+                    line => 1,
+                    spec => 3.14159265359,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => float,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => float,
+                    source => rufus_text
+                }},
+            spec => 'Pi'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_an_int_test() ->
     RufusText = "func Number() int { 42 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{int_lit, #{line => 1,
-                                               spec => 42,
-                                               type => {type, #{line => 1,
-                                                                spec => int,
-                                                                source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Number'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 1,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => int,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Number'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_a_string_test() ->
     RufusText = "func Greeting() string { \"Hello\" }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{string_lit, #{line => 1,
-                                                  spec => <<"Hello">>,
-                                                  type => {type, #{line => 1,
-                                                                   spec => string,
-                                                                   source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => string,
-                                                 source => rufus_text}},
-                         spec => 'Greeting'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {string_lit, #{
+                    line => 1,
+                    spec => <<"Hello">>,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => string,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => string,
+                    source => rufus_text
+                }},
+            spec => 'Greeting'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 %% Arity-0 functions with multiple function expressions
 
 forms_for_function_with_multiple_expressions_test() ->
-    RufusText = "
-    func Multiple() atom {
-        42
-        :fortytwo
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Multiple() atom {\n"
+        "        42\n"
+        "        :fortytwo\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{int_lit, #{line => 3,
-                                               spec => 42,
-                                               type => {type, #{line => 3,
-                                                                source => inferred,
-                                                                spec => int}}}},
-                                   {atom_lit, #{line => 4,
-                                                spec => fortytwo,
-                                                type => {type, #{line => 4,
-                                                                 source => inferred,
-                                                                 spec => atom}}}}],
-                         line => 2,
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Multiple'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {atom_lit, #{
+                    line => 4,
+                    spec => fortytwo,
+                    type =>
+                        {type, #{
+                            line => 4,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 2,
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Multiple'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
-    RufusText = "
-    func Multiple() atom {
-        42
-
-        :fortytwo
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Multiple() atom {\n"
+        "        42\n"
+        "\n"
+        "        :fortytwo\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{int_lit, #{line => 3,
-                                               spec => 42,
-                                               type => {type, #{line => 3,
-                                                                source => inferred,
-                                                                spec => int}}}},
-                                   {atom_lit, #{line => 5,
-                                                spec => fortytwo,
-                                                type => {type, #{line => 5,
-                                                                 source => inferred,
-                                                                 spec => atom}}}}],
-                         line => 2,
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Multiple'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 3,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 3,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {atom_lit, #{
+                    line => 5,
+                    spec => fortytwo,
+                    type =>
+                        {type, #{
+                            line => 5,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 2,
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Multiple'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 forms_for_function_with_multiple_expressions_separated_by_semicolons_test() ->
     RufusText = "func Multiple() atom { 42; :fortytwo }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [],
-                         exprs => [{int_lit, #{line => 1,
-                                               spec => 42,
-                                               type => {type, #{line => 1,
-                                                                source => inferred,
-                                                                spec => int}}}},
-                                   {atom_lit, #{line => 1,
-                                                spec => fortytwo,
-                                                type => {type, #{line => 1,
-                                                                 source => inferred,
-                                                                 spec => atom}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Multiple'}}],
+    Expected = [
+        {func, #{
+            params => [],
+            exprs => [
+                {int_lit, #{
+                    line => 1,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => int
+                        }}
+                }},
+                {atom_lit, #{
+                    line => 1,
+                    spec => fortytwo,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Multiple'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 forms_for_function_with_multiple_expressions_without_end_of_expression_separator_test() ->
@@ -180,105 +309,210 @@ parse_function_taking_an_atom_and_returning_an_atom_test() ->
     RufusText = "func Color(c atom) atom { :indigo }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [{param, #{line => 1,
-                                              spec => c,
-                                              type => {type, #{line => 1,
-                                                               spec => atom,
-                                                               source => rufus_text}}}}],
-                         exprs => [{atom_lit, #{line => 1,
-                                                spec => indigo,
-                                                type => {type, #{line => 1,
-                                                                 spec => atom,
-                                                                 source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => atom,
-                                                 source => rufus_text}},
-                         spec => 'Color'}}],
+    Expected = [
+        {func, #{
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => c,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => atom,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {atom_lit, #{
+                    line => 1,
+                    spec => indigo,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => atom,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => atom,
+                    source => rufus_text
+                }},
+            spec => 'Color'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_a_bool_and_returning_a_bool_test() ->
     RufusText = "func Echo(n bool) bool { true }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [{param, #{line => 1,
-                                              spec => n,
-                                              type => {type, #{line => 1,
-                                                               spec => bool,
-                                                               source => rufus_text}}}}],
-                         exprs => [{bool_lit, #{line => 1,
-                                                spec => true,
-                                                type => {type, #{line => 1,
-                                                                 spec => bool,
-                                                                 source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => bool,
-                                                 source => rufus_text}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => bool,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {bool_lit, #{
+                    line => 1,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => bool,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => bool,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_an_float_and_returning_an_float_test() ->
     RufusText = "func Echo(n float) float { 3.14159265359 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [{param, #{line => 1,
-                                              spec => n,
-                                              type => {type, #{line => 1,
-                                                               spec => float,
-                                                               source => rufus_text}}}}],
-                         exprs => [{float_lit, #{line => 1,
-                                                 spec => 3.14159265359,
-                                                 type => {type, #{line => 1,
-                                                                  spec => float,
-                                                                  source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => float,
-                                                 source => rufus_text}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => float,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {float_lit, #{
+                    line => 1,
+                    spec => 3.14159265359,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => float,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => float,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_an_int_and_returning_an_int_test() ->
     RufusText = "func Echo(n int) int { 42 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [{param, #{line => 1,
-                                              spec => n,
-                                              type => {type, #{line => 1,
-                                                               spec => int,
-                                                               source => rufus_text}}}}],
-                         exprs => [{int_lit, #{line => 1,
-                                               spec => 42,
-                                               type => {type, #{line => 1,
-                                                                spec => int,
-                                                                source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => int,
-                                                 source => rufus_text}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => int,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {int_lit, #{
+                    line => 1,
+                    spec => 42,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => int,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => int,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_an_string_and_returning_an_string_test() ->
     RufusText = "func Echo(n string) string { \"Hello\" }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{params => [{param, #{line => 1,
-                                              spec => n,
-                                              type => {type, #{line => 1,
-                                                               spec => string,
-                                                               source => rufus_text}}}}],
-                         exprs => [{string_lit, #{line => 1,
-                                                  spec => <<"Hello">>,
-                                                  type => {type, #{line => 1,
-                                                                   spec => string,
-                                                                   source => inferred}}}}],
-                         line => 1,
-                         return_type => {type, #{line => 1,
-                                                 spec => string,
-                                                 source => rufus_text}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => string,
+                            source => rufus_text
+                        }}
+                }}
+            ],
+            exprs => [
+                {string_lit, #{
+                    line => 1,
+                    spec => <<"Hello">>,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            spec => string,
+                            source => inferred
+                        }}
+                }}
+            ],
+            line => 1,
+            return_type =>
+                {type, #{
+                    line => 1,
+                    spec => string,
+                    source => rufus_text
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 %% Parameter patterns with literal values
@@ -287,103 +521,208 @@ parse_function_taking_an_atom_literal_test() ->
     RufusText = "func Echo(:ok) atom { :ok }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{atom_lit, #{line => 1,
-                                                spec => ok,
-                                                type => {type, #{line => 1,
-                                                                 source => inferred,
-                                                                 spec => atom}}}}],
-                         line => 1,
-                         params => [{atom_lit, #{line => 1,
-                                                 spec => ok,
-                                                 type => {type, #{line => 1,
-                                                                  source => inferred,
-                                                                  spec => atom}}}}],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {atom_lit, #{
+                    line => 1,
+                    spec => ok,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {atom_lit, #{
+                    line => 1,
+                    spec => ok,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => atom
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_a_bool_literal_test() ->
     RufusText = "func Echo(true) bool { true }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{bool_lit, #{line => 1,
-                                                spec => true,
-                                                type => {type, #{line => 1,
-                                                                 source => inferred,
-                                                                 spec => bool}}}}],
-                         line => 1,
-                         params => [{bool_lit, #{line => 1,
-                                                 spec => true,
-                                                 type => {type, #{line => 1,
-                                                                  source => inferred,
-                                                                  spec => bool}}}}],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {bool_lit, #{
+                    line => 1,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {bool_lit, #{
+                    line => 1,
+                    spec => true,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => bool
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_a_float_literal_test() ->
     RufusText = "func Echo(1.0) float { 1.0 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{float_lit, #{line => 1,
-                                                 spec => 1.0,
-                                                 type => {type, #{line => 1,
-                                                                  source => inferred,
-                                                                  spec => float}}}}],
-                         line => 1,
-                         params => [{float_lit, #{line => 1,
-                                                  spec => 1.0,
-                                                  type => {type, #{line => 1,
-                                                                   source => inferred,
-                                                                   spec => float}}}}],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => float}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {float_lit, #{
+                    line => 1,
+                    spec => 1.0,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {float_lit, #{
+                    line => 1,
+                    spec => 1.0,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => float
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => float
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_an_int_literal_test() ->
     RufusText = "func Echo(1) int { 1 }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{int_lit, #{line => 1,
-                                               spec => 1,
-                                               type => {type, #{line => 1,
-                                                                source => inferred,
-                                                                spec => int}}}}],
-                         line => 1,
-                         params => [{int_lit, #{line => 1,
-                                                spec => 1,
-                                                type => {type, #{line => 1,
-                                                                 source => inferred,
-                                                                 spec => int}}}}],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {int_lit, #{
+                    line => 1,
+                    spec => 1,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {int_lit, #{
+                    line => 1,
+                    spec => 1,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_a_string_literal_test() ->
     RufusText = "func Echo(\"ok\") string { \"ok\" }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{string_lit, #{line => 1,
-                                                  spec => <<"ok">>,
-                                                  type => {type, #{line => 1,
-                                                                   source => inferred,
-                                                                   spec => string}}}}],
-                         line => 1,
-                         params => [{string_lit, #{line => 1,
-                                                   spec => <<"ok">>,
-                                                   type => {type, #{line => 1,
-                                                                    source => inferred,
-                                                                    spec => string}}}}],
-                         return_type => {type, #{line => 1,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {string_lit, #{
+                    line => 1,
+                    spec => <<"ok">>,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => string
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {string_lit, #{
+                    line => 1,
+                    spec => <<"ok">>,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => inferred,
+                            spec => string
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 1,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_import_test.erl
+++ b/rf/test/rufus_parse_import_test.erl
@@ -6,6 +6,10 @@ parse_import_test() ->
     RufusText = "import \"bar\"",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{import, #{line => 1,
-                           spec => "bar"}}],
+    Expected = [
+        {import, #{
+            line => 1,
+            spec => "bar"
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_list_test.erl
+++ b/rf/test/rufus_parse_list_test.erl
@@ -6,338 +6,672 @@ parse_function_returning_empty_list_of_ints_test() ->
     RufusText = "func EmptyNumbers() list[int] { list[int]{} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{list_lit, #{elements => [],
-                                                line => 1,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 1,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 1,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'EmptyNumbers'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [],
+                    line => 1,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'EmptyNumbers'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_list_of_int_with_one_element_test() ->
     RufusText = "func OneNumber() list[int] { list[int]{10} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                         spec => 10,
-                                                                         type => {type, #{line => 1,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}}],
-                                                line => 1,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 1,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 1,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'OneNumber'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {int_lit, #{
+                            line => 1,
+                            spec => 10,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 1,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'OneNumber'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_list_of_many_ints_test() ->
     RufusText = "func ManyNumbers() list[int] { list[int]{10, 2} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                         spec => 10,
-                                                                         type => {type, #{line => 1,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}},
-                                                             {int_lit, #{line => 1,
-                                                                         spec => 2,
-                                                                         type => {type, #{line => 1,
-                                                                                          source => inferred,
-                                                                                          spec => int}}}}],
-                                                line => 1,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{line => 1,
-                                                                                          source => rufus_text,
-                                                                                          spec => int}},
-                                                                 line => 1,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[int]'}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'ManyNumbers'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {int_lit, #{
+                            line => 1,
+                            spec => 10,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                        {int_lit, #{
+                            line => 1,
+                            spec => 2,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 1,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'ManyNumbers'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_nested_list_of_list_of_ints_test() ->
-    RufusText = "func NestedNumbers() list[list[int]] { list[list[int]]{list[int]{1}, list[int]{2, 3}} }",
+    RufusText =
+        "func NestedNumbers() list[list[int]] { list[list[int]]{list[int]{1}, list[int]{2, 3}} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{list_lit, #{elements => [{list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                                                   spec => 1,
-                                                                                                   type => {type, #{line => 1,
-                                                                                                                    source => inferred,
-                                                                                                                    spec => int}}}}],
-                                                                          line => 1,
-                                                                          type => {type, #{collection_type => list,
-                                                                                           element_type => {type, #{line => 1,
-                                                                                                                    source => rufus_text,
-                                                                                                                    spec => int}},
-                                                                                           line => 1,
-                                                                                           source => rufus_text,
-                                                                                           spec => 'list[int]'}}}},
-                                                             {list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                                                   spec => 2,
-                                                                                                   type => {type, #{line => 1,
-                                                                                                                    source => inferred,
-                                                                                                                    spec => int}}}},
-                                                                                       {int_lit, #{line => 1,
-                                                                                                   spec => 3,
-                                                                                                   type => {type, #{line => 1,
-                                                                                                                    source => inferred,
-                                                                                                                    spec => int}}}}],
-                                                                          line => 1,
-                                                                          type => {type, #{collection_type => list,
-                                                                                           element_type => {type, #{line => 1,
-                                                                                                                    source => rufus_text,
-                                                                                                                    spec => int}},
-                                                                                           line => 1,
-                                                                                           source => rufus_text,
-                                                                                           spec => 'list[int]'}}}}],
-                                                line => 1,
-                                                type => {type, #{collection_type => list,
-                                                                 element_type => {type, #{collection_type => list,
-                                                                                          element_type => {type, #{line => 1,
-                                                                                                                   source => rufus_text,
-                                                                                                                   spec => int}},
-                                                                                          line => 1,
-                                                                                          source => rufus_text,
-                                                                                          spec => 'list[int]'}},
-                                                                 line => 1,
-                                                                 source => rufus_text,
-                                                                 spec => 'list[list[int]]'}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{collection_type => list,
-                                                                          element_type => {type, #{line => 1,
-                                                                                                   source => rufus_text,
-                                                                                                   spec => int}},
-                                                                          line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => 'list[int]'}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[list[int]]'}},
-                         spec => 'NestedNumbers'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 1,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 1,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }}
+                    ],
+                    line => 1,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[list[int]]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[list[int]]'
+                }},
+            spec => 'NestedNumbers'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_taking_and_returning_list_of_ints_test() ->
     RufusText = "func Echo(numbers list[int]) list[int] { numbers }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{identifier, #{line => 1,
-                                                  spec => numbers}}],
-                         line => 1,
-                         params => [{param, #{line => 1,
-                                              spec => numbers,
-                                              type => {type, #{collection_type => list,
-                                                               element_type => {type, #{line => 1,
-                                                                                        source => rufus_text,
-                                                                                        spec => int}},
-                                                               line => 1,
-                                                               source => rufus_text,
-                                                               spec => 'list[int]'}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 1,
+                    spec => numbers
+                }}
+            ],
+            line => 1,
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => numbers,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_returning_a_cons_expression_test() ->
     RufusText = "func Numbers() list[int] { list[int]{1|{2}} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{cons, #{head => {int_lit, #{line => 1,
-                                                                spec => 1,
-                                                                type => {type, #{line => 1,
-                                                                                 source => inferred,
-                                                                                 spec => int}}}},
+    Expected = [
+        {func, #{
+            exprs => [
+                {cons, #{
+                    head =>
+                        {int_lit, #{
+                            line => 1,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }},
+                    line => 1,
+                    tail =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
                                             line => 1,
-                                            tail => {list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                                          spec => 2,
-                                                                                          type => {type, #{line => 1,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}}],
-                                                                 line => 1,
-                                                                 type => {type, #{collection_type => list,
-                                                                                  element_type => {type, #{line => 1,
-                                                                                                           source => rufus_text,
-                                                                                                           spec => int}},
-                                                                                  line => 1,
-                                                                                  source => rufus_text,
-                                                                                  spec => 'list[int]'}}}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 1,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 1,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 1,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 1,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_test() ->
     RufusText = "func Prepend(number int) list[int] { list[int]{number|{2, 3, 4}} }",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{cons, #{head => {identifier, #{line => 1,
-                                                                   spec => number}},
+    Expected = [
+        {func, #{
+            exprs => [
+                {cons, #{
+                    head =>
+                        {identifier, #{
+                            line => 1,
+                            spec => number
+                        }},
+                    line => 1,
+                    tail =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
                                             line => 1,
-                                            tail => {list_lit, #{elements => [{int_lit, #{line => 1,
-                                                                                          spec => 2,
-                                                                                          type => {type, #{line => 1,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}},
-                                                                              {int_lit, #{line => 1,
-                                                                                          spec => 3,
-                                                                                          type => {type, #{line => 1,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}},
-                                                                              {int_lit, #{line => 1,
-                                                                                          spec => 4,
-                                                                                          type => {type, #{line => 1,
-                                                                                                           source => inferred,
-                                                                                                           spec => int}}}}],
-                                                                 line => 1,
-                                                                 type => {type, #{collection_type => list,
-                                                                                  element_type => {type, #{line => 1,
-                                                                                                           source => rufus_text,
-                                                                                                           spec => int}},
-                                                                                  line => 1,
-                                                                                  source => rufus_text,
-                                                                                  spec => 'list[int]'}}}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 1,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 1,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 1,
-                         params => [{param, #{line => 1,
-                                              spec => number,
-                                              type => {type, #{line => 1,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 1,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 1,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Prepend'}}],
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 1,
+                                    spec => 4,
+                                    type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 1,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 1,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 1,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 1,
+            params => [
+                {param, #{
+                    line => 1,
+                    spec => number,
+                    type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 1,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 1,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Prepend'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() ->
-    RufusText = "
-    func Numbers() list[int] {
-        head = 1
-        tail = list[int]{2, 3, 4}
-        list[int]{head|tail}
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Numbers() list[int] {\n"
+        "        head = 1\n"
+        "        tail = list[int]{2, 3, 4}\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => head}},
-                                             line => 3,
-                                             right => {int_lit, #{line => 3,
-                                                                  spec => 1,
-                                                                  type => {type, #{line => 3,
-                                                                                   source => inferred,
-                                                                                   spec => int}}}}}},
-                                   {match, #{left => {identifier, #{line => 4,
-                                                                    spec => tail}},
-                                             line => 4,
-                                             right => {list_lit, #{elements => [{int_lit, #{line => 4,
-                                                                                            spec => 2,
-                                                                                            type => {type, #{line => 4,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}},
-                                                                                {int_lit, #{line => 4,
-                                                                                            spec => 3,
-                                                                                            type => {type, #{line => 4,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}},
-                                                                                {int_lit, #{line => 4,
-                                                                                            spec => 4,
-                                                                                            type => {type, #{line => 4,
-                                                                                                             source => inferred,
-                                                                                                             spec => int}}}}],
-                                                                   line => 4,
-                                                                   type => {type, #{collection_type => list,
-                                                                                    element_type => {type, #{line => 4,
-                                                                                                             source => rufus_text,
-                                                                                                             spec => int}},
-                                                                                    line => 4,
-                                                                                    source => rufus_text,
-                                                                                    spec => 'list[int]'}}}}}},
-                                   {cons, #{head => {identifier, #{line => 5,
-                                                                   spec => head}},
-                                            line => 5,
-                                            tail => {identifier, #{line => 5,
-                                                                   spec => tail}},
-                                            type => {type, #{collection_type => list,
-                                                             element_type => {type, #{line => 5,
-                                                                                      source => rufus_text,
-                                                                                      spec => int}},
-                                                             line => 5,
-                                                             source => rufus_text,
-                                                             spec => 'list[int]'}}}}],
-                         line => 2,
-                         params => [],
-                         return_type => {type, #{collection_type => list,
-                                                 element_type => {type, #{line => 2,
-                                                                          source => rufus_text,
-                                                                          spec => int}},
-                                                 line => 2,
-                                                 source => rufus_text,
-                                                 spec => 'list[int]'}},
-                         spec => 'Numbers'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => head
+                        }},
+                    line => 3,
+                    right =>
+                        {int_lit, #{
+                            line => 3,
+                            spec => 1,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                }},
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            spec => tail
+                        }},
+                    line => 4,
+                    right =>
+                        {list_lit, #{
+                            elements => [
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 2,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 3,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 4,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 4,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }}
+                }},
+                {cons, #{
+                    head =>
+                        {identifier, #{
+                            line => 5,
+                            spec => head
+                        }},
+                    line => 5,
+                    tail =>
+                        {identifier, #{
+                            line => 5,
+                            spec => tail
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{
+                                    line => 5,
+                                    source => rufus_text,
+                                    spec => int
+                                }},
+                            line => 5,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{
+                            line => 2,
+                            source => rufus_text,
+                            spec => int
+                        }},
+                    line => 2,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Numbers'
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -3,138 +3,257 @@
 -include_lib("eunit/include/eunit.hrl").
 
 parse_function_with_a_match_that_binds_an_atom_literal_test() ->
-    RufusText = "
-    func Ping() atom {
-        response = :pong
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Ping() atom {\n"
+        "        response = :pong\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => response}},
-                                             line => 3,
-                                             right => {atom_lit, #{line => 3,
-                                                                   spec => pong,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => atom}}}}}},
-                                   {identifier, #{line => 4,
-                                                  spec => response}}],
-                         line => 2,
-                         params => [],
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => atom}},
-                         spec => 'Ping'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => response
+                        }},
+                    line => 3,
+                    right =>
+                        {atom_lit, #{
+                            line => 3,
+                            spec => pong,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => atom
+                                }}
+                        }}
+                }},
+                {identifier, #{
+                    line => 4,
+                    spec => response
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => atom
+                }},
+            spec => 'Ping'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_a_match_that_binds_a_bool_literal_test() ->
-    RufusText = "
-    func Truthy() bool {
-        response = true
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Truthy() bool {\n"
+        "        response = true\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => response}},
-                                             line => 3,
-                                             right => {bool_lit, #{line => 3,
-                                                                   spec => true,
-                                                                   type => {type, #{line => 3,
-                                                                                    source => inferred,
-                                                                                    spec => bool}}}}}},
-                                   {identifier, #{line => 4,
-                                                  spec => response}}],
-                         line => 2,
-                         params => [],
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => bool}},
-                         spec => 'Truthy'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => response
+                        }},
+                    line => 3,
+                    right =>
+                        {bool_lit, #{
+                            line => 3,
+                            spec => true,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => bool
+                                }}
+                        }}
+                }},
+                {identifier, #{
+                    line => 4,
+                    spec => response
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => bool
+                }},
+            spec => 'Truthy'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_a_match_that_binds_a_float_literal_test() ->
-    RufusText = "
-    func FortyTwo() float {
-        response = 42.0
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func FortyTwo() float {\n"
+        "        response = 42.0\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => response}},
-                                             line => 3,
-                                             right => {float_lit, #{line => 3,
-                                                                    spec => 42.0,
-                                                                    type => {type, #{line => 3,
-                                                                                     source => inferred,
-                                                                                     spec => float}}}}}},
-                                   {identifier, #{line => 4,
-                                                  spec => response}}],
-                         line => 2,
-                         params => [],
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => float}},
-                         spec => 'FortyTwo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => response
+                        }},
+                    line => 3,
+                    right =>
+                        {float_lit, #{
+                            line => 3,
+                            spec => 42.0,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => float
+                                }}
+                        }}
+                }},
+                {identifier, #{
+                    line => 4,
+                    spec => response
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => float
+                }},
+            spec => 'FortyTwo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_a_match_that_binds_a_string_literal_test() ->
-    RufusText = "
-    func Ping() string {
-        response = \"pong\"
-        response
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Ping() string {\n"
+        "        response = \"pong\"\n"
+        "        response\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => response}},
-                                             line => 3,
-                                             right => {string_lit, #{line => 3,
-                                                                     spec => <<"pong">>,
-                                                                     type => {type, #{line => 3,
-                                                                                      source => inferred,
-                                                                                      spec => string}}}}}},
-                                   {identifier, #{line => 4,
-                                                  spec => response}}],
-                         line => 2,
-                         params => [],
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => string}},
-                         spec => 'Ping'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => response
+                        }},
+                    line => 3,
+                    right =>
+                        {string_lit, #{
+                            line => 3,
+                            spec => <<"pong">>,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => inferred,
+                                    spec => string
+                                }}
+                        }}
+                }},
+                {identifier, #{
+                    line => 4,
+                    spec => response
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => string
+                }},
+            spec => 'Ping'
+        }}
+    ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_a_match_that_binds_a_variable_test() ->
-    RufusText = "
-    func Echo(n int) int {
-        m = n
-        m
-    }
-    ",
+    RufusText =
+        "\n"
+        "    func Echo(n int) int {\n"
+        "        m = n\n"
+        "        m\n"
+        "    }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
 
-    Expected = [{func, #{exprs => [{match, #{left => {identifier, #{line => 3,
-                                                                    spec => m}},
-                                             line => 3,
-                                             right => {identifier, #{line => 3,
-                                                                     spec => n}}}},
-                                   {identifier, #{line => 4,
-                                                  spec => m}}],
-                         line => 2,
-                         params => [{param, #{line => 2,
-                                              spec => n,
-                                              type => {type, #{line => 2,
-                                                               source => rufus_text,
-                                                               spec => int}}}}],
-                         return_type => {type, #{line => 2,
-                                                 source => rufus_text,
-                                                 spec => int}},
-                         spec => 'Echo'}}],
+    Expected = [
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            spec => m
+                        }},
+                    line => 3,
+                    right =>
+                        {identifier, #{
+                            line => 3,
+                            spec => n
+                        }}
+                }},
+                {identifier, #{
+                    line => 4,
+                    spec => m
+                }}
+            ],
+            line => 2,
+            params => [
+                {param, #{
+                    line => 2,
+                    spec => n,
+                    type =>
+                        {type, #{
+                            line => 2,
+                            source => rufus_text,
+                            spec => int
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    line => 2,
+                    source => rufus_text,
+                    spec => int
+                }},
+            spec => 'Echo'
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_module_test.erl
+++ b/rf/test/rufus_parse_module_test.erl
@@ -5,6 +5,10 @@
 parse_module_test() ->
     {ok, Tokens} = rufus_tokenize:string("module example"),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [{module, #{line => 1,
-                           spec => example}}],
+    Expected = [
+        {module, #{
+            line => 1,
+            spec => example
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_binary_op_test.erl
+++ b/rf/test/rufus_raw_tokenize_binary_op_test.erl
@@ -6,108 +6,147 @@
 
 string_with_binary_op_expression_using_plus_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 + 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'+', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'+', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_minus_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 - 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'-', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'-', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_multiplication_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 * 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'*', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'*', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_division_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 / 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'/', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'/', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_remainder_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 % 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'%', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'%', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 %% Conditional operators
 
 string_with_binary_op_expression_using_and_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true and false"),
-    ?assertEqual([
-        {bool_lit, 1, true},
-        {'and', 1},
-        {bool_lit, 1, false}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {bool_lit, 1, true},
+            {'and', 1},
+            {bool_lit, 1, false}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_or_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true or false"),
-    ?assertEqual([
-        {bool_lit, 1, true},
-        {'or', 1},
-        {bool_lit, 1, false}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {bool_lit, 1, true},
+            {'or', 1},
+            {bool_lit, 1, false}
+        ],
+        Tokens
+    ).
 
 %% Comparison operators
 
 string_with_binary_op_expression_using_equal_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true == false"),
-    ?assertEqual([
-        {bool_lit, 1, true},
-        {'==', 1},
-        {bool_lit, 1, false}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {bool_lit, 1, true},
+            {'==', 1},
+            {bool_lit, 1, false}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_not_equal_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("true != false"),
-    ?assertEqual([
-        {bool_lit, 1, true},
-        {'!=', 1},
-        {bool_lit, 1, false}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {bool_lit, 1, true},
+            {'!=', 1},
+            {bool_lit, 1, false}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_less_than_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 < 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'<', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'<', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_less_than_or_equal_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 <= 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'<=', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'<=', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_greater_than_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 > 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'>', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'>', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).
 
 string_with_binary_op_expression_using_greater_than_or_equal_operator_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("3 >= 5"),
-    ?assertEqual([
-        {int_lit, 1, 3},
-        {'>=', 1},
-        {int_lit, 1, 5}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {int_lit, 1, 3},
+            {'>=', 1},
+            {int_lit, 1, 5}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_raw_tokenize_const_test.erl
+++ b/rf/test/rufus_raw_tokenize_const_test.erl
@@ -4,192 +4,263 @@
 
 string_with_atom_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Name = :rufus"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {atom_lit, 1, rufus}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {atom_lit, 1, rufus}
+        ],
+        Tokens
+    ).
 
 string_with_single_character_atom_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Letter = :r"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Letter"},
-        {'=', 1},
-        {atom_lit, 1, r}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Letter"},
+            {'=', 1},
+            {atom_lit, 1, r}
+        ],
+        Tokens
+    ).
 
 string_with_quoted_atom_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Name = :'rufus programming language'"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {atom_lit, 1, 'rufus programming language'}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {atom_lit, 1, 'rufus programming language'}
+        ],
+        Tokens
+    ).
 
 string_with_quoted_single_character_atom_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Letter = :'r'"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Letter"},
-        {'=', 1},
-        {atom_lit, 1, r}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Letter"},
+            {'=', 1},
+            {atom_lit, 1, r}
+        ],
+        Tokens
+    ).
 
 string_with_false_bool_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Bool = false"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Bool"},
-        {'=', 1},
-        {bool_lit, 1, false}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Bool"},
+            {'=', 1},
+            {bool_lit, 1, false}
+        ],
+        Tokens
+    ).
 
 string_with_true_bool_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Bool = true"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Bool"},
-        {'=', 1},
-        {bool_lit, 1, true}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Bool"},
+            {'=', 1},
+            {bool_lit, 1, true}
+        ],
+        Tokens
+    ).
 
 string_with_float_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Float = 3.1415"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Float"},
-        {'=', 1},
-        {float_lit, 1, 3.1415}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Float"},
+            {'=', 1},
+            {float_lit, 1, 3.1415}
+        ],
+        Tokens
+    ).
 
 string_with_negative_float_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const NegativeFloat = -3.1415"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "NegativeFloat"},
-        {'=', 1},
-        {float_lit, 1, -3.1415}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "NegativeFloat"},
+            {'=', 1},
+            {float_lit, 1, -3.1415}
+        ],
+        Tokens
+    ).
 
 string_with_positive_float_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const PositiveFloat = +3.1415"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "PositiveFloat"},
-        {'=', 1},
-        {float_lit, 1, 3.1415}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "PositiveFloat"},
+            {'=', 1},
+            {float_lit, 1, 3.1415}
+        ],
+        Tokens
+    ).
 
 string_with_float_with_positive_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const FloatWithPositiveExponent = 4.0e+2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "FloatWithPositiveExponent"},
-        {'=', 1},
-        {float_lit, 1, 4.0e+2}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "FloatWithPositiveExponent"},
+            {'=', 1},
+            {float_lit, 1, 4.0e+2}
+        ],
+        Tokens
+    ).
 
 string_with_negative_float_with_positive_exponent_literal_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("const NegativeFloatWithPositiveExponent = -4.0e+2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "NegativeFloatWithPositiveExponent"},
-        {'=', 1},
-        {float_lit, 1, -4.0e+2}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "const NegativeFloatWithPositiveExponent = -4.0e+2"
+    ),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "NegativeFloatWithPositiveExponent"},
+            {'=', 1},
+            {float_lit, 1, -4.0e+2}
+        ],
+        Tokens
+    ).
 
 string_with_positive_float_with_positive_exponent_literal_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("const PositiveFloatWithPositiveExponent = +4.0e+2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "PositiveFloatWithPositiveExponent"},
-        {'=', 1},
-        {float_lit, 1, 4.0e+2}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "const PositiveFloatWithPositiveExponent = +4.0e+2"
+    ),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "PositiveFloatWithPositiveExponent"},
+            {'=', 1},
+            {float_lit, 1, 4.0e+2}
+        ],
+        Tokens
+    ).
 
 string_with_float_with_negative_exponent_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const FloatWithNegativeExponent = 48.0e-2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "FloatWithNegativeExponent"},
-        {'=', 1},
-        {float_lit, 1, 48.0e-2}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "FloatWithNegativeExponent"},
+            {'=', 1},
+            {float_lit, 1, 48.0e-2}
+        ],
+        Tokens
+    ).
 
 string_with_negative_float_with_negative_exponent_literal_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("const NegativeFloatWithNegativeExponent = -48.0e-2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "NegativeFloatWithNegativeExponent"},
-        {'=', 1},
-        {float_lit, 1, -48.0e-2}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "const NegativeFloatWithNegativeExponent = -48.0e-2"
+    ),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "NegativeFloatWithNegativeExponent"},
+            {'=', 1},
+            {float_lit, 1, -48.0e-2}
+        ],
+        Tokens
+    ).
 
 string_with_positive_float_with_negative_exponent_literal_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("const PositiveFloatWithNegativeExponent = +48.0e-2"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "PositiveFloatWithNegativeExponent"},
-        {'=', 1},
-        {float_lit, 1, 48.0e-2}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "const PositiveFloatWithNegativeExponent = +48.0e-2"
+    ),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "PositiveFloatWithNegativeExponent"},
+            {'=', 1},
+            {float_lit, 1, 48.0e-2}
+        ],
+        Tokens
+    ).
 
 string_with_int_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Int = 1"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Int"},
-        {'=', 1},
-        {int_lit, 1, 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Int"},
+            {'=', 1},
+            {int_lit, 1, 1}
+        ],
+        Tokens
+    ).
 
 string_with_negative_int_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const NegativeInt = -1"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "NegativeInt"},
-        {'=', 1},
-        {int_lit, 1, -1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "NegativeInt"},
+            {'=', 1},
+            {int_lit, 1, -1}
+        ],
+        Tokens
+    ).
 
 string_with_positive_int_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const PositiveInt = +1"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "PositiveInt"},
-        {'=', 1},
-        {int_lit, 1, 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "PositiveInt"},
+            {'=', 1},
+            {int_lit, 1, 1}
+        ],
+        Tokens
+    ).
 
 string_with_string_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Name = \"Rufus\""),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {string_lit, 1, "Rufus"}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {string_lit, 1, "Rufus"}
+        ],
+        Tokens
+    ).
 
 string_with_string_containing_number_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Number = \"42\""),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Number"},
-        {'=', 1},
-        {string_lit, 1, "42"}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Number"},
+            {'=', 1},
+            {string_lit, 1, "42"}
+        ],
+        Tokens
+    ).
 
 string_with_string_containing_whitespace_literal_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("const Whitespace = \"hello world\""),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Whitespace"},
-        {'=', 1},
-        {string_lit, 1, "hello world"}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Whitespace"},
+            {'=', 1},
+            {string_lit, 1, "hello world"}
+        ],
+        Tokens
+    ).
 
 %% TODO(jkakar): Implement these tests:
 %% - string_with_string_containing_punctuation_test

--- a/rf/test/rufus_raw_tokenize_func_test.erl
+++ b/rf/test/rufus_raw_tokenize_func_test.erl
@@ -4,148 +4,177 @@
 
 string_with_function_returning_a_bool_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func False() bool { false }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "False"},
-        {'(', 1},
-        {')', 1},
-        {bool, 1},
-        {'{', 1},
-        {bool_lit, 1, false},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "False"},
+            {'(', 1},
+            {')', 1},
+            {bool, 1},
+            {'{', 1},
+            {bool_lit, 1, false},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_function_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func number() float { 42.0 }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "number"},
-        {'(', 1},
-        {')', 1},
-        {float, 1},
-        {'{', 1},
-        {float_lit, 1, 42.0},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "number"},
+            {'(', 1},
+            {')', 1},
+            {float, 1},
+            {'{', 1},
+            {float_lit, 1, 42.0},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_function_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func number() int { 42 }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "number"},
-        {'(', 1},
-        {')', 1},
-        {int, 1},
-        {'{', 1},
-        {int_lit, 1, 42},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "number"},
+            {'(', 1},
+            {')', 1},
+            {int, 1},
+            {'{', 1},
+            {int_lit, 1, 42},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_function_returning_a_string_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func text() string { \"42\" }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "text"},
-        {'(', 1},
-        {')', 1},
-        {string, 1},
-        {'{', 1},
-        {string_lit, 1, "42"},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "text"},
+            {'(', 1},
+            {')', 1},
+            {string, 1},
+            {'{', 1},
+            {string_lit, 1, "42"},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_multiline_function_returning_a_string_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("
-func text() string {
-    \"42\"
-}
-"),
-    ?assertEqual([
-        {eol, 1},
-        {func, 2},
-        {identifier, 2, "text"},
-        {'(', 2},
-        {')', 2},
-        {string, 2},
-        {'{', 2},
-        {eol, 2},
-        {string_lit, 3, "42"},
-        {eol, 3},
-        {'}', 4},
-        {eol, 4}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\n"
+        "func text() string {\n"
+        "    \"42\"\n"
+        "}\n"
+    ),
+    ?assertEqual(
+        [
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "text"},
+            {'(', 2},
+            {')', 2},
+            {string, 2},
+            {'{', 2},
+            {eol, 2},
+            {string_lit, 3, "42"},
+            {eol, 3},
+            {'}', 4},
+            {eol, 4}
+        ],
+        Tokens
+    ).
 
 string_with_multiline_multiple_expression_function_returning_an_atom_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("
-func number() atom {
-    \"42\"
-    :fortytwo
-}
-"),
-    ?assertEqual([
-        {eol, 1},
-        {func, 2},
-        {identifier, 2, "number"},
-        {'(', 2},
-        {')', 2},
-        {atom, 2},
-        {'{', 2},
-        {eol, 2},
-        {string_lit, 3, "42"},
-        {eol, 3},
-        {atom_lit, 4, fortytwo},
-        {eol, 4},
-        {'}', 5},
-        {eol, 5}
-    ], Tokens).
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\n"
+        "func number() atom {\n"
+        "    \"42\"\n"
+        "    :fortytwo\n"
+        "}\n"
+    ),
+    ?assertEqual(
+        [
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "number"},
+            {'(', 2},
+            {')', 2},
+            {atom, 2},
+            {'{', 2},
+            {eol, 2},
+            {string_lit, 3, "42"},
+            {eol, 3},
+            {atom_lit, 4, fortytwo},
+            {eol, 4},
+            {'}', 5},
+            {eol, 5}
+        ],
+        Tokens
+    ).
 
 string_with_semicolon_multiple_expression_function_returning_an_atom_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func number() atom { \"42\"; :fortytwo }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "number"},
-        {'(', 1},
-        {')', 1},
-        {atom, 1},
-        {'{', 1},
-        {string_lit, 1, "42"},
-        {';', 1},
-        {atom_lit, 1, fortytwo},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "number"},
+            {'(', 1},
+            {')', 1},
+            {atom, 1},
+            {'{', 1},
+            {string_lit, 1, "42"},
+            {';', 1},
+            {atom_lit, 1, fortytwo},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_function_takes_an_int_and_returning_an_int_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func echo(n int) int { n }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "echo"},
-        {'(', 1},
-        {identifier, 1, "n"},
-        {int, 1},
-        {')', 1},
-        {int, 1},
-        {'{', 1},
-        {identifier, 1, "n"},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "echo"},
+            {'(', 1},
+            {identifier, 1, "n"},
+            {int, 1},
+            {')', 1},
+            {int, 1},
+            {'{', 1},
+            {identifier, 1, "n"},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_function_takes_an_int_and_a_string_and_returning_a_float_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func number(n int, s string) float { 42.0 }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "number"},
-        {'(', 1},
-        {identifier, 1, "n"},
-        {int, 1},
-        {',', 1},
-        {identifier, 1, "s"},
-        {string, 1},
-        {')', 1},
-        {float, 1},
-        {'{', 1},
-        {float_lit, 1, 42.0},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "number"},
+            {'(', 1},
+            {identifier, 1, "n"},
+            {int, 1},
+            {',', 1},
+            {identifier, 1, "s"},
+            {string, 1},
+            {')', 1},
+            {float, 1},
+            {'{', 1},
+            {float_lit, 1, 42.0},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 %% TODO(jkakar): Implement these tests:
 %%

--- a/rf/test/rufus_raw_tokenize_import_test.erl
+++ b/rf/test/rufus_raw_tokenize_import_test.erl
@@ -4,7 +4,10 @@
 
 string_with_import_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("import \"bar\""),
-    ?assertEqual([
-        {import, 1},
-        {string_lit, 1, "bar"}
-], Tokens).
+    ?assertEqual(
+        [
+            {import, 1},
+            {string_lit, 1, "bar"}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_raw_tokenize_list_test.erl
+++ b/rf/test/rufus_raw_tokenize_list_test.erl
@@ -4,116 +4,131 @@
 
 string_with_function_returning_a_list_of_bool_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("func False() list[bool] { list[bool]{false} }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "False"},
-        {'(', 1},
-        {')', 1},
-        {list, 1},
-        {'[', 1},
-        {bool, 1},
-        {']', 1},
-        {'{', 1},
-        {list, 1},
-        {'[', 1},
-        {bool, 1},
-        {']', 1},
-        {'{', 1},
-        {bool_lit, 1, false},
-        {'}', 1},
-        {'}', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "False"},
+            {'(', 1},
+            {')', 1},
+            {list, 1},
+            {'[', 1},
+            {bool, 1},
+            {']', 1},
+            {'{', 1},
+            {list, 1},
+            {'[', 1},
+            {bool, 1},
+            {']', 1},
+            {'{', 1},
+            {bool_lit, 1, false},
+            {'}', 1},
+            {'}', 1}
+        ],
+        Tokens
+    ).
 
 string_with_multiline_function_returning_a_list_of_bool_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("
-    func False() list[bool] {
-        list[bool]{false}
-    }"
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\n"
+        "    func False() list[bool] {\n"
+        "        list[bool]{false}\n"
+        "    }"
     ),
-    ?assertEqual([
-        {eol, 1},
-        {func, 2},
-        {identifier, 2, "False"},
-        {'(', 2},
-        {')', 2},
-        {list, 2},
-        {'[', 2},
-        {bool, 2},
-        {']', 2},
-        {'{', 2},
-        {eol, 2},
-        {list, 3},
-        {'[', 3},
-        {bool, 3},
-        {']', 3},
-        {'{', 3},
-        {bool_lit, 3, false},
-        {'}',3},
-        {eol, 3},
-        {'}', 4}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "False"},
+            {'(', 2},
+            {')', 2},
+            {list, 2},
+            {'[', 2},
+            {bool, 2},
+            {']', 2},
+            {'{', 2},
+            {eol, 2},
+            {list, 3},
+            {'[', 3},
+            {bool, 3},
+            {']', 3},
+            {'{', 3},
+            {bool_lit, 3, false},
+            {'}', 3},
+            {eol, 3},
+            {'}', 4}
+        ],
+        Tokens
+    ).
 
 string_with_multiline_function_returning_a_cons_of_int_with_an_empty_tail_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("
-    func Numbers() list[int] {
-        list[int]{1|[]}
-    }"
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\n"
+        "    func Numbers() list[int] {\n"
+        "        list[int]{1|[]}\n"
+        "    }"
     ),
-    ?assertEqual([
-        {eol, 1},
-        {func, 2},
-        {identifier, 2, "Numbers"},
-        {'(', 2},
-        {')', 2},
-        {list, 2},
-        {'[', 2},
-        {int, 2},
-        {']', 2},
-        {'{', 2},
-        {eol, 2},
-        {list, 3},
-        {'[', 3},
-        {int, 3},
-        {']', 3},
-        {'{', 3},
-        {int_lit, 3, 1},
-        {'|', 3},
-        {'[', 3},
-        {']', 3},
-        {'}', 3},
-        {eol, 3},
-        {'}', 4}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "Numbers"},
+            {'(', 2},
+            {')', 2},
+            {list, 2},
+            {'[', 2},
+            {int, 2},
+            {']', 2},
+            {'{', 2},
+            {eol, 2},
+            {list, 3},
+            {'[', 3},
+            {int, 3},
+            {']', 3},
+            {'{', 3},
+            {int_lit, 3, 1},
+            {'|', 3},
+            {'[', 3},
+            {']', 3},
+            {'}', 3},
+            {eol, 3},
+            {'}', 4}
+        ],
+        Tokens
+    ).
 
 string_with_multiline_function_returning_a_cons_of_int_with_a_nonempty_tail_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("
-    func Numbers() list[int] {
-        list[int]{1|{2}}
-    }"
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\n"
+        "    func Numbers() list[int] {\n"
+        "        list[int]{1|{2}}\n"
+        "    }"
     ),
-    ?assertEqual([
-        {eol, 1},
-        {func, 2},
-        {identifier, 2, "Numbers"},
-        {'(', 2},
-        {')', 2},
-        {list, 2},
-        {'[', 2},
-        {int, 2},
-        {']', 2},
-        {'{', 2},
-        {eol, 2},
-        {list, 3},
-        {'[', 3},
-        {int, 3},
-        {']', 3},
-        {'{', 3},
-        {int_lit, 3, 1},
-        {'|', 3},
-        {'{', 3},
-        {int_lit, 3, 2},
-        {'}', 3},
-        {'}', 3},
-        {eol, 3},
-        {'}', 4}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "Numbers"},
+            {'(', 2},
+            {')', 2},
+            {list, 2},
+            {'[', 2},
+            {int, 2},
+            {']', 2},
+            {'{', 2},
+            {eol, 2},
+            {list, 3},
+            {'[', 3},
+            {int, 3},
+            {']', 3},
+            {'{', 3},
+            {int_lit, 3, 1},
+            {'|', 3},
+            {'{', 3},
+            {int_lit, 3, 2},
+            {'}', 3},
+            {'}', 3},
+            {eol, 3},
+            {'}', 4}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_raw_tokenize_module_test.erl
+++ b/rf/test/rufus_raw_tokenize_module_test.erl
@@ -4,7 +4,10 @@
 
 string_with_module_test() ->
     {ok, Tokens, _} = rufus_raw_tokenize:string("module example"),
-    ?assertEqual([
-        {module, 1},
-        {identifier, 1, "example"}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {module, 1},
+            {identifier, 1, "example"}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_tokenize_test.erl
+++ b/rf/test/rufus_tokenize_test.erl
@@ -6,256 +6,324 @@
 
 string_inserts_semicolon_after_last_identifier_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("module empty"),
-    ?assertEqual([
-        {module, 1},
-        {identifier, 1, "empty"},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {module, 1},
+            {identifier, 1, "empty"},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_identifier_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("module empty\n"),
-    ?assertEqual([
-        {module, 1},
-        {identifier, 1, "empty"},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {module, 1},
+            {identifier, 1, "empty"},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_atom_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name = :rufus"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {atom_lit, 1, rufus},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {atom_lit, 1, rufus},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_atom_lit_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name = :rufus\n"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {atom_lit, 1, rufus},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {atom_lit, 1, rufus},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_bool_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Bool = true"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Bool"},
-        {'=', 1},
-        {bool_lit, 1, true},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Bool"},
+            {'=', 1},
+            {bool_lit, 1, true},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_bool_lit_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Bool = true\n"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Bool"},
-        {'=', 1},
-        {bool_lit, 1, true},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Bool"},
+            {'=', 1},
+            {bool_lit, 1, true},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_float_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Pi = 3.1415"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Pi"},
-        {'=', 1},
-        {float_lit, 1, 3.1415},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Pi"},
+            {'=', 1},
+            {float_lit, 1, 3.1415},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_float_lit_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Pi = 3.1415\n"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Pi"},
-        {'=', 1},
-        {float_lit, 1, 3.1415},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Pi"},
+            {'=', 1},
+            {float_lit, 1, 3.1415},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_int_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const FortyTwo = 42"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "FortyTwo"},
-        {'=', 1},
-        {int_lit, 1, 42},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "FortyTwo"},
+            {'=', 1},
+            {int_lit, 1, 42},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_int_lit_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("const FortyTwo = 42\n"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "FortyTwo"},
-        {'=', 1},
-        {int_lit, 1, 42},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "FortyTwo"},
+            {'=', 1},
+            {int_lit, 1, 42},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_string_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name = \"Rufus\""),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {string_lit, 1, "Rufus"},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {string_lit, 1, "Rufus"},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_string_lit_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name = \"Rufus\"\n"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {string_lit, 1, "Rufus"},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {string_lit, 1, "Rufus"},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_closing_paren_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("Name()"),
-    ?assertEqual([
-        {identifier, 1, "Name"},
-        {'(', 1},
-        {')', 1},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {identifier, 1, "Name"},
+            {'(', 1},
+            {')', 1},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_closing_paren_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("Name()\n"),
-    ?assertEqual([
-        {identifier, 1, "Name"},
-        {'(', 1},
-        {')', 1},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {identifier, 1, "Name"},
+            {'(', 1},
+            {')', 1},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_closing_brace_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("func Name() string { \"Rufus\" }"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "Name"},
-        {'(', 1},
-        {')', 1},
-        {string, 1},
-        {'{', 1},
-        {string_lit, 1, "Rufus"},
-        {'}', 1},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "Name"},
+            {'(', 1},
+            {')', 1},
+            {string, 1},
+            {'{', 1},
+            {string_lit, 1, "Rufus"},
+            {'}', 1},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_inserts_semicolon_after_last_closing_brace_in_line_test() ->
     {ok, Tokens} = rufus_tokenize:string("func Name() string { \"Rufus\" }\n"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "Name"},
-        {'(', 1},
-        {')', 1},
-        {string, 1},
-        {'{', 1},
-        {string_lit, 1, "Rufus"},
-        {'}', 1},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "Name"},
+            {'(', 1},
+            {')', 1},
+            {string, 1},
+            {'{', 1},
+            {string_lit, 1, "Rufus"},
+            {'}', 1},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 string_does_not_insert_a_duplicate_semicolon_for_the_closing_brace_when_the_previous_expression_is_automatically_terminated_test() ->
-    {ok, Tokens} = rufus_tokenize:string("
-    func Name() string {
-        \"Rufus\"
-    }
-    "),
-    ?assertEqual([
-        {func, 2},
-        {identifier, 2, "Name"},
-        {'(', 2},
-        {')', 2},
-        {string, 2},
-        {'{', 2},
-        {string_lit, 3, "Rufus"},
-        {';', 3},
-        {'}', 4},
-        {';', 4}
-    ], Tokens).
+    {ok, Tokens} = rufus_tokenize:string(
+        "\n"
+        "    func Name() string {\n"
+        "        \"Rufus\"\n"
+        "    }\n"
+        "    "
+    ),
+    ?assertEqual(
+        [
+            {func, 2},
+            {identifier, 2, "Name"},
+            {'(', 2},
+            {')', 2},
+            {string, 2},
+            {'{', 2},
+            {string_lit, 3, "Rufus"},
+            {';', 3},
+            {'}', 4},
+            {';', 4}
+        ],
+        Tokens
+    ).
 
 string_does_not_insert_a_duplicate_semicolon_for_the_closing_brace_when_the_last_expression_is_explicitly_terminated_test() ->
     {ok, Tokens} = rufus_tokenize:string("func Name() string { \"Rufus\"; }\n"),
-    ?assertEqual([
-        {func, 1},
-        {identifier, 1, "Name"},
-        {'(', 1},
-        {')', 1},
-        {string, 1},
-        {'{', 1},
-        {string_lit, 1, "Rufus"},
-        {';', 1},
-        {'}', 1},
-        {';', 1}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "Name"},
+            {'(', 1},
+            {')', 1},
+            {string, 1},
+            {'{', 1},
+            {string_lit, 1, "Rufus"},
+            {';', 1},
+            {'}', 1},
+            {';', 1}
+        ],
+        Tokens
+    ).
 
 %% %% Arbitrary whitespace.
 
 string_with_newlines_test() ->
-    RufusText = "
-    module rand
-
-    func Int() int {
-        42
-    }
-",
+    RufusText =
+        "\n"
+        "    module rand\n"
+        "\n"
+        "    func Int() int {\n"
+        "        42\n"
+        "    }\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
-    ?assertEqual([
-        {module, 2},
-        {identifier, 2, "rand"},
-        {';', 2},
-        {func, 4},
-        {identifier, 4, "Int"},
-        {'(', 4},
-        {')', 4},
-        {int, 4},
-        {'{', 4},
-        {int_lit, 5, 42},
-        {';', 5},
-        {'}', 6},
-        {';', 6}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {module, 2},
+            {identifier, 2, "rand"},
+            {';', 2},
+            {func, 4},
+            {identifier, 4, "Int"},
+            {'(', 4},
+            {')', 4},
+            {int, 4},
+            {'{', 4},
+            {int_lit, 5, 42},
+            {';', 5},
+            {'}', 6},
+            {';', 6}
+        ],
+        Tokens
+    ).
 
 string_with_extra_newlines_test() ->
     {ok, Tokens} = rufus_tokenize:string("\n\n\nconst Name = :rufus\n\n\n"),
-    ?assertEqual([
-        {const, 4},
-        {identifier, 4, "Name"},
-        {'=', 4},
-        {atom_lit, 4, rufus},
-        {';', 4}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 4},
+            {identifier, 4, "Name"},
+            {'=', 4},
+            {atom_lit, 4, rufus},
+            {';', 4}
+        ],
+        Tokens
+    ).
 
 string_with_newline_in_expression_after_operator_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name =\n :rufus"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 1, "Name"},
-        {'=', 1},
-        {atom_lit, 2, rufus},
-        {';', 2}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {atom_lit, 2, rufus},
+            {';', 2}
+        ],
+        Tokens
+    ).
 
 string_with_newline_in_expression_after_reserved_word_test() ->
     {ok, Tokens} = rufus_tokenize:string("const\n Name = :rufus"),
-    ?assertEqual([
-        {const, 1},
-        {identifier, 2, "Name"},
-        {'=', 2},
-        {atom_lit, 2, rufus},
-        {';', 2}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 2, "Name"},
+            {'=', 2},
+            {atom_lit, 2, rufus},
+            {';', 2}
+        ],
+        Tokens
+    ).
 
 %% %% Lists
 
@@ -289,34 +357,37 @@ string_with_list_test() ->
     ?assertEqual(Expected, Tokens).
 
 string_with_list_and_newlines_test() ->
-    RufusText = "
-    func Numbers() list[int] {
-        list[int]{42, 17, 3}
-    }
-",
+    RufusText =
+        "\n"
+        "    func Numbers() list[int] {\n"
+        "        list[int]{42, 17, 3}\n"
+        "    }\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
-    ?assertEqual([
-        {func, 2},
-        {identifier, 2, "Numbers"},
-        {'(', 2},
-        {')', 2},
-        {list, 2},
-        {'[', 2},
-        {int, 2},
-        {']', 2},
-        {'{', 2},
-        {list, 3},
-        {'[', 3},
-        {int, 3},
-        {']', 3},
-        {'{', 3},
-        {int_lit, 3, 42},
-        {',', 3},
-        {int_lit, 3, 17},
-        {',', 3},
-        {int_lit, 3, 3},
-        {'}', 3},
-        {';', 3},
-        {'}', 4},
-        {';', 4}
-    ], Tokens).
+    ?assertEqual(
+        [
+            {func, 2},
+            {identifier, 2, "Numbers"},
+            {'(', 2},
+            {')', 2},
+            {list, 2},
+            {'[', 2},
+            {int, 2},
+            {']', 2},
+            {'{', 2},
+            {list, 3},
+            {'[', 3},
+            {int, 3},
+            {']', 3},
+            {'{', 3},
+            {int_lit, 3, 42},
+            {',', 3},
+            {int_lit, 3, 17},
+            {',', 3},
+            {int_lit, 3, 3},
+            {'}', 3},
+            {';', 3},
+            {'}', 4},
+            {';', 4}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -3,80 +3,119 @@
 -include_lib("eunit/include/eunit.hrl").
 
 resolve_arithmetic_binary_op_with_ints_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(int, 5, 9),
-        Right = rufus_form:make_literal(int, 7, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        Expected = rufus_form:make_inferred_type(int, 9),
-        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
-    end, ['+', '-', '*', '/', '%']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(int, 5, 9),
+            Right = rufus_form:make_literal(int, 7, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            Expected = rufus_form:make_inferred_type(int, 9),
+            ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+        end,
+        ['+', '-', '*', '/', '%']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_arithmetic_binary_op_with_floats_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(float, 1.0, 9),
-        Right = rufus_form:make_literal(float, 2.14159265359, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        Expected = rufus_form:make_inferred_type(float, 9),
-        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
-    end, ['+', '-', '*', '/']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(float, 1.0, 9),
+            Right = rufus_form:make_literal(float, 2.14159265359, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            Expected = rufus_form:make_inferred_type(float, 9),
+            ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+        end,
+        ['+', '-', '*', '/']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_arithmetic_unmatched_operand_type_error_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(int, 5, 9),
-        Right = rufus_form:make_literal(float, 2.14159265359, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['+', '-', '*', '/']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(int, 5, 9),
+            Right = rufus_form:make_literal(float, 2.14159265359, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            ?assertEqual(
+                {error, unmatched_operand_type, #{form => Form}},
+                rufus_type:resolve(#{}, Form)
+            )
+        end,
+        ['+', '-', '*', '/']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_arithmetic_nested_unmatched_operand_type_error_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(float, 13.0, 9),
-        Right = rufus_form:make_literal(float, 6.0, 9),
-        LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
-        RightForm = rufus_form:make_literal(int, 23, 9),
-        Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
-        ?assertEqual({error, unmatched_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['+', '-', '*', '/']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(float, 13.0, 9),
+            Right = rufus_form:make_literal(float, 6.0, 9),
+            LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
+            RightForm = rufus_form:make_literal(int, 23, 9),
+            Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
+            ?assertEqual(
+                {error, unmatched_operand_type, #{form => Form}},
+                rufus_type:resolve(#{}, Form)
+            )
+        end,
+        ['+', '-', '*', '/']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_arithmetic_unsupported_operand_type_error_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(bool, true, 9),
-        Right = rufus_form:make_literal(bool, false, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['+', '-', '*', '/', '%']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(bool, true, 9),
+            Right = rufus_form:make_literal(bool, false, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            ?assertEqual(
+                {error, unsupported_operand_type, #{form => Form}},
+                rufus_type:resolve(#{}, Form)
+            )
+        end,
+        ['+', '-', '*', '/', '%']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_boolean_binary_op_with_bools_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(bool, true, 9),
-        Right = rufus_form:make_literal(bool, false, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        Expected = rufus_form:make_inferred_type(bool, 9),
-        ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(bool, true, 9),
+            Right = rufus_form:make_literal(bool, false, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            Expected = rufus_form:make_inferred_type(bool, 9),
+            ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
+        end,
+        ['and', 'or']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_boolean_unsupported_operand_type_error_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(int, 3, 9),
-        Right = rufus_form:make_literal(bool, true, 9),
-        Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(int, 3, 9),
+            Right = rufus_form:make_literal(bool, true, 9),
+            Form = rufus_form:make_binary_op(Op, Left, Right, 9),
+            ?assertEqual(
+                {error, unsupported_operand_type, #{form => Form}},
+                rufus_type:resolve(#{}, Form)
+            )
+        end,
+        ['and', 'or']
+    ),
     ?assertEqual([ok], lists:usort(Result)).
 
 resolve_boolean_nested_unsupported_operand_type_error_test() ->
-    Result = lists:map(fun(Op) ->
-        Left = rufus_form:make_literal(bool, true, 9),
-        Right = rufus_form:make_literal(bool, false, 9),
-        LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
-        RightForm = rufus_form:make_literal(int, 23, 9),
-        Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
-        ?assertEqual({error, unsupported_operand_type, #{form => Form}}, rufus_type:resolve(#{}, Form))
-    end, ['and', 'or']),
+    Result = lists:map(
+        fun(Op) ->
+            Left = rufus_form:make_literal(bool, true, 9),
+            Right = rufus_form:make_literal(bool, false, 9),
+            LeftForm = rufus_form:make_binary_op(Op, Left, Right, 9),
+            RightForm = rufus_form:make_literal(int, 23, 9),
+            Form = rufus_form:make_binary_op(Op, LeftForm, RightForm, 9),
+            ?assertEqual(
+                {error, unsupported_operand_type, #{form => Form}},
+                rufus_type:resolve(#{}, Form)
+            )
+        end,
+        ['and', 'or']
+    ),
     ?assertEqual([ok], lists:usort(Result)).

--- a/rf/test/rufus_type_call_test.erl
+++ b/rf/test/rufus_type_call_test.erl
@@ -3,10 +3,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 resolve_call_with_no_arguments_test() ->
-    RufusText = "
-    module example
-    func Random() int { 42 }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Random() int { 42 }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
@@ -15,10 +16,11 @@ resolve_call_with_no_arguments_test() ->
     ?assertEqual({ok, Expected}, rufus_type:resolve(Globals, Form)).
 
 resolve_call_with_one_argument_test() ->
-    RufusText = "
-    module example
-    func Echo(text string) string { text }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(text string) string { text }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
@@ -27,14 +29,15 @@ resolve_call_with_one_argument_test() ->
     ?assertEqual({ok, Expected}, rufus_type:resolve(Globals, Form)).
 
 resolve_call_with_one_argument_and_many_function_heads_test() ->
-    RufusText = "
-    module example
-    func Echo(name atom) atom { name }
-    func Echo(b bool) bool { b }
-    func Echo(n float) float { n }
-    func Echo(n int) int { n }
-    func Echo(text string) string { text }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(name atom) atom { name }\n"
+        "    func Echo(b bool) bool { b }\n"
+        "    func Echo(n float) float { n }\n"
+        "    func Echo(n int) int { n }\n"
+        "    func Echo(text string) string { text }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
@@ -43,72 +46,131 @@ resolve_call_with_one_argument_and_many_function_heads_test() ->
     ?assertEqual({ok, Expected}, rufus_type:resolve(Globals, Form)).
 
 resolve_call_with_two_argument_test() ->
-    RufusText = "
-    module example
-    func Concatenate(a atom, b string) string { \"hello world\" }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Concatenate(a atom, b string) string { \"hello world\" }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
-    Form = rufus_form:make_call('Concatenate', [rufus_form:make_literal(atom, hello, 7),
-                                                rufus_form:make_literal(string, <<"world">>, 7)], 7),
+    Form = rufus_form:make_call(
+        'Concatenate',
+        [
+            rufus_form:make_literal(atom, hello, 7),
+            rufus_form:make_literal(string, <<"world">>, 7)
+        ],
+        7
+    ),
     Expected = rufus_form:make_type(string, 3),
     ?assertEqual({ok, Expected}, rufus_type:resolve(Globals, Form)).
 
 resolve_unknown_func_error_test() ->
     Form = rufus_form:make_call('Ping', [], 7),
-    Expected = {error, unknown_func, #{args => [],
-                                       spec => 'Ping'}},
+    Expected =
+        {error, unknown_func, #{
+            args => [],
+            spec => 'Ping'
+        }},
     ?assertEqual(Expected, rufus_type:resolve(#{}, Form)).
 
 resolve_unknown_arity_error_test() ->
-    RufusText = "
-    module example
-    func Ping(message string) string { message }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Ping(message string) string { message }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
     Form = rufus_form:make_call('Ping', [], 7),
-    Data = #{args => [],
-             funcs => [{func, #{params => [{param, #{line => 3,
-                                                     spec => message,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => string}}}}],
-                                exprs => [{identifier, #{line => 3,
-                                                         spec => message}}],
+    Data = #{
+        args => [],
+        funcs => [
+            {func, #{
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => message,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => string}},
-                                spec => 'Ping'}}]},
+                                source => rufus_text,
+                                spec => string
+                            }}
+                    }}
+                ],
+                exprs => [
+                    {identifier, #{
+                        line => 3,
+                        spec => message
+                    }}
+                ],
+                line => 3,
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => string
+                    }},
+                spec => 'Ping'
+            }}
+        ]
+    },
     ?assertEqual({error, unknown_arity, Data}, rufus_type:resolve(Globals, Form)).
 
 resolve_unmatched_args_error_test() ->
-    RufusText = "
-    module example
-    func Echo(text string) string { text }
-    ",
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(text string) string { text }\n"
+        "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, Globals} = rufus_form:globals(Forms),
     Form = rufus_form:make_call('Echo', [rufus_form:make_literal(integer, 42, 7)], 7),
-    Data = #{args => [{integer_lit, #{line => 7,
-                                      spec => 42,
-                                      type => {type, #{line => 7,
-                                                       source => inferred,
-                                                       spec => integer}}}}],
-             funcs => [{func, #{params => [{param, #{line => 3,
-                                                     spec => text,
-                                                     type => {type, #{line => 3,
-                                                                      source => rufus_text,
-                                                                      spec => string}}}}],
-                                exprs => [{identifier, #{line => 3,
-                                                         spec => text}}],
+    Data = #{
+        args => [
+            {integer_lit, #{
+                line => 7,
+                spec => 42,
+                type =>
+                    {type, #{
+                        line => 7,
+                        source => inferred,
+                        spec => integer
+                    }}
+            }}
+        ],
+        funcs => [
+            {func, #{
+                params => [
+                    {param, #{
+                        line => 3,
+                        spec => text,
+                        type =>
+                            {type, #{
                                 line => 3,
-                                return_type => {type, #{line => 3,
-                                                        source => rufus_text,
-                                                        spec => string}},
-                                spec => 'Echo'}}]},
+                                source => rufus_text,
+                                spec => string
+                            }}
+                    }}
+                ],
+                exprs => [
+                    {identifier, #{
+                        line => 3,
+                        spec => text
+                    }}
+                ],
+                line => 3,
+                return_type =>
+                    {type, #{
+                        line => 3,
+                        source => rufus_text,
+                        spec => string
+                    }},
+                spec => 'Echo'
+            }}
+        ]
+    },
     ?assertEqual({error, unmatched_args, Data}, rufus_type:resolve(Globals, Form)).

--- a/rf/test/rufus_type_list_test.erl
+++ b/rf/test/rufus_type_list_test.erl
@@ -15,17 +15,35 @@ resolve_list_with_mismatched_element_type_test() ->
     IntTypeForm = rufus_form:make_type(int, 3),
     IntListTypeForm = rufus_form:make_type(list, IntTypeForm, 3),
     Form = rufus_form:make_literal(list, IntListTypeForm, [MismatchedElement], 3),
-    Data = #{form => {list_lit, #{elements => [{float_lit, #{line => 3,
-                                                             spec => 42.0,
-                                                             type => {type, #{line => 3,
-                                                                              source => inferred,
-                                                                              spec => float}}}}],
-                                  line => 3,
-                                  type => {type, #{collection_type => list,
-                                                   element_type => {type, #{line => 3,
-                                                                            source => rufus_text,
-                                                                            spec => int}},
-                                                   line => 3,
-                                                   source => rufus_text,
-                                                   spec => 'list[int]'}}}}},
+    Data = #{
+        form =>
+            {list_lit, #{
+                elements => [
+                    {float_lit, #{
+                        line => 3,
+                        spec => 42.0,
+                        type =>
+                            {type, #{
+                                line => 3,
+                                source => inferred,
+                                spec => float
+                            }}
+                    }}
+                ],
+                line => 3,
+                type =>
+                    {type, #{
+                        collection_type => list,
+                        element_type =>
+                            {type, #{
+                                line => 3,
+                                source => rufus_text,
+                                spec => int
+                            }},
+                        line => 3,
+                        source => rufus_text,
+                        spec => 'list[int]'
+                    }}
+            }}
+    },
     ?assertEqual({error, unexpected_element_type, Data}, rufus_type:resolve(#{}, Form)).


### PR DESCRIPTION
`erlfmt` is configured in `rebar.config` and can be run with `rebar3 fmt`. It's been used to reformat all Erlang source code.