### PR TITLE
compiler: Remove source annotations from type forms

### DIFF
--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -126,12 +126,12 @@ resolve_binary_op_type(
             {ok, Type}
     end.
 
-binary_op_type('==', Line) -> rufus_form:make_inferred_type(bool, Line);
-binary_op_type('!=', Line) -> rufus_form:make_inferred_type(bool, Line);
-binary_op_type('<', Line) -> rufus_form:make_inferred_type(bool, Line);
-binary_op_type('<=', Line) -> rufus_form:make_inferred_type(bool, Line);
-binary_op_type('>', Line) -> rufus_form:make_inferred_type(bool, Line);
-binary_op_type('>=', Line) -> rufus_form:make_inferred_type(bool, Line);
+binary_op_type('==', Line) -> rufus_form:make_type(bool, Line);
+binary_op_type('!=', Line) -> rufus_form:make_type(bool, Line);
+binary_op_type('<', Line) -> rufus_form:make_type(bool, Line);
+binary_op_type('<=', Line) -> rufus_form:make_type(bool, Line);
+binary_op_type('>', Line) -> rufus_form:make_type(bool, Line);
+binary_op_type('>=', Line) -> rufus_form:make_type(bool, Line);
 binary_op_type(_, _) -> default.
 
 %% allow_type_with_mathematical_operator returns true if the specified type may

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -184,7 +184,7 @@ eval_function_having_unmatched_return_types_test() ->
                 line => 3,
                 spec => 42,
                 type =>
-                    {type, #{line => 3, source => inferred, spec => int}}
+                    {type, #{line => 3, spec => int}}
             }},
         globals => #{
             'Number' => [
@@ -193,14 +193,14 @@ eval_function_having_unmatched_return_types_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func() float'
                 }}
             ]
         },
         return_type =>
-            {type, #{line => 3, source => rufus_text, spec => float}}
+            {type, #{line => 3, spec => float}}
     },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_compile:eval(RufusText)).
 
@@ -221,7 +221,7 @@ eval_function_taking_a_bool_and_returning_it_with_a_mismatched_return_type_test(
                 line => 3,
                 spec => b,
                 type =>
-                    {type, #{line => 3, source => rufus_text, spec => bool}}
+                    {type, #{line => 3, spec => bool}}
             }},
         globals => #{
             'MismatchedReturnType' => [
@@ -236,14 +236,14 @@ eval_function_taking_a_bool_and_returning_it_with_a_mismatched_return_type_test(
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(bool) int'
                 }}
             ]
         },
         return_type =>
-            {type, #{line => 3, source => rufus_text, spec => int}}
+            {type, #{line => 3, spec => int}}
     },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_compile:eval(RufusText)).
 

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -194,7 +194,6 @@ eval_function_having_unmatched_return_types_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func() float'
                 }}
             ]
@@ -231,13 +230,11 @@ eval_function_taking_a_bool_and_returning_it_with_a_mismatched_return_type_test(
                     param_types => [
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => bool
                         }}
                     ],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(bool) int'
                 }}
             ]

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -192,7 +192,7 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 line => 4,
                 right =>
@@ -200,10 +200,10 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                         line => 4,
                         spec => 2,
                         type =>
-                            {type, #{line => 4, source => inferred, spec => int}}
+                            {type, #{line => 4, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 4, source => inferred, spec => int}}
+                    {type, #{line => 4, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -212,7 +212,7 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -223,7 +223,7 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -274,7 +274,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                                     }}
                             }},
                         type =>
-                            {type, #{line => 6, source => inferred, spec => int}}
+                            {type, #{line => 6, spec => int}}
                     }},
                 line => 6,
                 right =>
@@ -282,10 +282,10 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                         line => 6,
                         spec => n,
                         type =>
-                            {type, #{line => 5, source => inferred, spec => int}}
+                            {type, #{line => 5, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 5, source => inferred, spec => int}}
+                    {type, #{line => 5, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -294,7 +294,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -305,7 +305,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -313,7 +313,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
         },
         locals => #{
             n =>
-                {type, #{line => 5, source => inferred, spec => int}}
+                {type, #{line => 5, spec => int}}
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_compile:eval(RufusText)).
@@ -334,7 +334,7 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 line => 4,
                 right =>
@@ -343,10 +343,10 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}}
+                    {type, #{line => 3, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -355,7 +355,7 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -366,7 +366,7 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -394,7 +394,7 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -405,7 +405,7 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -416,11 +416,11 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                 line => 6,
                 spec => n,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => string}}
+                    {type, #{line => 5, spec => string}}
             }},
         locals => #{
             n =>
-                {type, #{line => 5, source => inferred, spec => string}}
+                {type, #{line => 5, spec => string}}
         },
         right =>
             {call, #{
@@ -428,7 +428,7 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                 line => 6,
                 spec => 'Two',
                 type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}}
+                    {type, #{line => 3, spec => int}}
             }}
     },
     ?assertEqual({error, unmatched_types, Data}, rufus_compile:eval(RufusText)).
@@ -448,16 +448,16 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_arg_t
                 line => 5,
                 spec => two,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => atom}}
+                    {type, #{line => 5, spec => atom}}
             }}
         ],
         types => [
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                param_types => [{type, #{line => 3, spec => int}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 source => rufus_text,
                 spec => 'func(int) int'
             }}
@@ -482,7 +482,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                 line => 5,
                 locals => #{
                     value =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 },
                 spec => unbound
             }},
@@ -493,7 +493,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -501,7 +501,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
         },
         locals => #{
             value =>
-                {type, #{line => 4, source => inferred, spec => int}}
+                {type, #{line => 4, spec => int}}
         },
         stack => [
             {match_right, #{line => 5}},
@@ -539,7 +539,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                 locals => #{},
                 params => [],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 spec => 'Broken',
                 type =>
                     {type, #{
@@ -547,7 +547,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                         line => 3,
                         param_types => [],
                         return_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         source => rufus_text,
                         spec => 'func() int'
                     }}
@@ -574,7 +574,7 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -603,7 +603,7 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                 locals => #{},
                 params => [],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 spec => 'Broken',
                 type =>
                     {type, #{
@@ -611,7 +611,7 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                         line => 3,
                         param_types => [],
                         return_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         source => rufus_text,
                         spec => 'func() int'
                     }}
@@ -639,7 +639,7 @@ eval_function_with_a_match_that_has_unmatched_types_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -650,20 +650,20 @@ eval_function_with_a_match_that_has_unmatched_types_test() ->
                 line => 6,
                 spec => a,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => atom}}
+                    {type, #{line => 4, spec => atom}}
             }},
         locals => #{
             a =>
-                {type, #{line => 4, source => inferred, spec => atom}},
+                {type, #{line => 4, spec => atom}},
             i =>
-                {type, #{line => 5, source => inferred, spec => int}}
+                {type, #{line => 5, spec => int}}
         },
         right =>
             {identifier, #{
                 line => 6,
                 spec => i,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => int}}
+                    {type, #{line => 5, spec => int}}
             }}
     },
     ?assertEqual({error, unmatched_types, Data}, rufus_compile:eval(RufusText)).

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -213,7 +213,6 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -224,7 +223,6 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -255,7 +253,6 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                                 type =>
                                     {type, #{
                                         line => 6,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -269,7 +266,6 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             }},
@@ -295,7 +291,6 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -306,7 +301,6 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -356,7 +350,6 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -367,7 +360,6 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -395,7 +387,6 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -406,7 +397,6 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -458,7 +448,6 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_arg_t
                 param_types => [{type, #{line => 3, spec => int}}],
                 return_type =>
                     {type, #{line => 3, spec => int}},
-                source => rufus_text,
                 spec => 'func(int) int'
             }}
         ]
@@ -494,7 +483,6 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -523,7 +511,6 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                                 type =>
                                     {type, #{
                                         line => 4,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }}
@@ -548,7 +535,6 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                         param_types => [],
                         return_type =>
                             {type, #{line => 3, spec => int}},
-                        source => rufus_text,
                         spec => 'func() int'
                     }}
             }}
@@ -575,7 +561,6 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -612,7 +597,6 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
                         param_types => [],
                         return_type =>
                             {type, #{line => 3, spec => int}},
-                        source => rufus_text,
                         spec => 'func() int'
                     }}
             }}
@@ -640,7 +624,6 @@ eval_function_with_a_match_that_has_unmatched_types_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -23,7 +23,7 @@ typecheck_and_annotate_mathematical_operator_with_ints_test() ->
                             line => 3,
                             spec => 19,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '+',
@@ -32,16 +32,16 @@ typecheck_and_annotate_mathematical_operator_with_ints_test() ->
                             line => 3,
                             spec => 23,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'FortyTwo',
             type =>
                 {type, #{
@@ -49,7 +49,7 @@ typecheck_and_annotate_mathematical_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -96,13 +96,13 @@ typecheck_and_annotate_mathematical_operator_with_floats_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => float}}
+                        {type, #{line => 3, spec => float}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => float}},
+                {type, #{line => 3, spec => float}},
             spec => 'Pi',
             type =>
                 {type, #{
@@ -110,7 +110,7 @@ typecheck_and_annotate_mathematical_operator_with_floats_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func() float'
                 }}
@@ -319,7 +319,7 @@ typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
                             line => 3,
                             spec => 27,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '%',
@@ -328,16 +328,16 @@ typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
                             line => 3,
                             spec => 7,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Six',
             type =>
                 {type, #{
@@ -345,7 +345,7 @@ typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -434,13 +434,13 @@ typecheck_and_annotate_conditional_operator_with_bools_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -448,7 +448,7 @@ typecheck_and_annotate_conditional_operator_with_bools_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -518,13 +518,13 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -532,7 +532,7 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -587,13 +587,13 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => bool}}
+                        {type, #{line => 4, spec => bool}}
                 }}
             ],
             line => 4,
             params => [],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => bool}},
+                {type, #{line => 4, spec => bool}},
             spec => 'Truthy',
             type =>
                 {type, #{
@@ -601,7 +601,7 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => bool}},
+                        {type, #{line => 4, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -670,7 +670,7 @@ typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '==',
@@ -679,16 +679,16 @@ typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -696,7 +696,7 @@ typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -763,7 +763,7 @@ typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '!=',
@@ -772,16 +772,16 @@ typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -789,7 +789,7 @@ typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -856,7 +856,7 @@ typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '<',
@@ -865,16 +865,16 @@ typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -882,7 +882,7 @@ typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -989,7 +989,7 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() -
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '<=',
@@ -998,16 +998,16 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() -
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -1015,7 +1015,7 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() -
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -1122,7 +1122,7 @@ typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '>',
@@ -1131,16 +1131,16 @@ typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -1148,7 +1148,7 @@ typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -1255,7 +1255,7 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test(
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     op => '>=',
@@ -1264,16 +1264,16 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test(
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Falsy',
             type =>
                 {type, #{
@@ -1281,7 +1281,7 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test(
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}

--- a/rf/test/rufus_expr_binary_op_test.erl
+++ b/rf/test/rufus_expr_binary_op_test.erl
@@ -50,7 +50,6 @@ typecheck_and_annotate_mathematical_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -78,7 +77,6 @@ typecheck_and_annotate_mathematical_operator_with_floats_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => float
                                 }}
                         }},
@@ -91,7 +89,6 @@ typecheck_and_annotate_mathematical_operator_with_floats_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => float
                                 }}
                         }},
@@ -111,7 +108,6 @@ typecheck_and_annotate_mathematical_operator_with_floats_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func() float'
                 }}
         }}
@@ -136,7 +132,6 @@ typecheck_and_annotate_mathematical_operator_with_float_and_int_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }},
@@ -150,7 +145,6 @@ typecheck_and_annotate_mathematical_operator_with_float_and_int_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }}
@@ -178,7 +172,6 @@ typecheck_and_annotate_mathematical_operator_with_float_and_float_and_int_test()
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => inferred,
                                         spec => float
                                     }}
                             }},
@@ -191,14 +184,12 @@ typecheck_and_annotate_mathematical_operator_with_float_and_float_and_int_test()
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => inferred,
                                         spec => float
                                     }}
                             }},
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }},
@@ -212,7 +203,6 @@ typecheck_and_annotate_mathematical_operator_with_float_and_float_and_int_test()
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }}
@@ -238,7 +228,6 @@ typecheck_and_annotate_mathematical_operator_with_bools_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => bool
                             }}
                     }},
@@ -252,7 +241,6 @@ typecheck_and_annotate_mathematical_operator_with_bools_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => bool
                             }}
                     }}
@@ -278,7 +266,6 @@ typecheck_and_annotate_mathematical_operator_with_strings_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => string
                             }}
                     }},
@@ -292,7 +279,6 @@ typecheck_and_annotate_mathematical_operator_with_strings_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => string
                             }}
                     }}
@@ -346,7 +332,6 @@ typecheck_and_annotate_remainder_mathematical_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -371,7 +356,6 @@ typecheck_and_annotate_remainder_mathematical_operator_with_floats_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }},
@@ -385,7 +369,6 @@ typecheck_and_annotate_remainder_mathematical_operator_with_floats_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -416,7 +399,6 @@ typecheck_and_annotate_conditional_operator_with_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -429,7 +411,6 @@ typecheck_and_annotate_conditional_operator_with_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -449,7 +430,6 @@ typecheck_and_annotate_conditional_operator_with_bools_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -478,7 +458,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -493,7 +472,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => bool
                                         }}
                                 }},
@@ -506,14 +484,12 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => bool
                                         }}
                                 }},
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -533,7 +509,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }},
@@ -549,7 +524,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => bool
                                         }}
                                 }},
@@ -562,14 +536,12 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => bool
                                         }}
                                 }},
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -582,7 +554,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -602,7 +573,6 @@ typecheck_and_annotate_conditional_operator_with_nested_bools_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -627,7 +597,6 @@ typecheck_and_annotate_conditional_operator_with_bool_and_int_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => bool
                             }}
                     }},
