### PR TITLE
compiler: Compile cons patterns as left operands of match forms

### DIFF
--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -74,6 +74,42 @@ eval_function_with_a_match_that_binds_a_list_literal_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"Rufus">>}, example:'Unbox'([{string, <<"Rufus">>}])).
 
+eval_function_with_a_match_that_binds_a_cons_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(items list[int]) list[int] {\n"
+        "        list[int]{head|tail} = items\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual([1, 2, 3], example:'Echo'([1, 2, 3])).
+
+eval_function_with_a_match_that_binds_a_cons_head_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(items list[int]) int {\n"
+        "        list[int]{head|list[int]{2, 3}} = items\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(1, example:'First'([1, 2, 3])).
+
+eval_function_with_a_match_that_binds_a_cons_tail_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Rest(items list[int]) list[int] {\n"
+        "        list[int]{1|tail} = items\n"
+        "        tail\n"
+        "    }\n"
+        "    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual([2, 3], example:'Rest'([1, 2, 3])).
+
 %% match expressions involving binary_op expressions
 
 eval_function_with_a_match_that_has_a_left_binary_op_operand_test() ->

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -621,9 +621,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
     RufusText =
         "\n"
         "    module example\n"
-        "    func First(items list[int]) int {\n"
+        "    func Echo(items list[int]) list[int] {\n"
         "        list[int]{head|tail} = items\n"
-        "        head\n"
+        "        list[int]{head|tail}\n"
         "    }\n"
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
@@ -745,11 +745,46 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             spec => 'list[int]'
                         }}
                 }},
-                {identifier, #{
+                {cons, #{
+                    head =>
+                        {identifier, #{
+                            line => 5,
+                            spec => head,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
                     line => 5,
-                    spec => head,
+                    tail =>
+                        {identifier, #{
+                            line => 5,
+                            spec => tail,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
                     type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}}
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 5, source => rufus_text, spec => int}},
+                            line => 5,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
                 }}
             ],
             line => 3,
@@ -769,8 +804,15 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
-            spec => 'First'
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Echo'
         }}
     ],
     ?assertEqual(Expected, AnnotatedForms).


### PR DESCRIPTION
Add tests to ensure that compiling `cons` patterns works correctly.