### PR TITLE
compiler: Parse and typecheck match forms in function parameter lists

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -101,19 +101,7 @@ typecheck_and_annotate(Acc, Stack, Globals, Locals, [H | T]) ->
 typecheck_and_annotate(Acc, _Stack, _Globals, Locals, []) ->
     {ok, Locals, lists:reverse(Acc)}.
 
-%% scope helpers
-
-%% annotate_locals adds a `locals` key to a form context.
--spec annotate_locals(locals(), rufus_form()) -> {ok, rufus_form()}.
-annotate_locals(Locals, {FormType, Context}) ->
-    {ok, {FormType, Context#{locals => Locals}}}.
-
-%% push_local adds a form to the local scope.
--spec push_local(locals(), rufus_form()) -> {ok, locals()}.
-push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
-    {ok, Locals#{Spec => Type}}.
-
-%% binary_op helpers
+%% binary_op form helpers
 
 %% typecheck_and_annotate_binary_op ensures that binary_op operands are
 %% exclusively ints or exclusively floats. Inferred type information is added to
@@ -156,7 +144,7 @@ typecheck_and_annotate_binary_op(
             throw(Error)
     end.
 
-%% call helpers
+%% call form helpers
 
 %% typecheck_and_annotate_call resolves the return type for a function call and
 %% returns a call form annotated with type information.
@@ -173,7 +161,7 @@ typecheck_and_annotate_call(Stack, Globals, Locals, {call, Context1 = #{args := 
             throw(Error)
     end.
 
-%% cons helpers
+%% cons form helpers
 
 %% typecheck_and_annotate_cons enforces the constraint that the head and tail
 %% elements are of the expected type. Return values:
@@ -217,7 +205,7 @@ typecheck_and_annotate_cons(
             throw(Error)
     end.
 
-%% func helpers
+%% func form helpers
 
 %% typecheck_and_annotate_func adds all parameters to the local scope. It also
 %% resolves and annotates types for all expressions in the function body to
@@ -272,7 +260,7 @@ typecheck_func_return_type(Globals, {func, #{return_type := ReturnType, exprs :=
             throw(Error)
     end.
 
-%% identifier helpers
+%% identifier form helpers
 
 %% typecheck_and_annotate_identifier adds a locals key/value pair to the
 %% identifier with information about local variables that are in scope. Type
@@ -304,7 +292,7 @@ typecheck_and_annotate_identifier(
             {ok, Locals, AnnotatedForm2}
     end.
 
-%% list_lit helpers
+%% list_lit form helpers
 
 %% typecheck_and_annotate_list_lit enforces the constraint that each list
 %% element matches the collection type. Returns values:
@@ -337,7 +325,7 @@ typecheck_and_annotate_list_lit(
             throw(Error)
     end.
 
-%% match helpers
+%% match form helpers
 
 %% typecheck_and_annotate_match ensures that match operands have matching types.
 %% Unknown identifiers in the left operand are treated as unbound variables and
@@ -455,3 +443,15 @@ is_constant_expr({int_lit, _Context}) ->
     true;
 is_constant_expr(_Form) ->
     false.
+
+%% scope helpers
+
+%% annotate_locals adds a `locals` key to a form context.
+-spec annotate_locals(locals(), rufus_form()) -> {ok, rufus_form()}.
+annotate_locals(Locals, {FormType, Context}) ->
+    {ok, {FormType, Context#{locals => Locals}}}.
+
+%% push_local adds a form to the local scope.
+-spec push_local(locals(), rufus_form()) -> {ok, locals()}.
+push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
+    {ok, Locals#{Spec => Type}}.

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -30,6 +30,7 @@
     make_literal/3,
     make_literal/4,
     make_match/3,
+    make_match/4,
     make_match_left/1,
     make_match_right/1,
     make_module/2,
@@ -228,6 +229,11 @@ make_literal(list, Type, Elements, Line) ->
     {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_match(Left, Right, Line) ->
     {match, #{left => Left, right => Right, line => Line}}.
+
+-spec make_match(type_form(), rufus_form(), rufus_form(), integer()) ->
+    {match, #{left => rufus_form(), right => rufus_form(), line => integer(), type => type_form()}}.
+make_match(Type, Left, Right, Line) ->
+    {match, #{type => Type, left => Left, right => Right, line => Line}}.
 
 %% make_match_left returns a left form from a binary_op or match expression.
 -spec make_match_left(match_form()) -> match_left_form().

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -30,7 +30,6 @@
     make_literal/3,
     make_literal/4,
     make_match/3,
-    make_match/4,
     make_match_left/1,
     make_match_right/1,
     make_module/2,
@@ -229,11 +228,6 @@ make_literal(list, Type, Elements, Line) ->
     {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
 make_match(Left, Right, Line) ->
     {match, #{left => Left, right => Right, line => Line}}.
-
--spec make_match(type_form(), rufus_form(), rufus_form(), integer()) ->
-    {match, #{left => rufus_form(), right => rufus_form(), line => integer(), type => type_form()}}.
-make_match(Type, Left, Right, Line) ->
-    {match, #{type => Type, left => Left, right => Right, line => Line}}.
 
 %% make_match_left returns a left form from a binary_op or match expression.
 -spec make_match_left(match_form()) -> match_left_form().

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -5,7 +5,7 @@
 Nonterminals
     root decl
     type block param params args expr exprs
-    binary_op call cons match
+    binary_op call cons match match_param
     list_lit list_type.
 
 Terminals
@@ -110,6 +110,7 @@ list_lit -> list_type '{' args '}' :
 list_type -> list '[' type ']'   : rufus_form:make_type(list, '$3', line('$1')).
 
 match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
+match_param -> expr '=' param    : rufus_form:make_match('$1', '$3', line('$2')).
 
 params -> param params           : ['$1'|'$2'].
 params -> '$empty'               : [].
@@ -122,6 +123,7 @@ param -> float_lit               : rufus_form:make_literal(float, text('$1'), li
 param -> int_lit                 : rufus_form:make_literal(int, text('$1'), line('$1')).
 param -> list_lit                : '$1'.
 param -> string_lit              : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
+param -> match_param             : '$1'.
 
 type -> atom                     : rufus_form:make_type(atom, line('$1')).
 type -> bool                     : rufus_form:make_type(bool, line('$1')).

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -154,6 +154,17 @@ eval_function_with_a_match_that_has_a_right_call_operand_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(2, example:'Random'()).
 
+eval_function_taking_a_match_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Double(b = a int) int {\n"
+        "        a + b\n"
+        "    }\n"
+        "    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(4, example:'Double'(2)).
+
 eval_function_with_a_match_that_has_a_left_call_operand_test() ->
     RufusText =
         "\n"

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -165,6 +165,17 @@ eval_function_taking_a_match_pattern_test() ->
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(4, example:'Double'(2)).
 
+eval_function_taking_a_cons_in_match_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(list[int]{head|tail} = items list[int]) int {\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(1, example:'First'([1, 2, 3, 4])).
+
 eval_function_with_a_match_that_has_a_left_call_operand_test() ->
     RufusText =
         "\n"

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -1126,6 +1126,95 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_function_taking_a_match_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Double(b = a int) int {\n"
+        "        a + b\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            spec => a,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    line => 4,
+                    op => '+',
+                    right =>
+                        {identifier, #{
+                            line => 4,
+                            spec => b,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}}
+                }}
+            ],
+            line => 3,
+            params => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                a =>
+                                    {type, #{
+                                        line => 3,
+                                        source => rufus_text,
+                                        spec => int
+                                    }}
+                            },
+                            spec => b,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    line => 3,
+                    right =>
+                        {param, #{
+                            line => 3,
+                            spec => a,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }},
+                    type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 3, source => rufus_text, spec => int}},
+            spec => 'Double'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_with_mismatched_types_test() ->
     RufusText =
         "\n"

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -1215,6 +1215,150 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(list[int]{head|tail} = items list[int]) int {\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 4,
+                    spec => head,
+                    type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}}
+                }}
+            ],
+            line => 3,
+            params => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head =>
+                                {identifier, #{
+                                    line => 3,
+                                    locals => #{
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => head,
+                                    type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 3,
+                            tail =>
+                                {identifier, #{
+                                    line => 3,
+                                    locals => #{
+                                        head =>
+                                            {type, #{
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => int
+                                            }},
+                                        items =>
+                                            {type, #{
+                                                collection_type => list,
+                                                element_type =>
+                                                    {type, #{
+                                                        line => 3,
+                                                        source => rufus_text,
+                                                        spec => int
+                                                    }},
+                                                line => 3,
+                                                source => rufus_text,
+                                                spec => 'list[int]'
+                                            }}
+                                    },
+                                    spec => tail,
+                                    type =>
+                                        {type, #{
+                                            collection_type => list,
+                                            element_type =>
+                                                {type, #{
+                                                    line => 3,
+                                                    source => rufus_text,
+                                                    spec => int
+                                                }},
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 3,
+                    right =>
+                        {param, #{
+                            line => 3,
+                            spec => items,
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 3,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 3, source => rufus_text, spec => int}},
+            spec => 'First'
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_with_mismatched_types_test() ->
     RufusText =
         "\n"

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -585,3 +585,42 @@ parse_function_with_a_match_that_binds_a_variable_test() ->
         }}
     ],
     ?assertEqual(Expected, Forms).
+
+parse_function_taking_a_match_pattern_test() ->
+    RufusText = "func Double(b = a int) int { a + b }",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {binary_op, #{
+                    left => {identifier, #{line => 1, spec => a}},
+                    line => 1,
+                    op => '+',
+                    right => {identifier, #{line => 1, spec => b}}
+                }}
+            ],
+            line => 1,
+            params => [
+                {match, #{
+                    left => {identifier, #{line => 1, spec => b}},
+                    line => 1,
+                    right =>
+                        {param, #{
+                            line => 1,
+                            spec => a,
+                            type =>
+                                {type, #{
+                                    line => 1,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 1, source => rufus_text, spec => int}},
+            spec => 'Double'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -266,6 +266,270 @@ parse_function_with_a_match_that_binds_a_list_literal_test() ->
     ],
     ?assertEqual(Expected, Forms).
 
+parse_function_with_a_match_that_binds_a_cons_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(items list[int]) list[int] {\n"
+        "        list[int]{head|tail} = items\n"
+        "        list[int]{head|tail}\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head => {identifier, #{line => 4, spec => head}},
+                            line => 4,
+                            tail => {identifier, #{line => 4, spec => tail}},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right => {identifier, #{line => 4, spec => items}}
+                }},
+                {cons, #{
+                    head => {identifier, #{line => 5, spec => head}},
+                    line => 5,
+                    tail => {identifier, #{line => 5, spec => tail}},
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 5, source => rufus_text, spec => int}},
+                            line => 5,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Echo'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_a_cons_head_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func First(items list[int]) int {\n"
+        "        list[int]{head|list[int]{2, 3}} = items\n"
+        "        head\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head => {identifier, #{line => 4, spec => head}},
+                            line => 4,
+                            tail =>
+                                {list_lit, #{
+                                    elements => [
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 2,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 3,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }}
+                                    ],
+                                    line => 4,
+                                    type =>
+                                        {type, #{
+                                            collection_type => list,
+                                            element_type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => rufus_text,
+                                                    spec => int
+                                                }},
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right => {identifier, #{line => 4, spec => items}}
+                }},
+                {identifier, #{line => 5, spec => head}}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{line => 3, source => rufus_text, spec => int}},
+            spec => 'First'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_a_match_that_binds_a_cons_tail_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Rest(items list[int]) list[int] {\n"
+        "        list[int]{1|tail} = items\n"
+        "        tail\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {cons, #{
+                            head =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }},
+                            line => 4,
+                            tail => {identifier, #{line => 4, spec => tail}},
+                            type =>
+                                {type, #{
+                                    collection_type => list,
+                                    element_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    line => 4,
+                                    source => rufus_text,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 4,
+                    right => {identifier, #{line => 4, spec => items}}
+                }},
+                {identifier, #{line => 5, spec => tail}}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => items,
+                    type =>
+                        {type, #{
+                            collection_type => list,
+                            element_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            line => 3,
+                            source => rufus_text,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    collection_type => list,
+                    element_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    line => 3,
+                    source => rufus_text,
+                    spec => 'list[int]'
+                }},
+            spec => 'Rest'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
 parse_function_with_a_match_that_binds_a_variable_test() ->
     RufusText =
         "\n"


### PR DESCRIPTION
`rufus_parse` can parse `match_param` expressions, which are similar to `match` expressions, but match an `expr` with a `param` that has a known type.