@@ -641,7 +610,6 @@ typecheck_and_annotate_conditional_operator_with_bool_and_int_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }}
@@ -697,7 +665,6 @@ typecheck_and_annotate_equality_comparison_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -722,7 +689,6 @@ typecheck_and_annotate_equality_comparison_operator_with_mismatched_operands_tes
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -736,7 +702,6 @@ typecheck_and_annotate_equality_comparison_operator_with_mismatched_operands_tes
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -790,7 +755,6 @@ typecheck_and_annotate_inequality_comparison_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -815,7 +779,6 @@ typecheck_and_annotate_inequality_comparison_operator_with_mismatched_operands_t
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -829,7 +792,6 @@ typecheck_and_annotate_inequality_comparison_operator_with_mismatched_operands_t
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -883,7 +845,6 @@ typecheck_and_annotate_less_than_comparison_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -908,7 +869,6 @@ typecheck_and_annotate_less_than_comparison_operator_with_mismatched_operands_te
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -922,7 +882,6 @@ typecheck_and_annotate_less_than_comparison_operator_with_mismatched_operands_te
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -948,7 +907,6 @@ typecheck_and_annotate_less_than_comparison_operator_with_unsupported_operand_ty
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -962,7 +920,6 @@ typecheck_and_annotate_less_than_comparison_operator_with_unsupported_operand_ty
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }}
@@ -1016,7 +973,6 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_ints_test() -
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -1041,7 +997,6 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_mismatched_op
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -1055,7 +1010,6 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_mismatched_op
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -1081,7 +1035,6 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_unsupported_o
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -1095,7 +1048,6 @@ typecheck_and_annotate_less_than_or_equal_comparison_operator_with_unsupported_o
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }}
@@ -1149,7 +1101,6 @@ typecheck_and_annotate_greater_than_comparison_operator_with_ints_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -1174,7 +1125,6 @@ typecheck_and_annotate_greater_than_comparison_operator_with_mismatched_operands
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -1188,7 +1138,6 @@ typecheck_and_annotate_greater_than_comparison_operator_with_mismatched_operands
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -1214,7 +1163,6 @@ typecheck_and_annotate_greater_than_comparison_operator_with_unsupported_operand
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -1228,7 +1176,6 @@ typecheck_and_annotate_greater_than_comparison_operator_with_unsupported_operand
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }}
@@ -1282,7 +1229,6 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_ints_test(
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -1307,7 +1253,6 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_mismatched
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -1321,7 +1266,6 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_mismatched
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -1347,7 +1291,6 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_unsupporte
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -1361,7 +1304,6 @@ typecheck_and_annotate_greater_than_or_equal_comparison_operator_with_unsupporte
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }}

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -69,9 +69,9 @@ typecheck_and_annotate_with_function_calling_a_function_with_a_missing_argument_
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }}
@@ -95,16 +95,16 @@ typecheck_and_annotate_with_function_calling_a_function_with_a_mismatched_argume
                 line => 4,
                 spec => 42,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => int}}
+                    {type, #{line => 4, spec => int}}
             }}
         ],
         types => [
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }}
@@ -151,15 +151,15 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                    param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(string) string'
                 }}
@@ -192,7 +192,7 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
             line => 4,
             params => [],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => string}},
+                {type, #{line => 4, spec => string}},
             spec => 'Greeting',
             type =>
                 {type, #{
@@ -200,7 +200,7 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => string}},
+                        {type, #{line => 4, spec => string}},
                     source => rufus_text,
                     spec => 'func() string'
                 }}
@@ -248,7 +248,7 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -257,28 +257,28 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                     line => 3,
                     spec => m,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }},
                 {param, #{
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Sum',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
                     param_types => [
-                        {type, #{line => 3, source => rufus_text, spec => int}},
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}},
+                        {type, #{line => 3, spec => int}}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int, int) int'
                 }}
@@ -311,13 +311,13 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                     line => 4,
                     spec => 'Sum',
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 4,
             params => [],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => int}},
+                {type, #{line => 4, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -325,7 +325,7 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -368,10 +368,10 @@ eval_with_function_call_with_binary_op_argument_test() ->
                             line => 3,
                             spec => 2,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -380,19 +380,19 @@ eval_with_function_call_with_binary_op_argument_test() ->
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => double,
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -437,7 +437,7 @@ eval_with_function_call_with_binary_op_argument_test() ->
                     line => 4,
                     spec => double,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 4,
@@ -446,28 +446,28 @@ eval_with_function_call_with_binary_op_argument_test() ->
                     line => 4,
                     spec => m,
                     type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }},
                 {param, #{
                     line => 4,
                     spec => n,
                     type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => int}},
+                {type, #{line => 4, spec => int}},
             spec => 'SumAndDouble',
             type =>
                 {type, #{
                     kind => func,
                     line => 4,
                     param_types => [
-                        {type, #{line => 4, source => rufus_text, spec => int}},
-                        {type, #{line => 4, source => rufus_text, spec => int}}
+                        {type, #{line => 4, spec => int}},
+                        {type, #{line => 4, spec => int}}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func(int, int) int'
                 }}
@@ -495,7 +495,7 @@ eval_with_function_call_with_match_argument_test() ->
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -504,19 +504,19 @@ eval_with_function_call_with_match_argument_test() ->
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -529,7 +529,7 @@ eval_with_function_call_with_match_argument_test() ->
                             line => 4,
                             spec => 42,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 4,
                     right =>
@@ -556,13 +556,13 @@ eval_with_function_call_with_match_argument_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 4,
             params => [],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => int}},
+                {type, #{line => 4, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -570,7 +570,7 @@ eval_with_function_call_with_match_argument_test() ->
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -20,7 +20,6 @@ typecheck_and_annotate_with_function_calling_an_unknown_function_test() ->
                     text =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 },
@@ -34,17 +33,14 @@ typecheck_and_annotate_with_function_calling_an_unknown_function_test() ->
                     param_types => [
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                     ],
                     return_type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
             ]
@@ -72,7 +68,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_a_missing_argument_
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }}
         ]
@@ -105,7 +100,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_a_mismatched_argume
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }}
         ]
@@ -132,7 +126,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -145,7 +138,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -160,7 +152,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
         }},
@@ -174,7 +165,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => string
                                 }}
                         }}
@@ -184,7 +174,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -201,7 +190,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_one_argument_test()
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => string}},
-                    source => rufus_text,
                     spec => 'func() string'
                 }}
         }}
@@ -230,7 +218,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -243,7 +230,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -279,7 +265,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                     ],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int, int) int'
                 }}
         }},
@@ -293,7 +278,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -303,7 +287,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -326,7 +309,6 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -357,7 +339,6 @@ eval_with_function_call_with_binary_op_argument_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -393,7 +374,6 @@ eval_with_function_call_with_binary_op_argument_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }},
@@ -409,7 +389,6 @@ eval_with_function_call_with_binary_op_argument_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -422,14 +401,12 @@ eval_with_function_call_with_binary_op_argument_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -468,7 +445,6 @@ eval_with_function_call_with_binary_op_argument_test() ->
                     ],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int, int) int'
                 }}
         }}
@@ -517,7 +493,6 @@ eval_with_function_call_with_match_argument_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }},
@@ -541,7 +516,6 @@ eval_with_function_call_with_match_argument_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -551,7 +525,6 @@ eval_with_function_call_with_match_argument_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -571,7 +544,6 @@ eval_with_function_call_with_match_argument_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -36,7 +36,6 @@ typecheck_and_annotate_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -67,10 +66,8 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
                     return_type =>
                         {type, #{
                             line => 7,
-                            source => rufus_text,
                             spec => string
                         }},
-                    source => rufus_text,
                     spec => 'func() string'
                 }}
             ],
@@ -81,17 +78,14 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
                     param_types => [
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                     ],
                     return_type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
             ]
@@ -115,10 +109,8 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
                         return_type =>
                             {type, #{
                                 line => 7,
-                                source => rufus_text,
                                 spec => string
                             }},
-                        source => rufus_text,
                         spec => 'func() string'
                     }}
             }}
@@ -154,7 +146,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -164,7 +155,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -175,12 +165,10 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -193,7 +181,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -206,7 +193,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                         {type, #{line => 3, spec => int}},
                     kind => list,
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'EchoList',
@@ -221,10 +207,8 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }},
@@ -239,7 +223,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -256,7 +239,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     type =>
                                         {type, #{
                                             line => 6,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -266,7 +248,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     type =>
                                         {type, #{
                                             line => 6,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -277,12 +258,10 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 6,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 6,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -296,12 +275,10 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 6,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 6,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -311,7 +288,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -322,7 +298,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                         {type, #{line => 6, spec => int}},
                     kind => list,
                     line => 6,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'MakeList',
@@ -336,7 +311,6 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -346,10 +320,8 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                                 {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -397,7 +369,6 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_an_atom_literal
                     param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
                         {type, #{line => 3, spec => atom}},
-                    source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
         }}
@@ -443,7 +414,6 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_a_bool_literal_t
                     param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
         }}
@@ -478,7 +448,6 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_a_float_literal
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => float
                         }}
                 }}
@@ -493,7 +462,6 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_a_float_literal
                     param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func(float) float'
                 }}
         }}
@@ -539,7 +507,6 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_an_int_literal_t
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }}
@@ -574,7 +541,6 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_a_string_liter
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -589,7 +555,6 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_a_string_liter
                     param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
         }}
@@ -617,7 +582,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -629,7 +593,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -645,7 +608,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -656,7 +618,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'MaybeEcho',
@@ -670,7 +631,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -680,10 +640,8 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -731,7 +689,6 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_it_test() ->
                     param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
                         {type, #{line => 3, spec => atom}},
-                    source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
         }}
@@ -777,7 +734,6 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_it_test() ->
                     param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
         }}
@@ -803,7 +759,6 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_it_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => float
                         }}
                 }}
@@ -816,7 +771,6 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_it_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => float
                         }}
                 }}
@@ -831,7 +785,6 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_it_test() ->
                     param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func(float) float'
                 }}
         }}
@@ -877,7 +830,6 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_it_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }}
@@ -903,7 +855,6 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_it_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -916,7 +867,6 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_it_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -931,7 +881,6 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_it_test() ->
                     param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
         }}
@@ -960,7 +909,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -976,7 +924,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -987,7 +934,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo',
@@ -1001,7 +947,6 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -1011,10 +956,8 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -1055,7 +998,6 @@ typecheck_and_annotate_function_with_literal_return_value_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -1088,7 +1030,6 @@ typecheck_and_annotate_function_with_unmatched_return_types_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -1139,7 +1080,6 @@ typecheck_and_annotate_for_function_taking_an_atom_literal_test() ->
                     param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
                         {type, #{line => 3, spec => atom}},
-                    source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
         }}
@@ -1185,7 +1125,6 @@ typecheck_and_annotate_for_function_taking_a_bool_literal_test() ->
                     param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
         }}
@@ -1231,7 +1170,6 @@ typecheck_and_annotate_for_function_taking_a_float_literal_test() ->
                     param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func(float) float'
                 }}
         }}
@@ -1277,7 +1215,6 @@ typecheck_and_annotate_for_function_taking_an_int_literal_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }}
@@ -1323,7 +1260,6 @@ typecheck_and_annotate_for_function_taking_a_string_literal_test() ->
                     param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }}
         }}
@@ -1357,7 +1293,6 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -1374,7 +1309,6 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -1386,7 +1320,6 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'Echo',
@@ -1401,7 +1334,6 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                     ],
@@ -1412,10 +1344,8 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func(func() int) func() int'
                 }}
         }}
@@ -1445,7 +1375,6 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -1461,7 +1390,6 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -1475,7 +1403,6 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc',
@@ -1491,10 +1418,8 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func() int'
                 }}
         }}
@@ -1531,10 +1456,8 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() int'
                                 }}
                         }},
@@ -1550,7 +1473,6 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -1563,14 +1485,12 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -1587,10 +1507,8 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() int'
                                 }}
                         }},
@@ -1601,7 +1519,6 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }},
@@ -1615,7 +1532,6 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -1629,7 +1545,6 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc',
@@ -1645,10 +1560,8 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func() int'
                 }}
         }}
@@ -1692,13 +1605,10 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                             return_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
-                                            source => rufus_text,
                                             spec => 'func() int'
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() func() int'
                                 }}
                         }},
@@ -1714,7 +1624,6 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 5,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -1724,7 +1633,6 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 5,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     type =>
@@ -1735,10 +1643,8 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                             return_type =>
                                                 {type, #{
                                                     line => 5,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
-                                            source => rufus_text,
                                             spec => 'func() int'
                                         }}
                                 }}
@@ -1753,10 +1659,8 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() int'
                                 }},
                             type =>
@@ -1772,13 +1676,10 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                             return_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
-                                            source => rufus_text,
                                             spec => 'func() int'
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() func() int'
                                 }}
                         }},
@@ -1795,13 +1696,10 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() int'
                                 }},
-                            source => rufus_text,
                             spec => 'func() func() int'
                         }}
                 }},
@@ -1817,7 +1715,6 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -1831,7 +1728,6 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc',
@@ -1847,10 +1743,8 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func() int'
                 }}
         }}
@@ -1880,7 +1774,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => atom
                                 }}
                         }}
@@ -1893,7 +1786,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => atom
                                 }}
                         }}
@@ -1907,17 +1799,14 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => atom
                                 }}
                             ],
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => atom
                                 }},
-                            source => rufus_text,
                             spec => 'func(atom) atom'
                         }}
                 }}
@@ -1931,7 +1820,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                     param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
                         {type, #{line => 3, spec => atom}},
-                    source => rufus_text,
                     spec => 'func(atom) atom'
                 }},
             spec => 'EchoFunc',
@@ -1947,16 +1835,13 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => atom
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => atom}},
-                            source => rufus_text,
                             spec => 'func(atom) atom'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(atom) atom'
                 }}
         }}
@@ -1986,7 +1871,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => bool
                                 }}
                         }}
@@ -1999,7 +1883,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => bool
                                 }}
                         }}
@@ -2013,17 +1896,14 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => bool
                                 }}
                             ],
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => bool
                                 }},
-                            source => rufus_text,
                             spec => 'func(bool) bool'
                         }}
                 }}
@@ -2037,7 +1917,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                     param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func(bool) bool'
                 }},
             spec => 'EchoFunc',
@@ -2053,16 +1932,13 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => bool
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => bool}},
-                            source => rufus_text,
                             spec => 'func(bool) bool'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(bool) bool'
                 }}
         }}
@@ -2092,7 +1968,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => float
                                 }}
                         }}
@@ -2105,7 +1980,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => float
                                 }}
                         }}
@@ -2119,17 +1993,14 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => float
                                 }}
                             ],
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => float
                                 }},
