### PR TITLE
compiler: Parse and typecheck list_lit forms in function parameter lists

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -321,11 +321,12 @@ typecheck_and_annotate_list_lit(
     Stack,
     Globals,
     Locals,
-    {list_lit, Context = #{elements := Elements}}
+    Form = {list_lit, Context = #{elements := Elements}}
 ) ->
+    ListLitStack = [Form | Stack],
     {ok, NewLocals, AnnotatedElements} = typecheck_and_annotate(
         [],
-        Stack,
+        ListLitStack,
         Globals,
         Locals,
         Elements

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -120,6 +120,7 @@ param -> bool_lit                : rufus_form:make_literal(bool, text('$1'), lin
 param -> cons                    : '$1'.
 param -> float_lit               : rufus_form:make_literal(float, text('$1'), line('$1')).
 param -> int_lit                 : rufus_form:make_literal(int, text('$1'), line('$1')).
+param -> list_lit                : '$1'.
 param -> string_lit              : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
 
 type -> atom                     : rufus_form:make_type(atom, line('$1')).

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -331,7 +331,7 @@ lookup_identifier_type([{head, _Context1} | [{cons, #{type := Type}} | _T]], Sta
             Data = #{stack => Stack},
             throw({error, unknown_identifier, Data})
     end;
-lookup_identifier_type([{tail, _} | [{cons, #{type := Type}} | _T]], Stack) ->
+lookup_identifier_type([{tail, _Context1} | [{cons, #{type := Type}} | _T]], Stack) ->
     case
         lists:any(
             fun
@@ -345,6 +345,24 @@ lookup_identifier_type([{tail, _} | [{cons, #{type := Type}} | _T]], Stack) ->
     of
         true ->
             {ok, Type};
+        false ->
+            Data = #{stack => Stack},
+            throw({error, unknown_identifier, Data})
+    end;
+lookup_identifier_type([{list_lit, #{type := Type}} | _T], Stack) ->
+    case
+        lists:any(
+            fun
+                ({params, _Context}) ->
+                    true;
+                (_Form) ->
+                    false
+            end,
+            Stack
+        )
+    of
+        true ->
+            {ok, rufus_form:element_type(Type)};
         false ->
             Data = #{stack => Stack},
             throw({error, unknown_identifier, Data})

--- a/rf/test/rufus_compile_list_test.erl
+++ b/rf/test/rufus_compile_list_test.erl
@@ -137,3 +137,15 @@ eval_for_function_taking_a_cons_pattern_and_returning_the_tail_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertEqual([2, 3, 4], example:'Rest'([1, 2, 3, 4])).
+
+eval_for_function_taking_a_list_lit_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Reverse(list[int]{a, b, c}) list[int] {\n"
+        "        list[int]{c, b, a}\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    ?assertEqual([3, 2, 1], example:'Reverse'([1, 2, 3])).

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -1603,3 +1603,147 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
         stack => []
     },
     ?assertEqual({error, unknown_identifier, Data}, rufus_expr:typecheck_and_annotate(Forms)).
+
+typecheck_and_annotate_with_function_taking_a_list_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Reverse(list[int]{a, b, c}) list[int] {\n"
+        "        list[int]{c, b, a}\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {identifier, #{
+                            line => 4,
+                            spec => c,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 4,
+                            spec => b,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 4,
+                            spec => a,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            line => 4,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {list_lit, #{
+                    elements => [
+                        {identifier, #{
+                            line => 3,
+                            locals => #{},
+                            spec => a,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                a =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            },
+                            spec => b,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                a =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }},
+                                b =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            },
+                            spec => c,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Reverse'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -1604,7 +1604,7 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
     },
     ?assertEqual({error, unknown_identifier, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-typecheck_and_annotate_with_function_taking_a_list_pattern_test() ->
+typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
     RufusText =
         "\n"
         "    module example\n"

--- a/rf/test/rufus_parse_list_test.erl
+++ b/rf/test/rufus_parse_list_test.erl
@@ -728,3 +728,69 @@ parse_function_taking_a_cons_pattern_test() ->
         }}
     ],
     ?assertEqual(Expected, Forms).
+
+parse_function_taking_a_list_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Reverse(list[int]{a, b, c}) list[int] {\n"
+        "        list[int]{c, b, a}\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {list_lit, #{
+                    elements => [
+                        {identifier, #{line => 4, spec => c}},
+                        {identifier, #{line => 4, spec => b}},
+                        {identifier, #{line => 4, spec => a}}
+                    ],
+                    line => 4,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            line => 4,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {list_lit, #{
+                    elements => [
+                        {identifier, #{line => 3, spec => a}},
+                        {identifier, #{line => 3, spec => b}},
+                        {identifier, #{line => 3, spec => c}}
+                    ],
+                    line => 3,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Reverse'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).


### PR DESCRIPTION
The `Stack` is woven through `list_lit` typechecking and used when resolving identifier types. `list_lit` forms can be used directly in parameter lists to pattern match lists to values and variables.