### PR TITLE
compiler: Typecheck cons patterns as left operands of match forms

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -430,6 +430,8 @@ validate_pattern(_Data, {string_lit, _Context}) ->
     ok;
 validate_pattern(_Data, {list_lit, _Context}) ->
     ok;
+validate_pattern(_Data, {cons, _Context}) ->
+    ok;
 validate_pattern(_Data, {identifier, _Context}) ->
     ok;
 validate_pattern(Data, Form = {binary_op, _Context}) ->

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -617,6 +617,473 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(items list[int]) int {\n"
+        "        list[int]{head|tail} = items\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head =>
+                                {identifier, #{
+                                    line => 4,
+                                    locals => #{
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => head,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            tail =>
+                                {identifier, #{
+                                    line => 4,
+                                    locals => #{
+                                        head =>
+                                            {type, #{
+                                                line => 4,
+                                                source => rufus_text,
+                                                spec => int
+                                            }},
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => tail,
+                                    type =>
+                                        {type, #{
+                                            collection_type => list,
+                                            element_type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => rufus_text,
+                                                    spec => int
+                                                }},
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {identifier, #{
+                            line => 4,
+                            spec => items,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => head,
+                    type =>
+                        {type, #{line => 4, source => rufus_text, spec => int}}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 3, source => rufus_text, spec => int}},
+            spec => 'First'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(items list[int]) int {\n"
+        "        list[int]{head|list[int]{2, 3}} = items\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head =>
+                                {identifier, #{
+                                    line => 4,
+                                    locals => #{
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => head,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            tail =>
+                                {list_lit, #{
+                                    elements => [
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 2,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 3,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }}
+                                    ],
+                                    line => 4,
+                                    type =>
+                                        {type, #{
+                                            collection_type => list,
+                                            element_type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => rufus_text,
+                                                    spec => int
+                                                }},
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {identifier, #{
+                            line => 4,
+                            spec => items,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => head,
+                    type =>
+                        {type, #{line => 4, source => rufus_text, spec => int}}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 3, source => rufus_text, spec => int}},
+            spec => 'First'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Rest(items list[int]) list[int] {\n"
+        "        list[int]{1|tail} = items\n"
+        "        tail\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            tail =>
+                                {identifier, #{
+                                    line => 4,
+                                    locals => #{
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => tail,
+                                    type =>
+                                        {type, #{
+                                            collection_type => list,
+                                            element_type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => rufus_text,
+                                                    spec => int
+                                                }},
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {identifier, #{
+                            line => 4,
+                            spec => items,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => tail,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            line => 4,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Rest'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_with_mismatched_types_test() ->
     RufusText =
         "\n"


### PR DESCRIPTION
A `cons` form as the left operand of a `match` is allowed, with support for typechecking and variable binding.