-                            source => rufus_text,
                             spec => 'func(float) float'
                         }}
                 }}
@@ -2143,7 +2014,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                     param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func(float) float'
                 }},
             spec => 'EchoFunc',
@@ -2159,16 +2029,13 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => float
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => float}},
-                            source => rufus_text,
                             spec => 'func(float) float'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(float) float'
                 }}
         }}
@@ -2198,7 +2065,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -2211,7 +2077,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -2225,17 +2090,14 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                             ],
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }},
-                            source => rufus_text,
                             spec => 'func(int) int'
                         }}
                 }}
@@ -2249,7 +2111,6 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }},
             spec => 'EchoFunc',
@@ -2265,16 +2126,13 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func(int) int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(int) int'
                 }}
         }}
@@ -2304,7 +2162,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => string
                                 }}
                         }}
@@ -2317,7 +2174,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => string
                                 }}
                         }}
@@ -2331,17 +2187,14 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => string
                                 }}
                             ],
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => string
                                 }},
-                            source => rufus_text,
                             spec => 'func(string) string'
                         }}
                 }}
@@ -2355,7 +2208,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                     param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(string) string'
                 }},
             spec => 'EchoFunc',
@@ -2371,16 +2223,13 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => string
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => string}},
-                            source => rufus_text,
                             spec => 'func(string) string'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(string) string'
                 }}
         }}
@@ -2412,7 +2261,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -2426,12 +2274,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             kind => list,
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -2440,12 +2286,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -2461,7 +2305,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -2473,7 +2316,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                         head =>
                                             {type, #{
                                                 line => 4,
-                                                source => rufus_text,
                                                 spec => int
                                             }}
                                     },
@@ -2483,12 +2325,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             kind => list,
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -2497,12 +2337,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -2513,7 +2351,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                 {type, #{line => 4, spec => int}},
                             kind => list,
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
                     type =>
@@ -2525,12 +2362,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                             ],
@@ -2539,15 +2374,12 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }},
-                            source => rufus_text,
                             spec => 'func(list[int]) list[int]'
                         }}
                 }}
@@ -2564,7 +2396,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                 {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -2574,10 +2405,8 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                 {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }},
             spec => 'EchoNumberListFunc',
@@ -2595,12 +2424,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                             ],
@@ -2609,18 +2436,14 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }},
-                            source => rufus_text,
                             spec => 'func(list[int]) list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(list[int]) list[int]'
                 }}
         }}
@@ -2652,12 +2475,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -2675,12 +2496,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             kind => list,
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -2694,7 +2513,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -2704,7 +2522,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -2714,7 +2531,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -2725,12 +2541,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             kind => list,
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -2739,12 +2553,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -2755,7 +2567,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                 {type, #{line => 4, spec => int}},
                             kind => list,
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
                     type =>
@@ -2767,12 +2578,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                             ],
@@ -2781,15 +2590,12 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }},
-                            source => rufus_text,
                             spec => 'func(list[int]) list[int]'
                         }}
                 }}
@@ -2806,7 +2612,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                 {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -2816,10 +2621,8 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                 {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }},
             spec => 'EchoNumberListFunc',
@@ -2837,12 +2640,10 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                             ],
@@ -2851,18 +2652,14 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     kind => list,
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }},
-                            source => rufus_text,
                             spec => 'func(list[int]) list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(list[int]) list[int]'
                 }}
         }}
@@ -2894,7 +2691,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -2909,7 +2705,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -2921,14 +2716,12 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -2942,13 +2735,11 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                             param_types => [
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func(int) int'
                         }}
                 }}
@@ -2962,7 +2753,6 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }},
             spec => 'EchoFortyTwoFunc',
@@ -2978,16 +2768,13 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                             param_types => [
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                             ],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func(int) int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func(int) int'
                 }}
         }}
@@ -3017,7 +2804,6 @@ typecheck_and_annotate_closure_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -3033,7 +2819,6 @@ typecheck_and_annotate_closure_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 4, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -3054,7 +2839,6 @@ typecheck_and_annotate_closure_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'Memoize',
@@ -3070,10 +2854,8 @@ typecheck_and_annotate_closure_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 3, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func(int) func() int'
                 }}
         }}
@@ -3114,13 +2896,10 @@ typecheck_and_annotate_anonymous_function_with_unmatched_return_types_test() ->
                             return_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func() int'
                 }}
             ]
@@ -3159,10 +2938,8 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                             return_type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 },
@@ -3182,13 +2959,10 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                             return_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }},
-                            source => rufus_text,
                             spec => 'func() int'
                         }},
-                    source => rufus_text,
                     spec => 'func() func() int'
                 }}
             ]
@@ -3201,7 +2975,6 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         },
@@ -3232,7 +3005,6 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                                                 type =>
                                                     {type, #{
                                                         line => 5,
-                                                        source => inferred,
                                                         spec => int
                                                     }}
                                             }}
@@ -3244,7 +3016,6 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                                 return_type =>
                                     {type, #{
                                         line => 4,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             }}
@@ -3266,7 +3037,6 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                         param_types => [],
                         return_type =>
                             {type, #{line => 3, spec => int}},
-                        source => rufus_text,
                         spec => 'func() int'
                     }},
                 spec => 'EchoFunc',
@@ -3283,13 +3053,10 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                                 return_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
-                                source => rufus_text,
                                 spec => 'func() int'
                             }},
-                        source => rufus_text,
                         spec => 'func() func() int'
                     }}
             }}

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -21,13 +21,13 @@ typecheck_and_annotate_test() ->
                     line => 3,
                     spec => 42,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Number',
             type =>
                 {type, #{
@@ -35,7 +35,7 @@ typecheck_and_annotate_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -105,7 +105,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_function_scope_test() ->
                 locals => #{},
                 params => [],
                 return_type =>
-                    {type, #{line => 7, source => rufus_text, spec => string}},
+                    {type, #{line => 7, spec => string}},
                 spec => 'Broken',
                 type =>
                     {type, #{
@@ -190,7 +190,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
                             source => rufus_text,
@@ -203,7 +203,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
             return_type =>
                 {type, #{
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     kind => list,
                     line => 3,
                     source => rufus_text,
@@ -218,7 +218,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
                             source => rufus_text,
@@ -236,7 +236,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
                             source => rufus_text,
@@ -308,7 +308,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
                             source => rufus_text,
@@ -319,7 +319,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
             return_type =>
                 {type, #{
                     element_type =>
-                        {type, #{line => 6, source => rufus_text, spec => int}},
+                        {type, #{line => 6, spec => int}},
                     kind => list,
                     line => 6,
                     source => rufus_text,
@@ -333,7 +333,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     param_types => [
                         {type, #{
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
                             source => rufus_text,
@@ -343,7 +343,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             kind => list,
                             line => 6,
                             source => rufus_text,
@@ -375,7 +375,7 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_an_atom_literal
                     line => 3,
                     spec => pong,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             line => 3,
@@ -384,19 +384,19 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_an_atom_literal
                     line => 3,
                     spec => m,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => atom}},
+                {type, #{line => 3, spec => atom}},
             spec => 'Ping',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => atom}}],
+                    param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}},
+                        {type, #{line => 3, spec => atom}},
                     source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
@@ -421,7 +421,7 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_a_bool_literal_t
                     line => 3,
                     spec => true,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
@@ -430,19 +430,19 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_a_bool_literal_t
                     line => 3,
                     spec => b,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'MaybeEcho',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => bool}}],
+                    param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
@@ -467,7 +467,7 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_a_float_literal
                     line => 3,
                     spec => 3.14159265359,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => float}}
+                        {type, #{line => 3, spec => float}}
                 }}
             ],
             line => 3,
@@ -484,15 +484,15 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_a_float_literal
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => float}},
+                {type, #{line => 3, spec => float}},
             spec => 'MaybeEcho',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => float}}],
+                    param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func(float) float'
                 }}
@@ -517,7 +517,7 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_an_int_literal_t
                     line => 3,
                     spec => 42,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -526,19 +526,19 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_an_int_literal_t
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'MaybeEcho',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -563,7 +563,7 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_a_string_liter
                     line => 3,
                     spec => <<"Hello">>,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => string}}
+                        {type, #{line => 3, spec => string}}
                 }}
             ],
             line => 3,
@@ -580,15 +580,15 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_a_string_liter
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'MaybeEcho',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                    param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(string) string'
                 }}
@@ -627,7 +627,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -643,7 +643,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -654,7 +654,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -668,7 +668,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -678,7 +678,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_a_list_literal_t
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -709,7 +709,7 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_it_test() ->
                     line => 3,
                     spec => b,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             line => 3,
@@ -718,19 +718,19 @@ typecheck_and_annotate_for_function_taking_an_atom_and_returning_it_test() ->
                     line => 3,
                     spec => b,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => atom}},
+                {type, #{line => 3, spec => atom}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => atom}}],
+                    param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}},
+                        {type, #{line => 3, spec => atom}},
                     source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
@@ -755,7 +755,7 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_it_test() ->
                     line => 3,
                     spec => b,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
@@ -764,19 +764,19 @@ typecheck_and_annotate_for_function_taking_a_bool_and_returning_it_test() ->
                     line => 3,
                     spec => b,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => bool}}],
+                    param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
@@ -822,15 +822,15 @@ typecheck_and_annotate_for_function_taking_a_float_and_returning_it_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => float}},
+                {type, #{line => 3, spec => float}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => float}}],
+                    param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func(float) float'
                 }}
@@ -855,7 +855,7 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_it_test() ->
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -864,19 +864,19 @@ typecheck_and_annotate_for_function_taking_an_int_and_returning_it_test() ->
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -922,15 +922,15 @@ typecheck_and_annotate_for_function_taking_a_string_and_returning_it_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                    param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(string) string'
                 }}
@@ -958,7 +958,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -974,7 +974,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -985,7 +985,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -999,7 +999,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1009,7 +1009,7 @@ typecheck_and_annotate_for_function_taking_a_list_and_returning_it_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1040,13 +1040,13 @@ typecheck_and_annotate_function_with_literal_return_value_test() ->
                     line => 3,
                     spec => 42,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Number',
             type =>
                 {type, #{
@@ -1054,7 +1054,7 @@ typecheck_and_annotate_function_with_literal_return_value_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1078,7 +1078,7 @@ typecheck_and_annotate_function_with_unmatched_return_types_test() ->
                 line => 3,
                 spec => 42.0,
                 type =>
-                    {type, #{line => 3, source => inferred, spec => float}}
+                    {type, #{line => 3, spec => float}}
             }},
         globals => #{
             'Number' => [
@@ -1087,14 +1087,14 @@ typecheck_and_annotate_function_with_unmatched_return_types_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
         },
         return_type =>
-            {type, #{line => 3, source => rufus_text, spec => int}}
+            {type, #{line => 3, spec => int}}
     },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
@@ -1117,7 +1117,7 @@ typecheck_and_annotate_for_function_taking_an_atom_literal_test() ->
                     line => 3,
                     spec => ok,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             line => 3,
@@ -1126,19 +1126,19 @@ typecheck_and_annotate_for_function_taking_an_atom_literal_test() ->
                     line => 3,
                     spec => ok,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => atom}}
+                        {type, #{line => 3, spec => atom}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => atom}},
+                {type, #{line => 3, spec => atom}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => inferred, spec => atom}}],
+                    param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}},
+                        {type, #{line => 3, spec => atom}},
                     source => rufus_text,
                     spec => 'func(atom) atom'
                 }}
@@ -1163,7 +1163,7 @@ typecheck_and_annotate_for_function_taking_a_bool_literal_test() ->
                     line => 3,
                     spec => true,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             line => 3,
@@ -1172,19 +1172,19 @@ typecheck_and_annotate_for_function_taking_a_bool_literal_test() ->
                     line => 3,
                     spec => true,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => bool}}
+                        {type, #{line => 3, spec => bool}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => inferred, spec => bool}}],
+                    param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func(bool) bool'
                 }}
@@ -1209,7 +1209,7 @@ typecheck_and_annotate_for_function_taking_a_float_literal_test() ->
                     line => 3,
                     spec => 1.0,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => float}}
+                        {type, #{line => 3, spec => float}}
                 }}
             ],
             line => 3,
@@ -1218,19 +1218,19 @@ typecheck_and_annotate_for_function_taking_a_float_literal_test() ->
                     line => 3,
                     spec => 1.0,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => float}}
+                        {type, #{line => 3, spec => float}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => float}},
+                {type, #{line => 3, spec => float}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => inferred, spec => float}}],
+                    param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func(float) float'
                 }}
@@ -1255,7 +1255,7 @@ typecheck_and_annotate_for_function_taking_an_int_literal_test() ->
                     line => 3,
                     spec => 1,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -1264,19 +1264,19 @@ typecheck_and_annotate_for_function_taking_an_int_literal_test() ->
                     line => 3,
                     spec => 1,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => inferred, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -1301,7 +1301,7 @@ typecheck_and_annotate_for_function_taking_a_string_literal_test() ->
                     line => 3,
                     spec => <<"ok">>,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => string}}
+                        {type, #{line => 3, spec => string}}
                 }}
             ],
             line => 3,
@@ -1310,19 +1310,19 @@ typecheck_and_annotate_for_function_taking_a_string_literal_test() ->
                     line => 3,
                     spec => <<"ok">>,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => string}}
+                        {type, #{line => 3, spec => string}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'Echo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => inferred, spec => string}}],
+                    param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(string) string'
                 }}
@@ -1356,7 +1356,7 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1373,7 +1373,7 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1385,7 +1385,7 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -1400,7 +1400,7 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1411,7 +1411,7 @@ typecheck_and_annotate_function_taking_and_returning_a_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},
@@ -1453,14 +1453,14 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                     line => 4,
                     params => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     type =>
                         {type, #{
                             kind => func,
                             line => 4,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1474,7 +1474,7 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -1490,7 +1490,7 @@ typecheck_and_annotate_function_returning_a_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},
