### PR TITLE
compiler: Compile anonymous functions

### DIFF
--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -69,14 +69,14 @@ forms(Acc, [{bool_lit, _Context} = BoolLit | T]) ->
     forms([Form | Acc], T);
 forms(Acc, [{call, Context = #{spec := Spec, args := Args, line := Line}} | T]) ->
     {ok, ArgsForms} = forms([], Args),
-    Form =
+    Name =
         case maps:get(kind, Context, named) of
             anonymous ->
-                {call, Line, {var, Line, Spec}, ArgsForms};
+                {var, Line, Spec};
             named ->
-                {call, Line, {atom, Line, Spec}, ArgsForms}
+                {atom, Line, Spec}
         end,
-    forms([Form | Acc], T);
+    forms([{call, Line, Name, ArgsForms} | Acc], T);
 forms(Acc, [{cons, #{head := Head, tail := Tail, line := Line}} | T]) ->
     {ok, [HeadForm]} = forms([], [Head]),
     {ok, [TailForm]} = forms([], [Tail]),

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -67,9 +67,15 @@ forms(Acc, [{binary_op, #{line := Line, op := Op, left := Left, right := Right}}
 forms(Acc, [{bool_lit, _Context} = BoolLit | T]) ->
     Form = box(BoolLit),
     forms([Form | Acc], T);
-forms(Acc, [{call, #{spec := Spec, args := Args, line := Line}} | T]) ->
+forms(Acc, [{call, Context = #{spec := Spec, args := Args, line := Line}} | T]) ->
     {ok, ArgsForms} = forms([], Args),
-    Form = {call, Line, {atom, Line, Spec}, ArgsForms},
+    Form =
+        case maps:get(kind, Context, named) of
+            anonymous ->
+                {call, Line, {var, Line, Spec}, ArgsForms};
+            named ->
+                {call, Line, {atom, Line, Spec}, ArgsForms}
+        end,
     forms([Form | Acc], T);
 forms(Acc, [{cons, #{head := Head, tail := Tail, line := Line}} | T]) ->
     {ok, [HeadForm]} = forms([], [Head]),

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -165,9 +165,26 @@ typecheck_and_annotate_binary_op(
 %% returns a call form annotated with type information.
 -spec typecheck_and_annotate_call(rufus_stack(), globals(), locals(), call_form()) ->
     {ok, call_form()} | no_return().
-typecheck_and_annotate_call(Stack, Globals, Locals, {call, Context1 = #{args := Args}}) ->
+typecheck_and_annotate_call(
+    Stack,
+    Globals,
+    Locals,
+    {call, Context = #{args := Args, spec := Spec}}
+) ->
     {ok, _NewLocals, AnnotatedArgs} = typecheck_and_annotate([], Stack, Globals, Locals, Args),
-    Context2 = Context1#{args => AnnotatedArgs},
+    Context1 = Context#{args => AnnotatedArgs},
+    Context2 =
+        case maps:get(Spec, Locals, false) of
+            false ->
+                Context1;
+            _Type ->
+                %% The identifier being invoked refers to a function defined in
+                %% the local scope, which means it must be an anonymous
+                %% function. We mark the form so that rufus_erlang:forms/1 can
+                %% generate the correct Erlang abstract syntax to match the use
+                %% case of calling a named function vs. an anonymous function.
+                Context1#{kind => anonymous}
+        end,
     Form = {call, Context2#{locals => Locals}},
     case rufus_type:resolve(Globals, Form) of
         {ok, TypeForm} ->

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -174,8 +174,8 @@ typecheck_and_annotate_call(
     {ok, _NewLocals, AnnotatedArgs} = typecheck_and_annotate([], Stack, Globals, Locals, Args),
     Context1 = Context#{args => AnnotatedArgs},
     Context2 =
-        case maps:get(Spec, Locals, false) of
-            false ->
+        case maps:get(Spec, Locals, undefined) of
+            undefined ->
                 Context1;
             _Type ->
                 %% The identifier being invoked refers to a function defined in

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -140,20 +140,11 @@ typecheck_and_annotate_binary_op(
     {ok, Locals, [AnnotatedLeft]} = typecheck_and_annotate([], LeftStack, Globals, Locals, [Left]),
     RightStack = [rufus_form:make_binary_op_right(Form) | BinaryOpStack],
     {ok, Locals, [AnnotatedRight]} = typecheck_and_annotate([], RightStack, Globals, Locals, [Right]),
-    AnnotatedForm1 =
-        {binary_op, Context#{
-            left => AnnotatedLeft,
-            right => AnnotatedRight,
-            locals => Locals
-        }},
+    Context1 = Context#{left => AnnotatedLeft, right => AnnotatedRight},
+    AnnotatedForm1 = {binary_op, Context1#{locals => Locals}},
     case rufus_type:resolve(Globals, AnnotatedForm1) of
         {ok, TypeForm} ->
-            AnnotatedForm2 =
-                {binary_op, Context#{
-                    left => AnnotatedLeft,
-                    right => AnnotatedRight,
-                    type => TypeForm
-                }},
+            AnnotatedForm2 = {binary_op, Context1#{type => TypeForm}},
             {ok, AnnotatedForm2};
         Error ->
             throw(Error)

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -332,3 +332,34 @@ eval_function_taking_an_atom_literal_and_passing_an_invalid_value_test() ->
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
     ?assertError(function_clause, example:'Echo'(fine)).
+
+%% Anonymous functions
+
+eval_function_taking_and_returning_a_function_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(fn func() int) func() int {\n"
+        "        fn\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    NumberFunc = example:'Echo'(fun() -> 42 end),
+    ?assert(is_function(NumberFunc)),
+    ?assertEqual(42, NumberFunc()).
+
+eval_function_returning_a_function_variable_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func NumberFunc() func() int {\n"
+        "        fn = func() int { 21 + 21 }\n"
+        "        fn\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    NumberFunc = example:'NumberFunc'(),
+    ?assert(is_function(NumberFunc)),
+    ?assertEqual(42, NumberFunc()).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -487,30 +487,11 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
         "        func(numbers = list[int]{1, 2, 3}) list[int] { numbers }\n"
         "    }\n"
         "    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [
-        {attribute, 2, module, example},
-        {attribute, 3, export, [{'EchoNumberListFunc', 0}]},
-        {function, 3, 'EchoNumberListFunc', 0, [
-            {clause, 3, [], [], [
-                {'fun', 4,
-                    {clauses, [
-                        {clause, 4,
-                            [
-                                {match, 4, {var, 4, numbers},
-                                    {cons, 4, {integer, 4, 1},
-                                        {cons, 4, {integer, 4, 2},
-                                            {cons, 4, {integer, 4, 3}, {nil, 4}}}}}
-                            ],
-                            [], [{var, 4, numbers}]}
-                    ]}}
-            ]}
-        ]}
-    ],
-    ?assertEqual(Expected, ErlangForms).
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoNumberListFunc = example:'EchoNumberListFunc'(),
+    ?assert(is_function(EchoNumberListFunc)),
+    ?assertEqual([1, 2, 3], EchoNumberListFunc([1, 2, 3])).
 
 typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
     RufusText =
@@ -522,25 +503,11 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
         "        }\n"
         "    }\n"
         "    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [
-        {attribute, 2, module, example},
-        {attribute, 3, export, [{'EchoFortyTwoFunc', 0}]},
-        {function, 3, 'EchoFortyTwoFunc', 0, [
-            {clause, 3, [], [], [
-                {'fun', 4,
-                    {clauses, [
-                        {clause, 4, [{match, 4, {integer, 4, 42}, {var, 4, value}}], [], [
-                            {var, 5, value}
-                        ]}
-                    ]}}
-            ]}
-        ]}
-    ],
-    ?assertEqual(Expected, ErlangForms).
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFortyTwoFunc = example:'EchoFortyTwoFunc'(),
+    ?assert(is_function(EchoFortyTwoFunc)),
+    ?assertEqual(42, EchoFortyTwoFunc(42)).
 
 typecheck_and_annotate_closure_test() ->
     RufusText =
@@ -550,23 +517,8 @@ typecheck_and_annotate_closure_test() ->
         "        func() int { num }\n"
         "    }\n"
         "    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [
-        {attribute, 2, module, example},
-        {attribute, 3, export, [{'Memoize', 1}]},
-        {function, 3, 'Memoize', 1, [
-            {clause, 3, [{var, 3, num}],
-                [
-                    [
-                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [
-                            {var, 3, num}
-                        ]}
-                    ]
-                ],
-                [{'fun', 4, {clauses, [{clause, 4, [], [], [{var, 4, num}]}]}}]}
-        ]}
-    ],
-    ?assertEqual(Expected, ErlangForms).
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    FortyTwoFunc = example:'Memoize'(42),
+    ?assert(is_function(FortyTwoFunc)),
+    ?assertEqual(42, FortyTwoFunc()).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -377,3 +377,20 @@ eval_function_returning_a_function_variable_test() ->
     NumberFunc = example:'NumberFunc'(),
     ?assert(is_function(NumberFunc)),
     ?assertEqual(42, NumberFunc()).
+
+eval_function_returning_a_nested_function_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func NumberFunc() func() int {\n"
+        "        f = func() func() int {\n"
+        "            func() int { 42 }\n"
+        "        }\n"
+        "        f()\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    NumberFunc = example:'NumberFunc'(),
+    ?assert(is_function(NumberFunc)),
+    ?assertEqual(42, NumberFunc()).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -394,3 +394,73 @@ eval_function_returning_a_nested_function_test() ->
     NumberFunc = example:'NumberFunc'(),
     ?assert(is_function(NumberFunc)),
     ?assertEqual(42, NumberFunc()).
+
+eval_anonymous_function_taking_an_atom_and_returning_an_atom_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(atom) atom {\n"
+        "        func(value atom) atom { value }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFunc = example:'EchoFunc'(),
+    ?assert(is_function(EchoFunc)),
+    ?assertEqual(rufus, EchoFunc(rufus)).
+
+eval_for_anonymous_function_taking_a_bool_and_returning_a_bool_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(bool) bool {\n"
+        "        func(value bool) bool { value }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFunc = example:'EchoFunc'(),
+    ?assert(is_function(EchoFunc)),
+    ?assertEqual(true, EchoFunc(true)).
+
+eval_for_anonymous_function_taking_a_float_and_returning_a_float_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(float) float {\n"
+        "        func(value float) float { value }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFunc = example:'EchoFunc'(),
+    ?assert(is_function(EchoFunc)),
+    ?assertEqual(42.0, EchoFunc(42.0)).
+
+eval_for_anonymous_function_taking_an_int_and_returning_an_int_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(int) int {\n"
+        "        func(value int) int { value }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFunc = example:'EchoFunc'(),
+    ?assert(is_function(EchoFunc)),
+    ?assertEqual(42, EchoFunc(42)).
+
+eval_for_anonymous_function_taking_a_string_and_returning_a_string_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(string) string {\n"
+        "        func(value string) string { value }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoFunc = example:'EchoFunc'(),
+    ?assert(is_function(EchoFunc)),
+    ?assertEqual({string, <<"rufus">>}, EchoFunc({string, <<"rufus">>})).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -345,9 +345,23 @@ eval_function_taking_and_returning_a_function_test() ->
         "    ",
     Result = rufus_compile:eval(RufusText),
     ?assertEqual({ok, example}, Result),
-    NumberFunc = example:'Echo'(fun() -> 42 end),
-    ?assert(is_function(NumberFunc)),
-    ?assertEqual(42, NumberFunc()).
+    Fun = example:'Echo'(fun() -> 42 end),
+    ?assert(is_function(Fun)),
+    ?assertEqual(42, Fun()).
+
+eval_function_returning_a_function_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func NumberFunc() func() int {\n"
+        "        func() int { 42 }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    Fun = example:'NumberFunc'(),
+    ?assert(is_function(Fun)),
+    ?assertEqual(42, Fun()).
 
 eval_function_returning_a_function_variable_test() ->
     RufusText =

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -521,4 +521,5 @@ typecheck_and_annotate_closure_test() ->
     ?assertEqual({ok, example}, Result),
     FortyTwoFunc = example:'Memoize'(42),
     ?assert(is_function(FortyTwoFunc)),
+    ?assertEqual(42, FortyTwoFunc()),
     ?assertEqual(42, FortyTwoFunc()).

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -464,3 +464,109 @@ eval_for_anonymous_function_taking_a_string_and_returning_a_string_literal_test(
     EchoFunc = example:'EchoFunc'(),
     ?assert(is_function(EchoFunc)),
     ?assertEqual({string, <<"rufus">>}, EchoFunc({string, <<"rufus">>})).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoNumberListFunc() func(list[int]) list[int] {\n"
+        "        func(list[int]{head|tail}) list[int] { list[int]{head|tail} }\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    EchoNumberListFunc = example:'EchoNumberListFunc'(),
+    ?assert(is_function(EchoNumberListFunc)),
+    ?assertEqual([1, 2, 3], EchoNumberListFunc([1, 2, 3])).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoNumberListFunc() func(list[int]) list[int] {\n"
+        "        func(numbers = list[int]{1, 2, 3}) list[int] { numbers }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoNumberListFunc', 0}]},
+        {function, 3, 'EchoNumberListFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4,
+                            [
+                                {match, 4, {var, 4, numbers},
+                                    {cons, 4, {integer, 4, 1},
+                                        {cons, 4, {integer, 4, 2},
+                                            {cons, 4, {integer, 4, 3}, {nil, 4}}}}}
+                            ],
+                            [], [{var, 4, numbers}]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFortyTwoFunc() func(int) int {\n"
+        "        func(42 = value int) int {\n"
+        "            value\n"
+        "        }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFortyTwoFunc', 0}]},
+        {function, 3, 'EchoFortyTwoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{match, 4, {integer, 4, 42}, {var, 4, value}}], [], [
+                            {var, 5, value}
+                        ]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_closure_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Memoize(num int) func() int {\n"
+        "        func() int { num }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'Memoize', 1}]},
+        {function, 3, 'Memoize', 1, [
+            {clause, 3, [{var, 3, num}],
+                [
+                    [
+                        {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, is_integer}}, [
+                            {var, 3, num}
+                        ]}
+                    ]
+                ],
+                [{'fun', 4, {clauses, [{clause, 4, [], [], [{var, 4, num}]}]}}]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -571,3 +571,37 @@ forms_for_function_returning_a_nested_function_test() ->
         ]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+forms_for_anonymous_function_taking_an_atom_and_returning_an_atom_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(atom) atom {\n"
+        "        func(value atom) atom { value }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFunc', 0}]},
+        {function, 3, 'EchoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{var, 4, value}],
+                            [
+                                [
+                                    {call, 4, {remote, 4, {atom, 4, erlang}, {atom, 4, is_atom}}, [
+                                        {var, 4, value}
+                                    ]}
+                                ]
+                            ],
+                            [{var, 4, value}]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -605,3 +605,131 @@ forms_for_anonymous_function_taking_an_atom_and_returning_an_atom_literal_test()
         ]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(bool) bool {\n"
+        "        func(value bool) bool { value }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFunc', 0}]},
+        {function, 3, 'EchoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{var, 4, value}],
+                            [
+                                [
+                                    {call, 4, {remote, 4, {atom, 4, erlang}, {atom, 4, is_boolean}},
+                                        [{var, 4, value}]}
+                                ]
+                            ],
+                            [{var, 4, value}]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_float_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(float) float {\n"
+        "        func(value float) float { value }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFunc', 0}]},
+        {function, 3, 'EchoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{var, 4, value}],
+                            [
+                                [
+                                    {call, 4, {remote, 4, {atom, 4, erlang}, {atom, 4, is_float}}, [
+                                        {var, 4, value}
+                                    ]}
+                                ]
+                            ],
+                            [{var, 4, value}]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(int) int {\n"
+        "        func(value int) int { value }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFunc', 0}]},
+        {function, 3, 'EchoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{var, 4, value}],
+                            [
+                                [
+                                    {call, 4, {remote, 4, {atom, 4, erlang}, {atom, 4, is_integer}},
+                                        [{var, 4, value}]}
+                                ]
+                            ],
+                            [{var, 4, value}]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_string_literal_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func EchoFunc() func(string) string {\n"
+        "        func(value string) string { value }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'EchoFunc', 0}]},
+        {function, 3, 'EchoFunc', 0, [
+            {clause, 3, [], [], [
+                {'fun', 4,
+                    {clauses, [
+                        {clause, 4, [{tuple, 4, [{atom, 4, string}, {var, 4, value}]}], [], [
+                            {tuple, 4, [{atom, 4, string}, {var, 4, value}]}
+                        ]}
+                    ]}}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -501,7 +501,13 @@ forms_for_function_returning_a_function_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
-    Expected = [],
+    Expected = [
+        {attribute, 2, module, example},
+        {attribute, 3, export, [{'NumberFunc', 0}]},
+        {function, 3, 'NumberFunc', 0, [
+            {clause, 3, [], [], [{'fun', 4, {clauses, [{clause, 4, [], [], [{integer, 4, 42}]}]}}]}
+        ]}
+    ],
     ?assertEqual(Expected, ErlangForms).
 
 forms_for_function_returning_a_function_variable_test() ->

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -1335,6 +1335,7 @@ typecheck_and_annotate_for_function_taking_a_string_literal_test() ->
 typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
     RufusText =
         "\n"
+        "    module example\n"
         "    func Echo(fn func() int) func() int {\n"
         "        fn\n"
         "    }\n"
@@ -1343,262 +1344,9 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
     Expected = [
+        {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {identifier, #{
-                    line => 3,
-                    spec => fn,
-                    type =>
-                        {type, #{
-                            kind => func,
-                            line => 2,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }}
-                }}
-            ],
-            line => 2,
-            params => [
-                {param, #{
-                    line => 2,
-                    spec => fn,
-                    type =>
-                        {type, #{
-                            kind => func,
-                            line => 2,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }}
-                }}
-            ],
-            return_type =>
-                {type, #{
-                    kind => func,
-                    line => 2,
-                    param_types => [],
-                    return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
-                    source => rufus_text,
-                    spec => 'func() int'
-                }},
-            spec => 'Echo',
-            type =>
-                {type, #{
-                    kind => func,
-                    line => 2,
-                    param_types => [
-                        {type, #{
-                            kind => func,
-                            line => 2,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }}
-                    ],
-                    return_type =>
-                        {type, #{
-                            kind => func,
-                            line => 2,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }},
-                    source => rufus_text,
-                    spec => 'func(func() int) func() int'
-                }}
-        }}
-    ],
-    ?assertEqual(Expected, AnnotatedForms).
-
-typecheck_and_annotate_function_returning_a_function_test() ->
-    RufusText =
-        "\n"
-        "    func NumberFunc() func() int {\n"
-        "        func() int { 42 }\n"
-        "    }\n"
-        "    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [
-        {func, #{
-            exprs => [
-                {func, #{
-                    exprs => [
-                        {int_lit, #{
-                            line => 3,
-                            spec => 42,
-                            type =>
-                                {type, #{
-                                    line => 3,
-                                    source => inferred,
-                                    spec => int
-                                }}
-                        }}
-                    ],
-                    line => 3,
-                    params => [],
-                    return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
-                    type =>
-                        {type, #{
-                            kind => func,
-                            line => 3,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }}
-                }}
-            ],
-            line => 2,
-            params => [],
-            return_type =>
-                {type, #{
-                    kind => func,
-                    line => 2,
-                    param_types => [],
-                    return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
-                    source => rufus_text,
-                    spec => 'func() int'
-                }},
-            spec => 'NumberFunc',
-            type =>
-                {type, #{
-                    kind => func,
-                    line => 2,
-                    param_types => [],
-                    return_type =>
-                        {type, #{
-                            kind => func,
-                            line => 2,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }},
-                    source => rufus_text,
-                    spec => 'func() func() int'
-                }}
-        }}
-    ],
-    ?assertEqual(Expected, AnnotatedForms).
-
-typecheck_and_annotate_function_returning_a_function_variable_test() ->
-    RufusText =
-        "\n"
-        "    func NumberFunc() func() int {\n"
-        "        fn = func() int { 21 + 21 }\n"
-        "        fn\n"
-        "    }\n"
-        "    ",
-    {ok, Tokens} = rufus_tokenize:string(RufusText),
-    {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
-    Expected = [
-        {func, #{
-            exprs => [
-                {match, #{
-                    left =>
-                        {identifier, #{
-                            line => 3,
-                            locals => #{},
-                            spec => fn,
-                            type =>
-                                {type, #{
-                                    kind => func,
-                                    line => 3,
-                                    param_types => [],
-                                    return_type =>
-                                        {type, #{
-                                            line => 3,
-                                            source => rufus_text,
-                                            spec => int
-                                        }},
-                                    source => rufus_text,
-                                    spec => 'func() int'
-                                }}
-                        }},
-                    line => 3,
-                    right =>
-                        {func, #{
-                            exprs => [
-                                {binary_op, #{
-                                    left =>
-                                        {int_lit, #{
-                                            line => 3,
-                                            spec => 21,
-                                            type =>
-                                                {type, #{
-                                                    line => 3,
-                                                    source => inferred,
-                                                    spec => int
-                                                }}
-                                        }},
-                                    line => 3,
-                                    op => '+',
-                                    right =>
-                                        {int_lit, #{
-                                            line => 3,
-                                            spec => 21,
-                                            type =>
-                                                {type, #{
-                                                    line => 3,
-                                                    source => inferred,
-                                                    spec => int
-                                                }}
-                                        }},
-                                    type =>
-                                        {type, #{
-                                            line => 3,
-                                            source => inferred,
-                                            spec => int
-                                        }}
-                                }}
-                            ],
-                            line => 3,
-                            params => [],
-                            return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
-                            type =>
-                                {type, #{
-                                    kind => func,
-                                    line => 3,
-                                    param_types => [],
-                                    return_type =>
-                                        {type, #{
-                                            line => 3,
-                                            source => rufus_text,
-                                            spec => int
-                                        }},
-                                    source => rufus_text,
-                                    spec => 'func() int'
-                                }}
-                        }},
-                    type =>
-                        {type, #{
-                            kind => func,
-                            line => 3,
-                            param_types => [],
-                            return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
-                            source => rufus_text,
-                            spec => 'func() int'
-                        }}
-                }},
                 {identifier, #{
                     line => 4,
                     spec => fn,
@@ -1614,15 +1362,119 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                         }}
                 }}
             ],
-            line => 2,
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [],
+                    return_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    source => rufus_text,
+                    spec => 'func() int'
+                }},
+            spec => 'Echo',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                    ],
+                    return_type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }},
+                    source => rufus_text,
+                    spec => 'func(func() int) func() int'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_returning_a_function_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func NumberFunc() func() int {\n"
+        "        func() int { 42 }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {func, #{
+                    exprs => [
+                        {int_lit, #{
+                            line => 4,
+                            spec => 42,
+                            type =>
+                                {type, #{
+                                    line => 4,
+                                    source => inferred,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{line => 4, source => rufus_text, spec => int}},
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 4,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                }}
+            ],
+            line => 3,
             params => [],
             return_type =>
                 {type, #{
                     kind => func,
-                    line => 2,
+                    line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
+                        {type, #{line => 3, source => rufus_text, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -1630,15 +1482,169 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
             type =>
                 {type, #{
                     kind => func,
-                    line => 2,
+                    line => 3,
                     param_types => [],
                     return_type =>
                         {type, #{
                             kind => func,
-                            line => 2,
+                            line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }},
+                    source => rufus_text,
+                    spec => 'func() func() int'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_returning_a_function_variable_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func NumberFunc() func() int {\n"
+        "        fn = func() int { 21 + 21 }\n"
+        "        fn\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{},
+                            spec => fn,
+                            type =>
+                                {type, #{
+                                    kind => func,
+                                    line => 4,
+                                    param_types => [],
+                                    return_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    source => rufus_text,
+                                    spec => 'func() int'
+                                }}
+                        }},
+                    line => 4,
+                    right =>
+                        {func, #{
+                            exprs => [
+                                {binary_op, #{
+                                    left =>
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 21,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                    line => 4,
+                                    op => '+',
+                                    right =>
+                                        {int_lit, #{
+                                            line => 4,
+                                            spec => 21,
+                                            type =>
+                                                {type, #{
+                                                    line => 4,
+                                                    source => inferred,
+                                                    spec => int
+                                                }}
+                                        }},
+                                    type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => inferred,
+                                            spec => int
+                                        }}
+                                }}
+                            ],
+                            line => 4,
+                            params => [],
+                            return_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            type =>
+                                {type, #{
+                                    kind => func,
+                                    line => 4,
+                                    param_types => [],
+                                    return_type =>
+                                        {type, #{
+                                            line => 4,
+                                            source => rufus_text,
+                                            spec => int
+                                        }},
+                                    source => rufus_text,
+                                    spec => 'func() int'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 4,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                }},
+                {identifier, #{
+                    line => 5,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 4,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [],
+                    return_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    source => rufus_text,
+                    spec => 'func() int'
+                }},
+            spec => 'NumberFunc',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [],
+                    return_type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -2994,6 +2994,92 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_closure_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Memoize(num int) func() int {\n"
+        "        func() int { num }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {func, #{
+                    exprs => [
+                        {identifier, #{
+                            line => 4,
+                            spec => num,
+                            type =>
+                                {type, #{
+                                    line => 3,
+                                    source => rufus_text,
+                                    spec => int
+                                }}
+                        }}
+                    ],
+                    line => 4,
+                    params => [],
+                    return_type =>
+                        {type, #{line => 4, source => rufus_text, spec => int}},
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 4,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 4, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => num,
+                    type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [],
+                    return_type =>
+                        {type, #{line => 3, source => rufus_text, spec => int}},
+                    source => rufus_text,
+                    spec => 'func() int'
+                }},
+            spec => 'Memoize',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    return_type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [],
+                            return_type =>
+                                {type, #{line => 3, source => rufus_text, spec => int}},
+                            source => rufus_text,
+                            spec => 'func() int'
+                        }},
+                    source => rufus_text,
+                    spec => 'func(int) func() int'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_anonymous_function_with_unmatched_return_types_test() ->
     RufusText =
         "\n"

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -1806,6 +1806,7 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                         }}
                 }},
                 {call, #{
+                    kind => anonymous,
                     args => [],
                     line => 7,
                     spec => f,


### PR DESCRIPTION
`call` forms carry a new `kind => anonymous` key/value pair for calls to anonymous functions. `rufus_erlang:forms/1` uses this to determine how to render the call, either with an `atom` for named function calls or with a `var` for anonymous function calls. Anonymous `func` forms compile and run. 