### PR TITLE
compiler: Use unambiguous names for virtual forms

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -133,9 +133,9 @@ typecheck_and_annotate_binary_op(
     Form = {binary_op, Context = #{left := Left, right := Right}}
 ) ->
     BinaryOpStack = [Form | Stack],
-    LeftStack = [rufus_form:make_left(Form) | BinaryOpStack],
+    LeftStack = [rufus_form:make_binary_op_left(Form) | BinaryOpStack],
     {ok, Locals, [AnnotatedLeft]} = typecheck_and_annotate([], LeftStack, Globals, Locals, [Left]),
-    RightStack = [rufus_form:make_right(Form) | BinaryOpStack],
+    RightStack = [rufus_form:make_binary_op_right(Form) | BinaryOpStack],
     {ok, Locals, [AnnotatedRight]} = typecheck_and_annotate([], RightStack, Globals, Locals, [Right]),
     AnnotatedForm1 =
         {binary_op, Context#{
@@ -189,11 +189,11 @@ typecheck_and_annotate_cons(
     Form = {cons, Context = #{head := Head, tail := Tail}}
 ) ->
     ConsStack = [Form | Stack],
-    HeadStack = [rufus_form:make_head(Form) | ConsStack],
+    HeadStack = [rufus_form:make_cons_head(Form) | ConsStack],
     {ok, NewLocals1, [AnnotatedHead]} = typecheck_and_annotate([], HeadStack, Globals, Locals, [
         Head
     ]),
-    TailStack = [rufus_form:make_tail(Form) | ConsStack],
+    TailStack = [rufus_form:make_cons_tail(Form) | ConsStack],
     {ok, NewLocals2, [AnnotatedTail]} = typecheck_and_annotate(
         [],
         TailStack,
@@ -231,7 +231,7 @@ typecheck_and_annotate_func(
     Form = {func, Context = #{params := Params, exprs := Exprs}}
 ) ->
     FuncStack = [Form | Stack],
-    ParamsStack = [rufus_form:make_params(Form) | FuncStack],
+    ParamsStack = [rufus_form:make_func_params(Form) | FuncStack],
     {ok, NewLocals1, AnnotatedParams} = typecheck_and_annotate(
         [],
         ParamsStack,
@@ -239,7 +239,7 @@ typecheck_and_annotate_func(
         Locals,
         Params
     ),
-    ExprsStack = [rufus_form:make_exprs(Form) | FuncStack],
+    ExprsStack = [rufus_form:make_func_exprs(Form) | FuncStack],
     {ok, _NewLocals2, AnnotatedExprs} = typecheck_and_annotate(
         [],
         ExprsStack,

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -7,16 +7,19 @@
     has_type/1,
     line/1,
     make_binary_op/4,
+    make_binary_op_left/1,
+    make_binary_op_right/1,
     make_call/3,
     make_cons/4,
-    make_exprs/1,
+    make_cons_head/1,
+    make_cons_tail/1,
     make_func/5,
-    make_head/1,
+    make_func_exprs/1,
+    make_func_params/1,
     make_identifier/2,
     make_import/2,
     make_inferred_type/2,
     make_inferred_type/3,
-    make_left/1,
     make_literal/3,
     make_literal/4,
     make_match/3,
@@ -24,9 +27,6 @@
     make_match_right/1,
     make_module/2,
     make_param/3,
-    make_params/1,
-    make_right/1,
-    make_tail/1,
     make_type/2,
     make_type/3,
     return_type/1,
@@ -193,9 +193,9 @@ make_func(Spec, Params, ReturnType, Exprs, Line) ->
         line => Line
     }}.
 
--spec make_exprs(func_form()) -> exprs_form().
-make_exprs({func, #{line := Line}}) ->
-    {exprs, #{line => Line}}.
+-spec make_func_exprs(func_form()) -> func_exprs_form().
+make_func_exprs({func, #{line := Line}}) ->
+    {func_exprs, #{line => Line}}.
 
 %% make_param returns a form for a function parameter declaration.
 -spec make_param(atom(), type_form(), integer()) ->
@@ -204,9 +204,9 @@ make_param(Spec, Type, Line) ->
     {param, #{spec => Spec, type => Type, line => Line}}.
 
 %% make_params returns a form for a function parameter list.
--spec make_params(func_form()) -> params_form().
-make_params({func, #{line := Line}}) ->
-    {params, #{line => Line}}.
+-spec make_func_params(func_form()) -> func_params_form().
+make_func_params({func, #{line := Line}}) ->
+    {func_params, #{line => Line}}.
 
 %% call form builder API
 
@@ -250,33 +250,33 @@ make_literal(list, Type, Elements, Line) ->
 make_cons(Type, Head, Tail, Line) ->
     {cons, #{type => Type, head => Head, tail => Tail, line => Line}}.
 
-%% make_head returns a head form from a cons expression.
--spec make_head(cons_form()) -> head_form().
-make_head({cons, #{line := Line}}) ->
-    {head, #{line => Line}}.
+%% make_cons_head returns a head form from a cons expression.
+-spec make_cons_head(cons_form()) -> cons_head_form().
+make_cons_head({cons, #{line := Line}}) ->
+    {cons_head, #{line => Line}}.
 
-%% make_tail returns a tail form from a cons expression.
--spec make_tail(cons_form()) -> tail_form().
-make_tail({cons, #{line := Line}}) ->
-    {tail, #{line => Line}}.
+%% make_cons_tail returns a tail form from a cons expression.
+-spec make_cons_tail(cons_form()) -> cons_tail_form().
+make_cons_tail({cons, #{line := Line}}) ->
+    {cons_tail, #{line => Line}}.
 
 %% binary_op form builder API
 
-%% make_binary_op returns a form for a binary operation.
+%% make_binary_op returns a binary_op form.
 -spec make_binary_op(atom(), rufus_form(), rufus_form(), integer()) ->
     {binary_op, #{op => atom(), left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_binary_op(Op, Left, Right, Line) ->
     {binary_op, #{op => Op, left => Left, right => Right, line => Line}}.
 
-%% make_left returns a left form from a binary_op or match expression.
--spec make_left(binary_op_form()) -> {left, #{line => integer()}}.
-make_left({binary_op, #{line := Line}}) ->
-    {left, #{line => Line}}.
+%% make_binary_op_left returns a binary_op_left form.
+-spec make_binary_op_left(binary_op_form()) -> {binary_op_left, #{line => integer()}}.
+make_binary_op_left({binary_op, #{line := Line}}) ->
+    {binary_op_left, #{line => Line}}.
 
-%% make_right returns a right form from a binary_op or match expression.
--spec make_right(binary_op_form()) -> {right, #{line => integer()}}.
-make_right({binary_op, #{line := Line}}) ->
-    {right, #{line => Line}}.
+%% make_binary_op_right returns a binary_op_right form.
+-spec make_binary_op_right(binary_op_form()) -> {binary_op_right, #{line => integer()}}.
+make_binary_op_right({binary_op, #{line := Line}}) ->
+    {binary_op_right, #{line => Line}}.
 
 %% match form builder API
 

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -313,7 +313,7 @@ lookup_identifier_type(Stack) ->
     end.
 
 -spec lookup_identifier_type(rufus_stack(), rufus_stack()) -> {ok, type_form()} | no_return().
-lookup_identifier_type([{head, _Context1} | [{cons, #{type := Type}} | _T]], Stack) ->
+lookup_identifier_type([{cons_head, _Context1} | [{cons, #{type := Type}} | _T]], Stack) ->
     case allow_variable_binding(Stack) of
         true ->
             {ok, rufus_form:element_type(Type)};
@@ -321,7 +321,7 @@ lookup_identifier_type([{head, _Context1} | [{cons, #{type := Type}} | _T]], Sta
             Data = #{stack => Stack},
             throw({error, unknown_identifier, Data})
     end;
-lookup_identifier_type([{tail, _Context1} | [{cons, #{type := Type}} | _T]], Stack) ->
+lookup_identifier_type([{cons_tail, _Context1} | [{cons, #{type := Type}} | _T]], Stack) ->
     case allow_variable_binding(Stack) of
         true ->
             {ok, Type};
@@ -357,7 +357,7 @@ lookup_identifier_type([], Stack) ->
 allow_variable_binding(Stack) ->
     lists:any(
         fun
-            ({params, _Context}) ->
+            ({func_params, _Context}) ->
                 true;
             ({match_left, _Context}) ->
                 true;

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -71,12 +71,12 @@
 
 %% Virtual forms
 
--type exprs_form() :: {exprs, context()}.
--type params_form() :: {params, context()}.
--type head_form() :: {head, context()}.
--type left_form() :: {left, context()}.
--type right_form() :: {right, context()}.
--type tail_form() :: {tail, context()}.
+-type binary_op_left_form() :: {binary_op_left, context()}.
+-type binary_op_right_form() :: {binary_op_right, context()}.
+-type cons_head_form() :: {cons_head, context()}.
+-type cons_tail_form() :: {cons_tail, context()}.
+-type func_exprs_form() :: {func_exprs, context()}.
+-type func_params_form() :: {func_params, context()}.
 -type match_left_form() :: {match_left, context()}.
 -type match_right_form() :: {match_right, context()}.
 

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -656,7 +656,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                 line => 5,
                 right => {identifier, #{line => 5, spec => unbound}}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {match, #{
@@ -730,7 +730,7 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                 line => 4,
                 right => {identifier, #{line => 4, spec => unbound2}}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {match, #{

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -70,7 +70,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
         },
         locals => #{},
         stack => [
-            {exprs, #{line => 7}},
+            {func_exprs, #{line => 7}},
             {func, #{
                 exprs => [{identifier, #{line => 7, spec => a}}],
                 line => 7,

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -484,7 +484,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                         spec => 'list[int]'
                     }}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {list_lit, #{
@@ -1589,7 +1589,7 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
         },
         locals => #{},
         stack => [
-            {head, #{line => 3}},
+            {cons_head, #{line => 3}},
             {cons, #{
                 head => {identifier, #{line => 3, spec => head}},
                 line => 3,
@@ -1604,7 +1604,7 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                         spec => 'list[int]'
                     }}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {cons, #{

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -1767,7 +1767,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                 line => 5,
                 right => {identifier, #{line => 5, spec => unbound}}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {match, #{
@@ -1843,7 +1843,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                 line => 4,
                 right => {identifier, #{line => 4, spec => unbound2}}
             }},
-            {exprs, #{line => 3}},
+            {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
                     {match, #{


### PR DESCRIPTION
The `left` and `right` virtual forms have been renamed to `binary_op_left` and `binary_op_right`, respectively. The `head` and `tail` virtual forms have been renamed to `cons_head` and `cons_tail`, respectively. Finally, the `exprs` and `params` virtual forms have been renamed to `func_exprs` and `func_params`, respectively. All callsites and `rufus_form:make_*` functions have been updated.