@@ -1578,7 +1578,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             line => 4,
                             params => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             type =>
                                 {type, #{
                                     kind => func,
@@ -1600,7 +1600,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             line => 4,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1614,7 +1614,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             line => 4,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1628,7 +1628,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -1644,7 +1644,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},
@@ -1816,7 +1816,7 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                             line => 4,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -1830,7 +1830,7 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -1846,7 +1846,7 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},
@@ -1899,7 +1899,7 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => atom}},
+                        {type, #{line => 4, spec => atom}},
                     type =>
                         {type, #{
                             kind => func,
@@ -1928,9 +1928,9 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => atom}}],
+                    param_types => [{type, #{line => 3, spec => atom}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}},
+                        {type, #{line => 3, spec => atom}},
                     source => rufus_text,
                     spec => 'func(atom) atom'
                 }},
@@ -1952,7 +1952,7 @@ typecheck_and_annotate_for_anonymous_function_taking_an_atom_and_returning_an_at
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => atom}},
+                                {type, #{line => 3, spec => atom}},
                             source => rufus_text,
                             spec => 'func(atom) atom'
                         }},
@@ -2005,7 +2005,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => bool}},
+                        {type, #{line => 4, spec => bool}},
                     type =>
                         {type, #{
                             kind => func,
@@ -2034,9 +2034,9 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => bool}}],
+                    param_types => [{type, #{line => 3, spec => bool}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func(bool) bool'
                 }},
@@ -2058,7 +2058,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_bool_and_returning_a_bool
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => bool}},
+                                {type, #{line => 3, spec => bool}},
                             source => rufus_text,
                             spec => 'func(bool) bool'
                         }},
@@ -2111,7 +2111,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => float}},
+                        {type, #{line => 4, spec => float}},
                     type =>
                         {type, #{
                             kind => func,
@@ -2140,9 +2140,9 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => float}}],
+                    param_types => [{type, #{line => 3, spec => float}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func(float) float'
                 }},
@@ -2164,7 +2164,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_float_and_returning_a_flo
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => float}},
+                                {type, #{line => 3, spec => float}},
                             source => rufus_text,
                             spec => 'func(float) float'
                         }},
@@ -2217,7 +2217,7 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     type =>
                         {type, #{
                             kind => func,
@@ -2246,9 +2246,9 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }},
@@ -2270,7 +2270,7 @@ typecheck_and_annotate_for_anonymous_function_taking_an_int_and_returning_an_int
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func(int) int'
                         }},
@@ -2323,7 +2323,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => string}},
+                        {type, #{line => 4, spec => string}},
                     type =>
                         {type, #{
                             kind => func,
@@ -2352,9 +2352,9 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                    param_types => [{type, #{line => 3, spec => string}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(string) string'
                 }},
@@ -2376,7 +2376,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_string_and_returning_a_st
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => string}},
+                                {type, #{line => 3, spec => string}},
                             source => rufus_text,
                             spec => 'func(string) string'
                         }},
@@ -2510,7 +2510,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             kind => list,
                             line => 4,
                             source => rufus_text,
@@ -2561,7 +2561,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                     param_types => [
                         {type, #{
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
                             source => rufus_text,
@@ -2571,7 +2571,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
                             source => rufus_text,
@@ -2752,7 +2752,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             kind => list,
                             line => 4,
                             source => rufus_text,
@@ -2803,7 +2803,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                     param_types => [
                         {type, #{
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
                             source => rufus_text,
@@ -2813,7 +2813,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                     return_type =>
                         {type, #{
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             kind => list,
                             line => 3,
                             source => rufus_text,
@@ -2934,7 +2934,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     type =>
                         {type, #{
                             kind => func,
@@ -2947,7 +2947,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func(int) int'
                         }}
@@ -2959,9 +2959,9 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }},
@@ -2983,7 +2983,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                                 }}
                             ],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func(int) int'
                         }},
@@ -3025,14 +3025,14 @@ typecheck_and_annotate_closure_test() ->
                     line => 4,
                     params => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     type =>
                         {type, #{
                             kind => func,
                             line => 4,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -3044,7 +3044,7 @@ typecheck_and_annotate_closure_test() ->
                     line => 3,
                     spec => num,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
@@ -3053,7 +3053,7 @@ typecheck_and_annotate_closure_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -3062,14 +3062,14 @@ typecheck_and_annotate_closure_test() ->
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{
                             kind => func,
                             line => 3,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }},
@@ -3098,7 +3098,7 @@ typecheck_and_annotate_anonymous_function_with_unmatched_return_types_test() ->
                 line => 4,
                 spec => 42.0,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => float}}
+                    {type, #{line => 4, spec => float}}
             }},
         globals => #{
             'EchoFunc' => [
@@ -3126,7 +3126,7 @@ typecheck_and_annotate_anonymous_function_with_unmatched_return_types_test() ->
             ]
         },
         return_type =>
-            {type, #{line => 4, source => rufus_text, spec => int}}
+            {type, #{line => 4, spec => int}}
     },
     ?assertEqual({error, unmatched_return_type, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
@@ -3200,7 +3200,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -3265,7 +3265,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                         line => 3,
                         param_types => [],
                         return_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         source => rufus_text,
                         spec => 'func() int'
                     }},

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -22,7 +22,7 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -35,7 +35,7 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -50,7 +50,7 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -93,7 +93,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -106,7 +106,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -121,7 +121,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -186,7 +186,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -199,7 +199,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -214,7 +214,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -307,7 +307,7 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -323,7 +323,7 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -334,7 +334,7 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -348,7 +348,7 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -358,7 +358,7 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -401,7 +401,7 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -414,14 +414,14 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                     line => 3,
                     spec => n,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -431,12 +431,12 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -491,7 +491,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                 type =>
                     {type, #{
                         element_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
                         source => rufus_text,
@@ -525,7 +525,7 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                 return_type =>
                     {type, #{
                         element_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
                         source => rufus_text,
@@ -577,7 +577,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     tail =>
@@ -613,7 +613,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -626,7 +626,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -641,7 +641,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -672,7 +672,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     tail =>
@@ -728,7 +728,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -741,7 +741,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -756,7 +756,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -792,7 +792,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             locals => #{},
                             spec => head,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 4,
                     right =>
@@ -800,10 +800,10 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             line => 4,
                             spec => 1,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }},
                 {match, #{
                     left =>
@@ -886,7 +886,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 5, source => rufus_text, spec => int}},
+                                {type, #{line => 5, spec => int}},
                             line => 5,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -898,7 +898,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             line => 6,
                             spec => head,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 6,
                     tail =>
@@ -923,7 +923,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 6, source => rufus_text, spec => int}},
+                                {type, #{line => 6, spec => int}},
                             line => 6,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -936,7 +936,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -951,7 +951,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1349,7 +1349,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1402,7 +1402,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1413,7 +1413,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -1427,7 +1427,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1437,7 +1437,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1468,7 +1468,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                     line => 4,
                     spec => head,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -1517,7 +1517,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1525,7 +1525,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'First',
             type =>
                 {type, #{
@@ -1535,14 +1535,14 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
@@ -1572,7 +1572,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1587,7 +1587,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                             line => 3,
                             spec => 1,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     tail =>
@@ -1613,7 +1613,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1624,7 +1624,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -1638,7 +1638,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1648,7 +1648,7 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1705,7 +1705,7 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                 type =>
                     {type, #{
                         element_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
                         source => rufus_text,
@@ -1740,7 +1740,7 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                 return_type =>
                     {type, #{
                         element_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
                         source => rufus_text,
@@ -1826,7 +1826,7 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1896,7 +1896,7 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1907,7 +1907,7 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -1921,7 +1921,7 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1931,7 +1931,7 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -24,7 +24,6 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -37,7 +36,6 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -52,10 +50,8 @@ typecheck_and_annotate_with_function_returning_an_empty_list_of_ints_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -83,7 +79,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -95,7 +90,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -108,7 +102,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -123,10 +116,8 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -156,7 +147,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -169,14 +159,12 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -188,7 +176,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -201,7 +188,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -216,10 +202,8 @@ typecheck_and_annotate_with_function_returning_a_list_of_one_int_binary_op_test(
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -244,7 +228,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_mismatched_ele
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -254,7 +237,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_mismatched_ele
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }},
@@ -264,7 +246,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_mismatched_ele
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => int
                             }}
                     }}
@@ -276,11 +257,9 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_mismatched_ele
                         element_type =>
                             {type, #{
                                 line => 3,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }}
@@ -309,7 +288,6 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -325,7 +303,6 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -336,7 +313,6 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo',
@@ -350,7 +326,6 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -360,10 +335,8 @@ typecheck_and_annotate_with_function_taking_a_list_and_returning_a_list_test() -
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -391,7 +364,6 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -403,7 +375,6 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -423,7 +394,6 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'ToList',
@@ -438,10 +408,8 @@ typecheck_and_annotate_with_function_taking_an_int_and_returning_a_list_of_int_t
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(int) list[int]'
                 }}
         }}
@@ -470,15 +438,12 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                             element_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
             ]
@@ -494,7 +459,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                             {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }},
@@ -509,12 +473,10 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                                 element_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 kind => list,
                                 line => 3,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }}
                     }}
@@ -528,7 +490,6 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                             {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }},
                 spec => 'Numbers',
@@ -542,15 +503,12 @@ typecheck_and_annotate_with_function_returning_a_list_of_int_with_an_unknown_var
                                 element_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 kind => list,
                                 line => 3,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }},
-                        source => rufus_text,
                         spec => 'func() list[int]'
                     }}
             }}
@@ -589,7 +547,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -601,11 +558,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -615,7 +570,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -628,7 +582,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -643,10 +596,8 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_literal_pair_
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -684,7 +635,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -694,7 +644,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -704,7 +653,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -716,11 +664,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -730,7 +676,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -743,7 +688,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -758,10 +702,8 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_multiple_lite
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -813,7 +755,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                 head =>
                                     {type, #{
                                         line => 4,
-                                        source => inferred,
                                         spec => int
                                     }}
                             },
@@ -824,11 +765,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     element_type =>
                                         {type, #{
                                             line => 5,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 5,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -842,7 +781,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     type =>
                                         {type, #{
                                             line => 5,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -852,7 +790,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     type =>
                                         {type, #{
                                             line => 5,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -862,7 +799,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     type =>
                                         {type, #{
                                             line => 5,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -874,11 +810,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     element_type =>
                                         {type, #{
                                             line => 5,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 5,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -888,7 +822,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             element_type =>
                                 {type, #{line => 5, spec => int}},
                             line => 5,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }},
@@ -911,11 +844,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                                     element_type =>
                                         {type, #{
                                             line => 5,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 5,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -925,7 +856,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             element_type =>
                                 {type, #{line => 6, spec => int}},
                             line => 6,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -938,7 +868,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers',
@@ -953,10 +882,8 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -975,7 +902,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
         element_type =>
             {type, #{
                 line => 3,
-                source => rufus_text,
                 spec => int
             }},
         form =>
@@ -987,7 +913,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -1001,7 +926,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -1011,7 +935,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -1021,7 +944,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }}
@@ -1033,11 +955,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 element_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 line => 3,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }}
                     }},
@@ -1047,24 +967,20 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         element_type =>
                             {type, #{
                                 line => 3,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }},
         head_type =>
             {type, #{
                 line => 3,
-                source => inferred,
                 spec => atom
             }},
         tail_element_type =>
             {type, #{
                 line => 3,
-                source => rufus_text,
                 spec => int
             }}
     },
@@ -1088,7 +1004,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => atom
                             }}
                     }}
@@ -1100,11 +1015,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         element_type =>
                             {type, #{
                                 line => 3,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }}
@@ -1125,7 +1038,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
         element_type =>
             {type, #{
                 line => 5,
-                source => rufus_text,
                 spec => int
             }},
         form =>
@@ -1137,7 +1049,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         type =>
                             {type, #{
                                 line => 4,
-                                source => inferred,
                                 spec => atom
                             }}
                     }},
@@ -1151,7 +1062,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 5,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -1161,7 +1071,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 5,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -1171,7 +1080,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 type =>
                                     {type, #{
                                         line => 5,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }}
@@ -1183,11 +1091,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 element_type =>
                                     {type, #{
                                         line => 5,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 line => 5,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }}
                     }},
@@ -1197,24 +1103,20 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         element_type =>
                             {type, #{
                                 line => 5,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 5,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }},
         head_type =>
             {type, #{
                 line => 4,
-                source => inferred,
                 spec => atom
             }},
         tail_element_type =>
             {type, #{
                 line => 5,
-                source => rufus_text,
                 spec => int
             }}
     },
@@ -1235,7 +1137,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
         element_type =>
             {type, #{
                 line => 5,
-                source => rufus_text,
                 spec => int
             }},
         form =>
@@ -1247,7 +1148,6 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         type =>
                             {type, #{
                                 line => 5,
-                                source => inferred,
                                 spec => int
                             }}
                     }},
@@ -1262,11 +1162,9 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                                 element_type =>
                                     {type, #{
                                         line => 4,
-                                        source => rufus_text,
                                         spec => atom
                                     }},
                                 line => 4,
-                                source => rufus_text,
                                 spec => 'list[atom]'
                             }}
                     }},
@@ -1276,24 +1174,20 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_an_unexpected
                         element_type =>
                             {type, #{
                                 line => 5,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 5,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }},
         head_type =>
             {type, #{
                 line => 5,
-                source => inferred,
                 spec => int
             }},
         tail_element_type =>
             {type, #{
                 line => 4,
-                source => rufus_text,
                 spec => atom
             }}
     },
@@ -1322,7 +1216,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1337,11 +1230,9 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1351,7 +1242,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1367,7 +1257,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1379,7 +1268,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                                 head =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             },
@@ -1390,11 +1278,9 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1404,7 +1290,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1415,7 +1300,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo',
@@ -1429,7 +1313,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -1439,10 +1322,8 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -1482,7 +1363,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1494,7 +1374,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                                 head =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             },
@@ -1505,11 +1384,9 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1519,7 +1396,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1537,13 +1413,11 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
         }}
@@ -1574,7 +1448,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1601,11 +1474,9 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1615,7 +1486,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1626,7 +1496,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Rest',
@@ -1640,7 +1509,6 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -1650,10 +1518,8 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_tai
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -1682,15 +1548,12 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                             element_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             kind => list,
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
             ]
@@ -1708,7 +1571,6 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                             {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }},
@@ -1724,12 +1586,10 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                                 element_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 kind => list,
                                 line => 3,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }}
                     }}
@@ -1743,7 +1603,6 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                             {type, #{line => 3, spec => int}},
                         kind => list,
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }},
                 spec => 'Broken',
@@ -1757,15 +1616,12 @@ typecheck_and_annotate_with_function_returning_a_cons_pattern_without_data_test(
                                 element_type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 kind => list,
                                 line => 3,
-                                source => rufus_text,
                                 spec => 'list[int]'
                             }},
-                        source => rufus_text,
                         spec => 'func() list[int]'
                     }}
             }}
@@ -1796,7 +1652,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1806,7 +1661,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1816,7 +1670,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -1828,7 +1681,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1844,7 +1696,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1854,7 +1705,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                                 a =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             },
@@ -1862,7 +1712,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1872,13 +1721,11 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                                 a =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }},
                                 b =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             },
@@ -1886,7 +1733,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}
@@ -1898,7 +1744,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1909,7 +1754,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Reverse',
@@ -1923,7 +1767,6 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -1933,10 +1776,8 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -46,19 +46,19 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
                                 }}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => atom}}
+                        {type, #{line => 4, spec => atom}}
                 }},
                 {identifier, #{
                     line => 5,
                     spec => response,
                     type =>
-                        {type, #{line => 4, source => inferred, spec => atom}}
+                        {type, #{line => 4, spec => atom}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => atom}},
+                {type, #{line => 3, spec => atom}},
             spec => 'Ping',
             type =>
                 {type, #{
@@ -66,7 +66,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => atom}},
+                        {type, #{line => 3, spec => atom}},
                     source => rufus_text,
                     spec => 'func() atom'
                 }}
@@ -116,19 +116,19 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => bool}}
+                        {type, #{line => 4, spec => bool}}
                 }},
                 {identifier, #{
                     line => 5,
                     spec => response,
                     type =>
-                        {type, #{line => 4, source => inferred, spec => bool}}
+                        {type, #{line => 4, spec => bool}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => bool}},
+                {type, #{line => 3, spec => bool}},
             spec => 'Truthy',
             type =>
                 {type, #{
@@ -136,7 +136,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => bool}},
+                        {type, #{line => 3, spec => bool}},
                     source => rufus_text,
                     spec => 'func() bool'
                 }}
@@ -186,19 +186,19 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
                                 }}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => float}}
+                        {type, #{line => 4, spec => float}}
                 }},
                 {identifier, #{
                     line => 5,
                     spec => response,
                     type =>
-                        {type, #{line => 4, source => inferred, spec => float}}
+                        {type, #{line => 4, spec => float}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => float}},
+                {type, #{line => 3, spec => float}},
             spec => 'FortyTwo',
             type =>
                 {type, #{
@@ -206,7 +206,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => float}},
+                        {type, #{line => 3, spec => float}},
                     source => rufus_text,
                     spec => 'func() float'
                 }}
@@ -237,7 +237,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
                             locals => #{},
                             spec => response,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 4,
                     right =>
@@ -245,22 +245,22 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
                             line => 4,
                             spec => 42,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }},
                 {identifier, #{
                     line => 5,
                     spec => response,
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'FortyTwo',
             type =>
                 {type, #{
@@ -268,7 +268,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -318,19 +318,19 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
                                 }}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => string}}
+                        {type, #{line => 4, spec => string}}
                 }},
                 {identifier, #{
                     line => 5,
                     spec => response,
                     type =>
-                        {type, #{line => 4, source => inferred, spec => string}}
+                        {type, #{line => 4, spec => string}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'Ping',
             type =>
                 {type, #{
@@ -338,7 +338,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func() string'
                 }}
@@ -416,7 +416,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -429,7 +429,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -442,7 +442,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -457,7 +457,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -595,7 +595,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => string}},
+                {type, #{line => 3, spec => string}},
             spec => 'Unbox',
             type =>
                 {type, #{
@@ -616,7 +616,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => string}},
+                        {type, #{line => 3, spec => string}},
                     source => rufus_text,
                     spec => 'func(list[string]) string'
                 }}
@@ -746,7 +746,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -787,7 +787,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 5, source => rufus_text, spec => int}},
+                                {type, #{line => 5, spec => int}},
                             line => 5,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -803,7 +803,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -814,7 +814,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -828,7 +828,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -838,7 +838,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -972,7 +972,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -982,7 +982,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                     line => 5,
                     spec => head,
                     type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }}
             ],
             line => 3,
@@ -994,7 +994,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1002,7 +1002,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'First',
             type =>
                 {type, #{
@@ -1012,14 +1012,14 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
@@ -1128,7 +1128,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1141,7 +1141,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1157,7 +1157,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1168,7 +1168,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -1182,7 +1182,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1192,7 +1192,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1245,7 +1245,7 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -1283,19 +1283,19 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Double',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -1322,7 +1322,7 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
                     line => 4,
                     spec => a,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -1333,7 +1333,7 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
                             line => 3,
                             spec => 42,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     right =>
@@ -1348,19 +1348,19 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'EchoFortyTwo',
             type =>
                 {type, #{
                     kind => func,
                     line => 3,
-                    param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                    param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(int) int'
                 }}
@@ -1387,7 +1387,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                     line => 4,
                     spec => head,
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
@@ -1498,7 +1498,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -1506,7 +1506,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'First',
             type =>
                 {type, #{
@@ -1516,14 +1516,14 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
@@ -1549,7 +1549,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_wi
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1560,7 +1560,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_wi
                 line => 4,
                 spec => 2.0,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => float}}
+                    {type, #{line => 4, spec => float}}
             }},
         locals => #{},
         right =>
@@ -1568,7 +1568,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_wi
                 line => 4,
                 spec => 2,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => int}}
+                    {type, #{line => 4, spec => int}}
             }}
     },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -1598,7 +1598,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                             locals => #{},
                             spec => n,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 4,
                     right =>
@@ -1606,10 +1606,10 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                             line => 4,
                             spec => 3,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }},
                 {match, #{
                     left =>
@@ -1639,7 +1639,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                                         }}
                                 }},
                             type =>
-                                {type, #{line => 5, source => inferred, spec => int}}
+                                {type, #{line => 5, spec => int}}
                         }},
                     line => 5,
                     right =>
@@ -1647,16 +1647,16 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                             line => 5,
                             spec => n,
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -1664,7 +1664,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1692,7 +1692,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                             locals => #{},
                             spec => n,
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     line => 3,
                     right =>
@@ -1722,16 +1722,16 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                                         }}
                                 }},
                             type =>
-                                {type, #{line => 3, source => inferred, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -1739,7 +1739,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1790,7 +1790,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                         }}
                                 }},
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     line => 4,
                     right =>
@@ -1820,16 +1820,16 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                         }}
                                 }},
                             type =>
-                                {type, #{line => 4, source => inferred, spec => int}}
+                                {type, #{line => 4, spec => int}}
                         }},
                     type =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -1837,7 +1837,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1865,13 +1865,13 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                     line => 3,
                     spec => 2,
                     type =>
-                        {type, #{line => 3, source => inferred, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 3,
             params => [],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'Two',
             type =>
                 {type, #{
@@ -1879,7 +1879,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1913,13 +1913,13 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                                 }}
                         }},
                     type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 4,
             params => [],
             return_type =>
-                {type, #{line => 4, source => rufus_text, spec => int}},
+                {type, #{line => 4, spec => int}},
             spec => 'Random',
             type =>
                 {type, #{
@@ -1927,7 +1927,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1953,7 +1953,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 line => 4,
                 right =>
@@ -1961,10 +1961,10 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                         line => 4,
                         spec => 2,
                         type =>
-                            {type, #{line => 4, source => inferred, spec => int}}
+                            {type, #{line => 4, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 4, source => inferred, spec => int}}
+                    {type, #{line => 4, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -1973,7 +1973,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -1984,7 +1984,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2037,7 +2037,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                     }}
                             }},
                         type =>
-                            {type, #{line => 6, source => inferred, spec => int}}
+                            {type, #{line => 6, spec => int}}
                     }},
                 line => 6,
                 right =>
@@ -2045,10 +2045,10 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                         line => 6,
                         spec => n,
                         type =>
-                            {type, #{line => 5, source => inferred, spec => int}}
+                            {type, #{line => 5, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 5, source => inferred, spec => int}}
+                    {type, #{line => 5, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -2057,7 +2057,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2068,7 +2068,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2076,7 +2076,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
         },
         locals => #{
             n =>
-                {type, #{line => 5, source => inferred, spec => int}}
+                {type, #{line => 5, spec => int}}
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -2122,7 +2122,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                     }}
                             }},
                         type =>
-                            {type, #{line => 5, source => inferred, spec => int}}
+                            {type, #{line => 5, spec => int}}
                     }},
                 line => 5,
                 right =>
@@ -2130,10 +2130,10 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                         line => 5,
                         spec => 2,
                         type =>
-                            {type, #{line => 5, source => inferred, spec => int}}
+                            {type, #{line => 5, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 5, source => inferred, spec => int}}
+                    {type, #{line => 5, spec => int}}
             }},
         globals => #{
             'Two' => [
@@ -2142,7 +2142,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2150,7 +2150,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
         },
         locals => #{
             n =>
-                {type, #{line => 4, source => inferred, spec => int}}
+                {type, #{line => 4, spec => int}}
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -2173,7 +2173,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 line => 4,
                 right =>
@@ -2182,10 +2182,10 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                         line => 4,
                         spec => 'Two',
                         type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}}
+                            {type, #{line => 3, spec => int}}
                     }},
                 type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}}
+                    {type, #{line => 3, spec => int}}
             }},
         globals => #{
             'Random' => [
@@ -2194,7 +2194,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2205,7 +2205,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2235,7 +2235,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                     line => 4,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 4, source => rufus_text, spec => int}},
+                        {type, #{line => 4, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2246,7 +2246,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2257,11 +2257,11 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                 line => 6,
                 spec => n,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => string}}
+                    {type, #{line => 5, spec => string}}
             }},
         locals => #{
             n =>
-                {type, #{line => 5, source => inferred, spec => string}}
+                {type, #{line => 5, spec => string}}
         },
         right =>
             {call, #{
@@ -2269,7 +2269,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                 line => 6,
                 spec => 'Two',
                 type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}}
+                    {type, #{line => 3, spec => int}}
             }}
     },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -2291,16 +2291,16 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                 line => 5,
                 spec => two,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => atom}}
+                    {type, #{line => 5, spec => atom}}
             }}
         ],
         types => [
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => int}}],
+                param_types => [{type, #{line => 3, spec => int}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 source => rufus_text,
                 spec => 'func(int) int'
             }}
@@ -2327,7 +2327,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                 line => 5,
                 locals => #{
                     value =>
-                        {type, #{line => 4, source => inferred, spec => int}}
+                        {type, #{line => 4, spec => int}}
                 },
                 spec => unbound
             }},
@@ -2338,7 +2338,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2346,7 +2346,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
         },
         locals => #{
             value =>
-                {type, #{line => 4, source => inferred, spec => int}}
+                {type, #{line => 4, spec => int}}
         },
         stack => [
             {match_right, #{line => 5}},
@@ -2384,7 +2384,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                 locals => #{},
                 params => [],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 spec => 'Broken',
                 type =>
                     {type, #{
@@ -2392,7 +2392,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                         line => 3,
                         param_types => [],
                         return_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         source => rufus_text,
                         spec => 'func() int'
                     }}
@@ -2421,7 +2421,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2450,7 +2450,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                 locals => #{},
                 params => [],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => int}},
+                    {type, #{line => 3, spec => int}},
                 spec => 'Broken',
                 type =>
                     {type, #{
@@ -2458,7 +2458,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                         line => 3,
                         param_types => [],
                         return_type =>
-                            {type, #{line => 3, source => rufus_text, spec => int}},
+                            {type, #{line => 3, spec => int}},
                         source => rufus_text,
                         spec => 'func() int'
                     }}
@@ -2488,7 +2488,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }}
@@ -2499,20 +2499,20 @@ typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
                 line => 6,
                 spec => a,
                 type =>
-                    {type, #{line => 4, source => inferred, spec => atom}}
+                    {type, #{line => 4, spec => atom}}
             }},
         locals => #{
             a =>
-                {type, #{line => 4, source => inferred, spec => atom}},
+                {type, #{line => 4, spec => atom}},
             i =>
-                {type, #{line => 5, source => inferred, spec => int}}
+                {type, #{line => 5, spec => int}}
         },
         right =>
             {identifier, #{
                 line => 6,
                 spec => i,
                 type =>
-                    {type, #{line => 5, source => inferred, spec => int}}
+                    {type, #{line => 5, spec => int}}
             }}
     },
     ?assertEqual({error, unmatched_types, Data}, rufus_expr:typecheck_and_annotate(Forms)).

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -29,7 +29,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => atom
                                 }}
                         }},
@@ -41,7 +40,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => atom
                                 }}
                         }},
@@ -67,7 +65,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => atom}},
-                    source => rufus_text,
                     spec => 'func() atom'
                 }}
         }}
@@ -99,7 +96,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -111,7 +107,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -137,7 +132,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => bool}},
-                    source => rufus_text,
                     spec => 'func() bool'
                 }}
         }}
@@ -169,7 +163,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => float
                                 }}
                         }},
@@ -181,7 +174,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => float
                                 }}
                         }},
@@ -207,7 +199,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => float}},
-                    source => rufus_text,
                     spec => 'func() float'
                 }}
         }}
@@ -269,7 +260,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -301,7 +291,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => string
                                 }}
                         }},
@@ -313,7 +302,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => inferred,
                                     spec => string
                                 }}
                         }},
@@ -339,7 +327,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func() string'
                 }}
         }}
@@ -374,11 +361,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -392,7 +377,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -404,11 +388,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -418,7 +400,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }},
@@ -431,7 +412,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -444,7 +424,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'FortyTwo',
@@ -459,10 +438,8 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func() list[int]'
                 }}
         }}
@@ -498,11 +475,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => string
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[string]'
                                             }}
                                     },
@@ -510,7 +485,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => string
                                         }}
                                 }}
@@ -522,11 +496,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => string
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[string]'
                                 }}
                         }},
@@ -541,11 +513,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => string
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[string]'
                                 }}
                         }},
@@ -555,11 +525,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                             element_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => string
                                 }},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[string]'
                         }}
                 }},
@@ -569,7 +537,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                     type =>
                         {type, #{
                             line => 4,
-                            source => rufus_text,
                             spec => string
                         }}
                 }}
@@ -585,11 +552,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                             element_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => string
                                 }},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[string]'
                         }}
                 }}
@@ -607,17 +572,14 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                             element_type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => string
                                 }},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[string]'
                         }}
                     ],
                     return_type =>
                         {type, #{line => 3, spec => string}},
-                    source => rufus_text,
                     spec => 'func(list[string]) string'
                 }}
         }}
@@ -653,11 +615,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -665,7 +625,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -677,7 +636,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                         head =>
                                             {type, #{
                                                 line => 4,
-                                                source => rufus_text,
                                                 spec => int
                                             }},
                                         items =>
@@ -686,11 +644,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -701,11 +657,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -715,11 +669,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -734,11 +686,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -748,7 +698,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }},
@@ -760,7 +709,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             type =>
                                 {type, #{
                                     line => 4,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -775,11 +723,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -789,7 +735,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 5, spec => int}},
                             line => 5,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -805,7 +750,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -816,7 +760,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo',
@@ -830,7 +773,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -840,10 +782,8 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -879,11 +819,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -891,7 +829,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -905,7 +842,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -915,7 +851,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -927,11 +862,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -941,11 +874,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -960,11 +891,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -974,7 +903,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }},
@@ -996,7 +924,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1014,13 +941,11 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
         }}
@@ -1053,7 +978,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1068,11 +992,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -1083,11 +1005,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -1097,11 +1017,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1116,11 +1034,9 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1130,7 +1046,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }},
@@ -1143,7 +1058,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1159,7 +1073,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1170,7 +1083,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Rest',
@@ -1184,7 +1096,6 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
@@ -1194,10 +1105,8 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
-                    source => rufus_text,
                     spec => 'func(list[int]) list[int]'
                 }}
         }}
@@ -1227,7 +1136,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1240,7 +1148,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1258,7 +1165,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                                 a =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             },
@@ -1266,7 +1172,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1278,7 +1183,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1296,7 +1200,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }}
@@ -1343,7 +1246,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1361,7 +1263,6 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
                     param_types => [{type, #{line => 3, spec => int}}],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(int) int'
                 }}
         }}
@@ -1405,11 +1306,9 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -1417,7 +1316,6 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }},
@@ -1429,7 +1327,6 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                         head =>
                                             {type, #{
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => int
                                             }},
                                         items =>
@@ -1438,11 +1335,9 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                                 element_type =>
                                                     {type, #{
                                                         line => 3,
-                                                        source => rufus_text,
                                                         spec => int
                                                     }},
                                                 line => 3,
-                                                source => rufus_text,
                                                 spec => 'list[int]'
                                             }}
                                     },
@@ -1453,11 +1348,9 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 3,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             line => 3,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -1467,11 +1360,9 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1486,11 +1377,9 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -1500,7 +1389,6 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -1518,13 +1406,11 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                     ],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func(list[int]) int'
                 }}
         }}
@@ -1550,7 +1436,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_operands_wi
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -1621,7 +1506,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                                     type =>
                                         {type, #{
                                             line => 5,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1634,7 +1518,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                                     type =>
                                         {type, #{
                                             line => 5,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1665,7 +1548,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -1704,7 +1586,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1717,7 +1598,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                                     type =>
                                         {type, #{
                                             line => 3,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1740,7 +1620,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -1772,7 +1651,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1785,7 +1663,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1802,7 +1679,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1815,7 +1691,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -1838,7 +1713,6 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -1880,7 +1754,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }},
@@ -1895,7 +1768,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1908,7 +1780,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }},
@@ -1928,7 +1799,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
         }}
@@ -1974,7 +1844,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -1985,7 +1854,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2018,7 +1886,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                 type =>
                                     {type, #{
                                         line => 6,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -2032,7 +1899,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                 type =>
                                     {type, #{
                                         line => 3,
-                                        source => rufus_text,
                                         spec => int
                                     }}
                             }},
@@ -2058,7 +1924,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -2069,7 +1934,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2104,7 +1968,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                 type =>
                                     {type, #{
                                         line => 5,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -2117,7 +1980,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                                 type =>
                                     {type, #{
                                         line => 4,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }},
@@ -2143,7 +2005,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2195,7 +2056,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -2206,7 +2066,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2236,7 +2095,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                     param_types => [],
                     return_type =>
                         {type, #{line => 4, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ],
@@ -2247,7 +2105,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2301,7 +2158,6 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                 param_types => [{type, #{line => 3, spec => int}}],
                 return_type =>
                     {type, #{line => 3, spec => int}},
-                source => rufus_text,
                 spec => 'func(int) int'
             }}
         ]
@@ -2339,7 +2195,6 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2368,7 +2223,6 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                                 type =>
                                     {type, #{
                                         line => 4,
-                                        source => inferred,
                                         spec => int
                                     }}
                             }}
@@ -2393,7 +2247,6 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                         param_types => [],
                         return_type =>
                             {type, #{line => 3, spec => int}},
-                        source => rufus_text,
                         spec => 'func() int'
                     }}
             }}
@@ -2422,7 +2275,6 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]
@@ -2459,7 +2311,6 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
                         param_types => [],
                         return_type =>
                             {type, #{line => 3, spec => int}},
-                        source => rufus_text,
                         spec => 'func() int'
                     }}
             }}
@@ -2489,7 +2340,6 @@ typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }}
             ]

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -336,12 +336,12 @@ make_module_test() ->
 
 make_inferred_type_test() ->
     ?assertEqual(
-        {type, #{spec => int, source => inferred, line => 4}},
+        {type, #{spec => int, line => 4}},
         rufus_form:make_inferred_type(int, 4)
     ).
 
 make_type_test() ->
     ?assertEqual(
-        {type, #{spec => float, source => rufus_text, line => 37}},
+        {type, #{spec => float, line => 37}},
         rufus_form:make_type(float, 37)
     ).

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -17,12 +17,6 @@ return_type_test() ->
     Form = rufus_form:make_func('Ping', [], ReturnType, [], 13),
     ?assertEqual(ReturnType, rufus_form:return_type(Form)).
 
-source_test() ->
-    Type = rufus_form:make_type(int, 19),
-    ?assertEqual(rufus_text, rufus_form:source(Type)),
-    InferredType = rufus_form:make_inferred_type(int, 27),
-    ?assertEqual(inferred, rufus_form:source(InferredType)).
-
 spec_test() ->
     Form =
         {identifier, #{
@@ -32,7 +26,7 @@ spec_test() ->
     ?assertEqual(n, rufus_form:spec(Form)).
 
 has_type_test() ->
-    Type = rufus_form:make_inferred_type(int, 27),
+    Type = rufus_form:make_type(int, 27),
     Form =
         {int_lit, #{
             spec => 42,
@@ -42,7 +36,7 @@ has_type_test() ->
     ?assertEqual(true, rufus_form:has_type(Form)).
 
 has_type_infers_identifier_type_from_locals_test() ->
-    Type = rufus_form:make_inferred_type(int, 27),
+    Type = rufus_form:make_type(int, 27),
     {FormType, Context} = rufus_form:make_identifier(number, 13),
     Locals = #{number => Type},
     Form = {FormType, Context#{locals => Locals}},
@@ -65,7 +59,7 @@ element_type_test() ->
     ?assertEqual(ElementType, rufus_form:element_type(Form)).
 
 type_test() ->
-    Type = rufus_form:make_inferred_type(int, 27),
+    Type = rufus_form:make_type(int, 27),
     Form =
         {int_lit, #{
             spec => 42,
@@ -75,7 +69,7 @@ type_test() ->
     ?assertEqual(Type, rufus_form:type(Form)).
 
 type_spec_with_rufus_form_test() ->
-    Type = rufus_form:make_inferred_type(int, 27),
+    Type = rufus_form:make_type(int, 27),
     Form =
         {int_lit, #{
             spec => 42,
@@ -85,7 +79,7 @@ type_spec_with_rufus_form_test() ->
     ?assertEqual(int, rufus_form:type_spec(Form)).
 
 type_spec_with_type_form_test() ->
-    Type = rufus_form:make_inferred_type(int, 27),
+    Type = rufus_form:make_type(int, 27),
     ?assertEqual(int, rufus_form:type_spec(Type)).
 
 type_spec_with_locals_test() ->
@@ -254,7 +248,7 @@ make_literal_for_bool_lit_test() ->
         {bool_lit, #{
             spec => true,
             line => 7,
-            type => rufus_form:make_inferred_type(bool, 7)
+            type => rufus_form:make_type(bool, 7)
         }},
     ?assertEqual(Expected, rufus_form:make_literal(bool, true, 7)).
 
@@ -263,7 +257,7 @@ make_literal_for_float_lit_test() ->
         {float_lit, #{
             spec => "37.103",
             line => 92,
-            type => rufus_form:make_inferred_type(float, 92)
+            type => rufus_form:make_type(float, 92)
         }},
     ?assertEqual(Expected, rufus_form:make_literal(float, "37.103", 92)).
 
@@ -272,7 +266,7 @@ make_literal_for_int_lit_test() ->
         {int_lit, #{
             spec => "42",
             line => 5,
-            type => rufus_form:make_inferred_type(int, 5)
+            type => rufus_form:make_type(int, 5)
         }},
     ?assertEqual(Expected, rufus_form:make_literal(int, "42", 5)).
 
@@ -281,7 +275,7 @@ make_literal_for_string_lit_test() ->
         {string_lit, #{
             spec => <<"hello">>,
             line => 9,
-            type => rufus_form:make_inferred_type(string, 9)
+            type => rufus_form:make_type(string, 9)
         }},
     ?assertEqual(Expected, rufus_form:make_literal(string, <<"hello">>, 9)).
 
@@ -334,14 +328,8 @@ make_module_test() ->
         }},
     ?assertEqual(Expected, rufus_form:make_module(example, 1)).
 
-make_inferred_type_test() ->
-    ?assertEqual(
-        {type, #{spec => int, line => 4}},
-        rufus_form:make_inferred_type(int, 4)
-    ).
-
 make_type_test() ->
     ?assertEqual(
-        {type, #{spec => float, line => 37}},
-        rufus_form:make_type(float, 37)
+        {type, #{spec => int, line => 4}},
+        rufus_form:make_type(int, 4)
     ).

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -15,7 +15,7 @@ map_test() ->
     Form = rufus_form:make_literal(bool, true, 7),
     Expected1 =
         {bool_lit,
-            Context = #{spec => true, line => 7, type => rufus_form:make_inferred_type(bool, 7)}},
+            Context = #{spec => true, line => 7, type => rufus_form:make_type(bool, 7)}},
     ?assertEqual(Expected1, Form),
     [AnnotatedForm] = rufus_forms:map([Form], fun annotate/1),
     Expected2 = {bool_lit, Context#{annotated => true}},
@@ -157,7 +157,6 @@ globals_test() ->
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }}
         ],
@@ -168,7 +167,6 @@ globals_test() ->
                 param_types => [],
                 return_type =>
                     {type, #{line => 4, spec => int}},
-                source => rufus_text,
                 spec => 'func() int'
             }}
         ]
@@ -193,7 +191,6 @@ globals_with_multiple_function_heads_test() ->
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }},
             {type, #{
@@ -202,7 +199,6 @@ globals_with_multiple_function_heads_test() ->
                 param_types => [{type, #{line => 4, spec => int}}],
                 return_type =>
                     {type, #{line => 4, spec => int}},
-                source => rufus_text,
                 spec => 'func(int) int'
             }}
         ]

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -154,9 +154,9 @@ globals_test() ->
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }}
@@ -167,7 +167,7 @@ globals_test() ->
                 line => 4,
                 param_types => [],
                 return_type =>
-                    {type, #{line => 4, source => rufus_text, spec => int}},
+                    {type, #{line => 4, spec => int}},
                 source => rufus_text,
                 spec => 'func() int'
             }}
@@ -190,18 +190,18 @@ globals_with_multiple_function_heads_test() ->
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }},
             {type, #{
                 kind => func,
                 line => 4,
-                param_types => [{type, #{line => 4, source => rufus_text, spec => int}}],
+                param_types => [{type, #{line => 4, spec => int}}],
                 return_type =>
-                    {type, #{line => 4, source => rufus_text, spec => int}},
+                    {type, #{line => 4, spec => int}},
                 source => rufus_text,
                 spec => 'func(int) int'
             }}

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -14,8 +14,7 @@ map_with_noop_function_test() ->
 map_test() ->
     Form = rufus_form:make_literal(bool, true, 7),
     Expected1 =
-        {bool_lit,
-            Context = #{spec => true, line => 7, type => rufus_form:make_type(bool, 7)}},
+        {bool_lit, Context = #{spec => true, line => 7, type => rufus_form:make_type(bool, 7)}},
     ?assertEqual(Expected1, Form),
     [AnnotatedForm] = rufus_forms:map([Form], fun annotate/1),
     Expected2 = {bool_lit, Context#{annotated => true}},

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -43,8 +43,7 @@ parse_function_adding_two_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Three'
         }}
@@ -106,8 +105,7 @@ parse_function_adding_three_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Six'
         }}
@@ -153,8 +151,7 @@ parse_function_subtracting_two_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'One'
         }}
@@ -216,8 +213,7 @@ parse_function_subtracting_three_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'MinusNine'
         }}
@@ -263,8 +259,7 @@ parse_function_multiplying_two_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'FortyTwo'
         }}
@@ -326,8 +321,7 @@ parse_function_multiplying_three_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'OneTwenty'
         }}
@@ -373,8 +367,7 @@ parse_function_dividing_two_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'FortyTwo'
         }}
@@ -436,8 +429,7 @@ parse_function_dividing_three_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Five'
         }}
@@ -483,8 +475,7 @@ parse_function_remaindering_two_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Six'
         }}
@@ -546,8 +537,7 @@ parse_function_remaindering_three_ints_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Four'
         }}

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -571,7 +571,6 @@ parse_function_anding_two_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -584,7 +583,6 @@ parse_function_anding_two_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }}
@@ -595,7 +593,6 @@ parse_function_anding_two_bools_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -618,7 +615,6 @@ parse_function_oring_two_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -631,7 +627,6 @@ parse_function_oring_two_bools_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }}
@@ -642,7 +637,6 @@ parse_function_oring_two_bools_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Truthy'
@@ -667,7 +661,6 @@ parse_function_comparing_two_bools_for_equality_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -680,7 +673,6 @@ parse_function_comparing_two_bools_for_equality_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }}
@@ -691,7 +683,6 @@ parse_function_comparing_two_bools_for_equality_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -714,7 +705,6 @@ parse_function_comparing_two_bools_for_inequality_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }},
@@ -727,7 +717,6 @@ parse_function_comparing_two_bools_for_inequality_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }}
@@ -738,7 +727,6 @@ parse_function_comparing_two_bools_for_inequality_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -761,7 +749,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -774,7 +761,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -785,7 +771,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -808,7 +793,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_or_equal_test() -
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -821,7 +805,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_or_equal_test() -
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -832,7 +815,6 @@ parse_function_comparing_two_ints_to_determine_which_is_lesser_or_equal_test() -
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -855,7 +837,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -868,7 +849,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -879,7 +859,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'
@@ -902,7 +881,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_or_equal_test() 
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -915,7 +893,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_or_equal_test() 
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -926,7 +903,6 @@ parse_function_comparing_two_ints_to_determine_which_is_greater_or_equal_test() 
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Falsy'

--- a/rf/test/rufus_parse_binary_op_test.erl
+++ b/rf/test/rufus_parse_binary_op_test.erl
@@ -22,8 +22,7 @@ parse_function_adding_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }},
                     right =>
@@ -33,8 +32,7 @@ parse_function_adding_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -69,8 +67,7 @@ parse_function_adding_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             right =>
@@ -80,8 +77,7 @@ parse_function_adding_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             line => 1
@@ -95,8 +91,7 @@ parse_function_adding_three_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -130,8 +125,7 @@ parse_function_subtracting_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }},
                     right =>
@@ -141,8 +135,7 @@ parse_function_subtracting_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -177,8 +170,7 @@ parse_function_subtracting_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             right =>
@@ -188,8 +180,7 @@ parse_function_subtracting_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             line => 1
@@ -203,8 +194,7 @@ parse_function_subtracting_three_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -238,8 +228,7 @@ parse_function_multiplying_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }},
                     right =>
@@ -249,8 +238,7 @@ parse_function_multiplying_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -285,8 +273,7 @@ parse_function_multiplying_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             right =>
@@ -296,8 +283,7 @@ parse_function_multiplying_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             line => 1
@@ -311,8 +297,7 @@ parse_function_multiplying_three_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -346,8 +331,7 @@ parse_function_dividing_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }},
                     right =>
@@ -357,8 +341,7 @@ parse_function_dividing_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -393,8 +376,7 @@ parse_function_dividing_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             right =>
@@ -404,8 +386,7 @@ parse_function_dividing_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             line => 1
@@ -419,8 +400,7 @@ parse_function_dividing_three_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -454,8 +434,7 @@ parse_function_remaindering_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }},
                     right =>
@@ -465,8 +444,7 @@ parse_function_remaindering_two_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}
@@ -501,8 +479,7 @@ parse_function_remaindering_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             right =>
@@ -512,8 +489,7 @@ parse_function_remaindering_three_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            spec => int,
-                                            source => inferred
+                                            spec => int
                                         }}
                                 }},
                             line => 1
@@ -527,8 +503,7 @@ parse_function_remaindering_three_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    spec => int,
-                                    source => inferred
+                                    spec => int
                                 }}
                         }}
                 }}

--- a/rf/test/rufus_parse_call_test.erl
+++ b/rf/test/rufus_parse_call_test.erl
@@ -22,7 +22,6 @@ parse_function_calling_a_function_without_arguments_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => int
                 }},
             spec => 'Random'
@@ -48,7 +47,6 @@ parse_function_calling_a_function_with_an_argument_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => string
                                 }}
                         }}
@@ -61,7 +59,6 @@ parse_function_calling_a_function_with_an_argument_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => string
                 }},
             spec => 'Echo'

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -752,7 +752,7 @@ parse_function_taking_and_returning_a_function_test() ->
                             line => 2,
                             param_types => [],
                             return_type =>
-                                {type, #{line => 2, source => rufus_text, spec => int}},
+                                {type, #{line => 2, spec => int}},
                             source => rufus_text,
                             spec => 'func() int'
                         }}
@@ -764,7 +764,7 @@ parse_function_taking_and_returning_a_function_test() ->
                     line => 2,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
+                        {type, #{line => 2, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -801,7 +801,7 @@ parse_function_returning_a_function_test() ->
                     line => 3,
                     params => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}}
+                        {type, #{line => 3, spec => int}}
                 }}
             ],
             line => 2,
@@ -812,7 +812,7 @@ parse_function_returning_a_function_test() ->
                     line => 2,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
+                        {type, #{line => 2, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -870,7 +870,7 @@ parse_function_returning_a_function_variable_test() ->
                             line => 3,
                             params => [],
                             return_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}}
+                                {type, #{line => 3, spec => int}}
                         }}
                 }},
                 {identifier, #{line => 4, spec => fn}}
@@ -883,7 +883,7 @@ parse_function_returning_a_function_variable_test() ->
                     line => 2,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 2, source => rufus_text, spec => int}},
+                        {type, #{line => 2, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},
@@ -966,7 +966,7 @@ parse_function_returning_a_nested_function_test() ->
                     line => 3,
                     param_types => [],
                     return_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     source => rufus_text,
                     spec => 'func() int'
                 }},

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -27,8 +27,7 @@ parse_function_returning_an_atom_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => atom,
-                    source => rufus_text
+                    spec => atom
                 }},
             spec => 'Color'
         }}
@@ -58,8 +57,7 @@ parse_function_returning_a_bool_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => bool,
-                    source => rufus_text
+                    spec => bool
                 }},
             spec => 'True'
         }}
@@ -89,8 +87,7 @@ parse_function_returning_a_float_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => float,
-                    source => rufus_text
+                    spec => float
                 }},
             spec => 'Pi'
         }}
@@ -120,8 +117,7 @@ parse_function_returning_an_int_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Number'
         }}
@@ -151,8 +147,7 @@ parse_function_returning_a_string_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => string,
-                    source => rufus_text
+                    spec => string
                 }},
             spec => 'Greeting'
         }}
@@ -309,8 +304,7 @@ parse_function_taking_an_atom_and_returning_an_atom_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => atom,
-                            source => rufus_text
+                            spec => atom
                         }}
                 }}
             ],
@@ -330,8 +324,7 @@ parse_function_taking_an_atom_and_returning_an_atom_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => atom,
-                    source => rufus_text
+                    spec => atom
                 }},
             spec => 'Color'
         }}
@@ -351,8 +344,7 @@ parse_function_taking_a_bool_and_returning_a_bool_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => bool,
-                            source => rufus_text
+                            spec => bool
                         }}
                 }}
             ],
@@ -372,8 +364,7 @@ parse_function_taking_a_bool_and_returning_a_bool_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => bool,
-                    source => rufus_text
+                    spec => bool
                 }},
             spec => 'Echo'
         }}
@@ -393,8 +384,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => float,
-                            source => rufus_text
+                            spec => float
                         }}
                 }}
             ],
@@ -414,8 +404,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => float,
-                    source => rufus_text
+                    spec => float
                 }},
             spec => 'Echo'
         }}
@@ -435,8 +424,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => int,
-                            source => rufus_text
+                            spec => int
                         }}
                 }}
             ],
@@ -456,8 +444,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => int,
-                    source => rufus_text
+                    spec => int
                 }},
             spec => 'Echo'
         }}
@@ -477,8 +464,7 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => string,
-                            source => rufus_text
+                            spec => string
                         }}
                 }}
             ],
@@ -498,8 +484,7 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    spec => string,
-                    source => rufus_text
+                    spec => string
                 }},
             spec => 'Echo'
         }}

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -18,8 +18,7 @@ parse_function_returning_an_atom_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => atom,
-                            source => inferred
+                            spec => atom
                         }}
                 }}
             ],
@@ -48,8 +47,7 @@ parse_function_returning_a_bool_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => bool,
-                            source => inferred
+                            spec => bool
                         }}
                 }}
             ],
@@ -78,8 +76,7 @@ parse_function_returning_a_float_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => float,
-                            source => inferred
+                            spec => float
                         }}
                 }}
             ],
@@ -108,8 +105,7 @@ parse_function_returning_an_int_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => int,
-                            source => inferred
+                            spec => int
                         }}
                 }}
             ],
@@ -138,8 +134,7 @@ parse_function_returning_a_string_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => string,
-                            source => inferred
+                            spec => string
                         }}
                 }}
             ],
@@ -315,8 +310,7 @@ parse_function_taking_an_atom_and_returning_an_atom_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => atom,
-                            source => inferred
+                            spec => atom
                         }}
                 }}
             ],
@@ -355,8 +349,7 @@ parse_function_taking_a_bool_and_returning_a_bool_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => bool,
-                            source => inferred
+                            spec => bool
                         }}
                 }}
             ],
@@ -395,8 +388,7 @@ parse_function_taking_an_float_and_returning_an_float_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => float,
-                            source => inferred
+                            spec => float
                         }}
                 }}
             ],
@@ -435,8 +427,7 @@ parse_function_taking_an_int_and_returning_an_int_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => int,
-                            source => inferred
+                            spec => int
                         }}
                 }}
             ],
@@ -475,8 +466,7 @@ parse_function_taking_an_string_and_returning_an_string_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            spec => string,
-                            source => inferred
+                            spec => string
                         }}
                 }}
             ],

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -181,7 +181,6 @@ forms_for_function_with_multiple_expressions_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => inferred,
                             spec => int
                         }}
                 }},
@@ -191,7 +190,6 @@ forms_for_function_with_multiple_expressions_test() ->
                     type =>
                         {type, #{
                             line => 4,
-                            source => inferred,
                             spec => atom
                         }}
                 }}
@@ -200,7 +198,6 @@ forms_for_function_with_multiple_expressions_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => atom
                 }},
             spec => 'Multiple'
@@ -229,7 +226,6 @@ forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
                     type =>
                         {type, #{
                             line => 3,
-                            source => inferred,
                             spec => int
                         }}
                 }},
@@ -239,7 +235,6 @@ forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
                     type =>
                         {type, #{
                             line => 5,
-                            source => inferred,
                             spec => atom
                         }}
                 }}
@@ -248,7 +243,6 @@ forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => atom
                 }},
             spec => 'Multiple'
@@ -270,7 +264,6 @@ forms_for_function_with_multiple_expressions_separated_by_semicolons_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => int
                         }}
                 }},
@@ -280,7 +273,6 @@ forms_for_function_with_multiple_expressions_separated_by_semicolons_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => atom
                         }}
                 }}
@@ -289,7 +281,6 @@ forms_for_function_with_multiple_expressions_separated_by_semicolons_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => atom
                 }},
             spec => 'Multiple'
@@ -530,7 +521,6 @@ parse_function_taking_an_atom_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => atom
                         }}
                 }}
@@ -543,7 +533,6 @@ parse_function_taking_an_atom_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => atom
                         }}
                 }}
@@ -551,7 +540,6 @@ parse_function_taking_an_atom_literal_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => atom
                 }},
             spec => 'Echo'
@@ -572,7 +560,6 @@ parse_function_taking_a_bool_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => bool
                         }}
                 }}
@@ -585,7 +572,6 @@ parse_function_taking_a_bool_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => bool
                         }}
                 }}
@@ -593,7 +579,6 @@ parse_function_taking_a_bool_literal_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Echo'
@@ -614,7 +599,6 @@ parse_function_taking_a_float_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => float
                         }}
                 }}
@@ -627,7 +611,6 @@ parse_function_taking_a_float_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => float
                         }}
                 }}
@@ -635,7 +618,6 @@ parse_function_taking_a_float_literal_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => float
                 }},
             spec => 'Echo'
@@ -656,7 +638,6 @@ parse_function_taking_an_int_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => int
                         }}
                 }}
@@ -669,7 +650,6 @@ parse_function_taking_an_int_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => int
                         }}
                 }}
@@ -677,7 +657,6 @@ parse_function_taking_an_int_literal_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => int
                 }},
             spec => 'Echo'
@@ -698,7 +677,6 @@ parse_function_taking_a_string_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => string
                         }}
                 }}
@@ -711,7 +689,6 @@ parse_function_taking_a_string_literal_test() ->
                     type =>
                         {type, #{
                             line => 1,
-                            source => inferred,
                             spec => string
                         }}
                 }}
@@ -719,7 +696,6 @@ parse_function_taking_a_string_literal_test() ->
             return_type =>
                 {type, #{
                     line => 1,
-                    source => rufus_text,
                     spec => string
                 }},
             spec => 'Echo'
@@ -753,7 +729,6 @@ parse_function_taking_and_returning_a_function_test() ->
                             param_types => [],
                             return_type =>
                                 {type, #{line => 2, spec => int}},
-                            source => rufus_text,
                             spec => 'func() int'
                         }}
                 }}
@@ -765,7 +740,6 @@ parse_function_taking_and_returning_a_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 2, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'Echo'
@@ -793,7 +767,6 @@ parse_function_returning_a_function_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -813,7 +786,6 @@ parse_function_returning_a_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 2, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc'
@@ -848,7 +820,6 @@ parse_function_returning_a_function_variable_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 3,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -861,7 +832,6 @@ parse_function_returning_a_function_variable_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 3,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -884,7 +854,6 @@ parse_function_returning_a_function_variable_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 2, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc'
@@ -923,7 +892,6 @@ parse_function_returning_a_nested_function_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 5,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -933,7 +901,6 @@ parse_function_returning_a_nested_function_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 5,
-                                            source => rufus_text,
                                             spec => int
                                         }}
                                 }}
@@ -948,10 +915,8 @@ parse_function_returning_a_nested_function_test() ->
                                     return_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
-                                    source => rufus_text,
                                     spec => 'func() int'
                                 }}
                         }}
@@ -967,7 +932,6 @@ parse_function_returning_a_nested_function_test() ->
                     param_types => [],
                     return_type =>
                         {type, #{line => 3, spec => int}},
-                    source => rufus_text,
                     spec => 'func() int'
                 }},
             spec => 'NumberFunc'

--- a/rf/test/rufus_parse_list_test.erl
+++ b/rf/test/rufus_parse_list_test.erl
@@ -691,7 +691,7 @@ parse_function_taking_a_cons_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 1, source => rufus_text, spec => int}},
+                                {type, #{line => 1, spec => int}},
                             line => 1,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -708,7 +708,7 @@ parse_function_taking_a_cons_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 1, source => rufus_text, spec => int}},
+                                {type, #{line => 1, spec => int}},
                             line => 1,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -719,7 +719,7 @@ parse_function_taking_a_cons_pattern_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 1, source => rufus_text, spec => int}},
+                        {type, #{line => 1, spec => int}},
                     line => 1,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -754,7 +754,7 @@ parse_function_taking_a_list_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 4, source => rufus_text, spec => int}},
+                                {type, #{line => 4, spec => int}},
                             line => 4,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -774,7 +774,7 @@ parse_function_taking_a_list_pattern_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -785,7 +785,7 @@ parse_function_taking_a_list_pattern_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'

--- a/rf/test/rufus_parse_list_test.erl
+++ b/rf/test/rufus_parse_list_test.erl
@@ -18,11 +18,9 @@ parse_function_returning_empty_list_of_ints_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -35,11 +33,9 @@ parse_function_returning_empty_list_of_ints_test() ->
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'EmptyNumbers'
@@ -62,7 +58,6 @@ parse_function_returning_list_of_int_with_one_element_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -74,11 +69,9 @@ parse_function_returning_list_of_int_with_one_element_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -91,11 +84,9 @@ parse_function_returning_list_of_int_with_one_element_test() ->
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'OneNumber'
@@ -118,7 +109,6 @@ parse_function_returning_list_of_many_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -128,7 +118,6 @@ parse_function_returning_list_of_many_ints_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -140,11 +129,9 @@ parse_function_returning_list_of_many_ints_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -157,11 +144,9 @@ parse_function_returning_list_of_many_ints_test() ->
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'ManyNumbers'
@@ -187,7 +172,6 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -199,11 +183,9 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 1,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 1,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -215,7 +197,6 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -225,7 +206,6 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -237,11 +217,9 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 1,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 1,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -256,15 +234,12 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 1,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 1,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[list[int]]'
                         }}
                 }}
@@ -280,15 +255,12 @@ parse_function_returning_nested_list_of_list_of_ints_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[list[int]]'
                 }},
             spec => 'NestedNumbers'
@@ -319,11 +291,9 @@ parse_function_taking_and_returning_list_of_ints_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -334,11 +304,9 @@ parse_function_taking_and_returning_list_of_ints_test() ->
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo'
@@ -361,7 +329,6 @@ parse_function_returning_a_cons_expression_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }},
@@ -375,7 +342,6 @@ parse_function_returning_a_cons_expression_test() ->
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -387,11 +353,9 @@ parse_function_returning_a_cons_expression_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 1,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 1,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -401,11 +365,9 @@ parse_function_returning_a_cons_expression_test() ->
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -418,11 +380,9 @@ parse_function_returning_a_cons_expression_test() ->
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers'
@@ -453,7 +413,6 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -463,7 +422,6 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -473,7 +431,6 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                                     type =>
                                         {type, #{
                                             line => 1,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -485,11 +442,9 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                                     element_type =>
                                         {type, #{
                                             line => 1,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 1,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -499,11 +454,9 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                             element_type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -516,7 +469,6 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                     type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }}
                 }}
@@ -527,11 +479,9 @@ parse_function_that_creates_cons_expression_from_a_variable_and_a_list_literal_t
                     element_type =>
                         {type, #{
                             line => 1,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Prepend'
@@ -567,7 +517,6 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => int
                                 }}
                         }}
@@ -588,7 +537,6 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -598,7 +546,6 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -608,7 +555,6 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }}
@@ -620,11 +566,9 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }}
@@ -647,11 +591,9 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                             element_type =>
                                 {type, #{
                                     line => 5,
-                                    source => rufus_text,
                                     spec => int
                                 }},
                             line => 5,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -664,11 +606,9 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                     element_type =>
                         {type, #{
                             line => 2,
-                            source => rufus_text,
                             spec => int
                         }},
                     line => 2,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Numbers'
@@ -693,7 +633,6 @@ parse_function_taking_a_cons_pattern_test() ->
                             element_type =>
                                 {type, #{line => 1, spec => int}},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -710,7 +649,6 @@ parse_function_taking_a_cons_pattern_test() ->
                             element_type =>
                                 {type, #{line => 1, spec => int}},
                             line => 1,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -721,7 +659,6 @@ parse_function_taking_a_cons_pattern_test() ->
                     element_type =>
                         {type, #{line => 1, spec => int}},
                     line => 1,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo'
@@ -756,7 +693,6 @@ parse_function_taking_a_list_pattern_test() ->
                             element_type =>
                                 {type, #{line => 4, spec => int}},
                             line => 4,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -776,7 +712,6 @@ parse_function_taking_a_list_pattern_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -787,7 +722,6 @@ parse_function_taking_a_list_pattern_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Reverse'

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -260,7 +260,7 @@ parse_function_with_a_match_that_binds_a_list_literal_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 2, source => rufus_text, spec => string}},
+                {type, #{line => 2, spec => string}},
             spec => 'Unbox'
         }}
     ],
@@ -312,7 +312,7 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 5, source => rufus_text, spec => int}},
+                                {type, #{line => 5, spec => int}},
                             line => 5,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -328,7 +328,7 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -339,7 +339,7 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -436,7 +436,7 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -444,7 +444,7 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 3, source => rufus_text, spec => int}},
+                {type, #{line => 3, spec => int}},
             spec => 'First'
         }}
     ],
@@ -509,7 +509,7 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                         {type, #{
                             kind => list,
                             element_type =>
-                                {type, #{line => 3, source => rufus_text, spec => int}},
+                                {type, #{line => 3, spec => int}},
                             line => 3,
                             source => rufus_text,
                             spec => 'list[int]'
@@ -520,7 +520,7 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                 {type, #{
                     kind => list,
                     element_type =>
-                        {type, #{line => 3, source => rufus_text, spec => int}},
+                        {type, #{line => 3, spec => int}},
                     line => 3,
                     source => rufus_text,
                     spec => 'list[int]'
@@ -619,7 +619,7 @@ parse_function_taking_a_match_pattern_test() ->
                 }}
             ],
             return_type =>
-                {type, #{line => 1, source => rufus_text, spec => int}},
+                {type, #{line => 1, spec => int}},
             spec => 'Double'
         }}
     ],

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -29,7 +29,6 @@ parse_function_with_a_match_that_binds_an_atom_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => atom
                                 }}
                         }}
@@ -44,7 +43,6 @@ parse_function_with_a_match_that_binds_an_atom_literal_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => atom
                 }},
             spec => 'Ping'
@@ -79,7 +77,6 @@ parse_function_with_a_match_that_binds_a_bool_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => bool
                                 }}
                         }}
@@ -94,7 +91,6 @@ parse_function_with_a_match_that_binds_a_bool_literal_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => bool
                 }},
             spec => 'Truthy'
@@ -129,7 +125,6 @@ parse_function_with_a_match_that_binds_a_float_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => float
                                 }}
                         }}
@@ -144,7 +139,6 @@ parse_function_with_a_match_that_binds_a_float_literal_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => float
                 }},
             spec => 'FortyTwo'
@@ -179,7 +173,6 @@ parse_function_with_a_match_that_binds_a_string_literal_test() ->
                             type =>
                                 {type, #{
                                     line => 3,
-                                    source => inferred,
                                     spec => string
                                 }}
                         }}
@@ -194,7 +187,6 @@ parse_function_with_a_match_that_binds_a_string_literal_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => string
                 }},
             spec => 'Ping'
@@ -226,11 +218,9 @@ parse_function_with_a_match_that_binds_a_list_literal_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 3,
-                                            source => rufus_text,
                                             spec => string
                                         }},
                                     line => 3,
-                                    source => rufus_text,
                                     spec => 'list[string]'
                                 }}
                         }},
@@ -250,11 +240,9 @@ parse_function_with_a_match_that_binds_a_list_literal_test() ->
                             element_type =>
                                 {type, #{
                                     line => 2,
-                                    source => rufus_text,
                                     spec => string
                                 }},
                             line => 2,
-                            source => rufus_text,
                             spec => 'list[string]'
                         }}
                 }}
@@ -293,11 +281,9 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -314,7 +300,6 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 5, spec => int}},
                             line => 5,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -330,7 +315,6 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -341,7 +325,6 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Echo'
@@ -378,7 +361,6 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }},
@@ -388,7 +370,6 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                                             type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => inferred,
                                                     spec => int
                                                 }}
                                         }}
@@ -400,11 +381,9 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                                             element_type =>
                                                 {type, #{
                                                     line => 4,
-                                                    source => rufus_text,
                                                     spec => int
                                                 }},
                                             line => 4,
-                                            source => rufus_text,
                                             spec => 'list[int]'
                                         }}
                                 }},
@@ -414,11 +393,9 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -438,7 +415,6 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -475,7 +451,6 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                                     type =>
                                         {type, #{
                                             line => 4,
-                                            source => inferred,
                                             spec => int
                                         }}
                                 }},
@@ -487,11 +462,9 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                                     element_type =>
                                         {type, #{
                                             line => 4,
-                                            source => rufus_text,
                                             spec => int
                                         }},
                                     line => 4,
-                                    source => rufus_text,
                                     spec => 'list[int]'
                                 }}
                         }},
@@ -511,7 +484,6 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                             element_type =>
                                 {type, #{line => 3, spec => int}},
                             line => 3,
-                            source => rufus_text,
                             spec => 'list[int]'
                         }}
                 }}
@@ -522,7 +494,6 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
                     element_type =>
                         {type, #{line => 3, spec => int}},
                     line => 3,
-                    source => rufus_text,
                     spec => 'list[int]'
                 }},
             spec => 'Rest'
@@ -570,7 +541,6 @@ parse_function_with_a_match_that_binds_a_variable_test() ->
                     type =>
                         {type, #{
                             line => 2,
-                            source => rufus_text,
                             spec => int
                         }}
                 }}
@@ -578,7 +548,6 @@ parse_function_with_a_match_that_binds_a_variable_test() ->
             return_type =>
                 {type, #{
                     line => 2,
-                    source => rufus_text,
                     spec => int
                 }},
             spec => 'Echo'
@@ -612,7 +581,6 @@ parse_function_taking_a_match_pattern_test() ->
                             type =>
                                 {type, #{
                                     line => 1,
-                                    source => rufus_text,
                                     spec => int
                                 }}
                         }}

--- a/rf/test/rufus_type_binary_op_test.erl
+++ b/rf/test/rufus_type_binary_op_test.erl
@@ -8,7 +8,7 @@ resolve_arithmetic_binary_op_with_ints_test() ->
             Left = rufus_form:make_literal(int, 5, 9),
             Right = rufus_form:make_literal(int, 7, 9),
             Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-            Expected = rufus_form:make_inferred_type(int, 9),
+            Expected = rufus_form:make_type(int, 9),
             ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
         end,
         ['+', '-', '*', '/', '%']
@@ -21,7 +21,7 @@ resolve_arithmetic_binary_op_with_floats_test() ->
             Left = rufus_form:make_literal(float, 1.0, 9),
             Right = rufus_form:make_literal(float, 2.14159265359, 9),
             Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-            Expected = rufus_form:make_inferred_type(float, 9),
+            Expected = rufus_form:make_type(float, 9),
             ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
         end,
         ['+', '-', '*', '/']
@@ -81,7 +81,7 @@ resolve_boolean_binary_op_with_bools_test() ->
             Left = rufus_form:make_literal(bool, true, 9),
             Right = rufus_form:make_literal(bool, false, 9),
             Form = rufus_form:make_binary_op(Op, Left, Right, 9),
-            Expected = rufus_form:make_inferred_type(bool, 9),
+            Expected = rufus_form:make_type(bool, 9),
             ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form))
         end,
         ['and', 'or']

--- a/rf/test/rufus_type_call_test.erl
+++ b/rf/test/rufus_type_call_test.erl
@@ -123,7 +123,6 @@ resolve_unknown_arity_error_test() ->
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }}
         ]
@@ -160,7 +159,6 @@ resolve_unmatched_args_error_test() ->
                 param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
                     {type, #{line => 3, spec => string}},
-                source => rufus_text,
                 spec => 'func(string) string'
             }}
         ]

--- a/rf/test/rufus_type_call_test.erl
+++ b/rf/test/rufus_type_call_test.erl
@@ -120,9 +120,9 @@ resolve_unknown_arity_error_test() ->
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }}
@@ -150,16 +150,16 @@ resolve_unmatched_args_error_test() ->
                 line => 7,
                 spec => 42,
                 type =>
-                    {type, #{line => 7, source => inferred, spec => integer}}
+                    {type, #{line => 7, spec => integer}}
             }}
         ],
         types => [
             {type, #{
                 kind => func,
                 line => 3,
-                param_types => [{type, #{line => 3, source => rufus_text, spec => string}}],
+                param_types => [{type, #{line => 3, spec => string}}],
                 return_type =>
-                    {type, #{line => 3, source => rufus_text, spec => string}},
+                    {type, #{line => 3, spec => string}},
                 source => rufus_text,
                 spec => 'func(string) string'
             }}

--- a/rf/test/rufus_type_list_test.erl
+++ b/rf/test/rufus_type_list_test.erl
@@ -25,7 +25,6 @@ resolve_list_with_mismatched_element_type_test() ->
                         type =>
                             {type, #{
                                 line => 3,
-                                source => inferred,
                                 spec => float
                             }}
                     }}
@@ -37,11 +36,9 @@ resolve_list_with_mismatched_element_type_test() ->
                         element_type =>
                             {type, #{
                                 line => 3,
-                                source => rufus_text,
                                 spec => int
                             }},
                         line => 3,
-                        source => rufus_text,
                         spec => 'list[int]'
                     }}
             }}

--- a/rf/test/rufus_type_test.erl
+++ b/rf/test/rufus_type_test.erl
@@ -4,5 +4,5 @@
 
 resolve_form_with_an_existing_type_form_test() ->
     Form = rufus_form:make_literal(bool, true, 7),
-    Expected = {type, #{spec => bool, source => inferred, line => 7}},
+    Expected = {type, #{spec => bool, line => 7}},
     ?assertEqual({ok, Expected}, rufus_type:resolve(#{}, Form)).


### PR DESCRIPTION
The `source` annotation on `type` forms is no longer present. It was mostly a source of noise and not very useful information.