### PR TITLE
compiler: Global and local symbol tables use the same format

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -168,7 +168,7 @@ typecheck_and_annotate_call(
         case maps:get(Spec, Locals, undefined) of
             undefined ->
                 Context1;
-            _Type ->
+            [_Type] ->
                 %% The identifier being invoked refers to a function defined in
                 %% the local scope, which means it must be an anonymous
                 %% function. We mark the form so that rufus_erlang:forms/1 can
@@ -402,7 +402,7 @@ typecheck_and_annotate_identifier(
                 {error, Reason, Data} ->
                     throw({error, Reason, Data})
             end;
-        TypeForm ->
+        [TypeForm] ->
             AnnotatedForm2 = {identifier, Context1#{type => TypeForm}},
             {ok, Locals, AnnotatedForm2}
     end.
@@ -569,4 +569,4 @@ annotate_locals(Locals, {FormType, Context}) ->
 %% push_local adds a form to the local scope.
 -spec push_local(locals(), rufus_form()) -> {ok, locals()}.
 push_local(Locals, {_FormType, #{spec := Spec, type := Type}}) ->
-    {ok, Locals#{Spec => Type}}.
+    {ok, Locals#{Spec => [Type]}}.

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -257,6 +257,9 @@ typecheck_and_annotate_func_params(
     ),
     ParamTypes = lists:map(fun(ParamForm) -> rufus_form:type(ParamForm) end, AnnotatedParams),
     FuncType = rufus_form:make_type(func, ParamTypes, ReturnType, Line),
+    %% Local symbols from the parameter list are captured and stored on the
+    %% annotated func form. They're used during the second pass when the
+    %% function body is typechecked.
     AnnotatedForm =
         {func, Context#{
             params => AnnotatedParams,

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -64,7 +64,7 @@ has_type({_FormType, #{type := _Type}}) ->
     true;
 has_type({identifier, #{spec := Spec, locals := Locals}}) ->
     case maps:get(Spec, Locals, undefined) of
-        {type, _Context} ->
+        [{type, _Context}] ->
             true;
         undefined ->
             false
@@ -85,7 +85,7 @@ type({_, #{type := Type}}) ->
     Type;
 type(Form = {identifier, #{spec := Spec, locals := Locals}}) ->
     case maps:get(Spec, Locals, undefined) of
-        {type, Context} ->
+        [{type, Context}] ->
             {type, Context};
         undefined ->
             {error, unknown_form, #{form => Form}}
@@ -99,7 +99,7 @@ type_spec({_, #{type := {type, #{spec := TypeSpec}}}}) ->
     TypeSpec;
 type_spec(Form = {identifier, #{spec := Spec, locals := Locals}}) ->
     case maps:get(Spec, Locals, undefined) of
-        {type, #{spec := TypeSpec}} ->
+        [{type, #{spec := TypeSpec}}] ->
             TypeSpec;
         undefined ->
             {error, unknown_form, #{form => Form}}

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -203,19 +203,8 @@ resolve_call_type(
                 stack => Stack
             },
             throw({error, unknown_func, Data});
-        Types1 ->
-            %% TODO(jkakar) Eliminate this transformation. The issue here is
-            %% that Locals is a map of identifer->type, while Globals is a map
-            %% of identifier->[type]. This is here to ensure we always pass a
-            %% list of types to find_matching_types.
-            Types2 =
-                case Types1 of
-                    Types1 when is_list(Types1) ->
-                        Types1;
-                    Types1 ->
-                        [Types1]
-                end,
-            case find_matching_types(Types2, Args) of
+        Types ->
+            case find_matching_types(Types, Args) of
                 {error, Reason1, Data1} ->
                     throw({error, Reason1, Data1});
                 {ok, MatchingTypes} when length(MatchingTypes) > 1 ->
@@ -320,7 +309,7 @@ pair_types_match_cons_type(_, _, _) ->
     {ok, type_form()} | no_return().
 resolve_identifier_type(Stack, Globals, Form = {identifier, #{spec := Spec, locals := Locals}}) ->
     case maps:get(Spec, Locals, undefined) of
-        {type, _Context} = Type ->
+        [{type, _Context}] = Type ->
             {ok, Type};
         undefined ->
             case lookup_identifier_type(Stack) of

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -12,18 +12,18 @@
 
 -type rufus_text() :: string().
 
-%% Symbols
-
--type symbols() :: #{atom() := list(type_form())}.
--type globals() :: symbols().
--type locals() :: symbols().
-
 %% Types
 
 -type kind_spec() :: func | list.
 -type type_spec() :: atom().
 -type type_form() :: {type, context()}.
 -type type_source() :: inferred | rufus_text.
+
+%% Symbols
+
+-type symbols() :: #{atom() := list(type_form())}.
+-type globals() :: symbols().
+-type locals() :: symbols().
 
 %% Modules
 

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -12,10 +12,11 @@
 
 -type rufus_text() :: string().
 
-%% State storage
+%% Symbols
 
--type globals() :: context().
--type locals() :: context().
+-type symbols() :: #{atom() := list(type_form())}.
+-type globals() :: symbols().
+-type locals() :: symbols().
 
 %% Types
 
@@ -39,20 +40,20 @@
 -type cons_form() :: {cons, context()}.
 
 -type literal_form() ::
-    atom_lit_form() |
-    bool_lit_form() |
-    float_lit_form() |
-    int_lit_form() |
-    string_lit_form() |
-    list_lit_form() |
-    cons_form().
+    atom_lit_form()
+    | bool_lit_form()
+    | float_lit_form()
+    | int_lit_form()
+    | string_lit_form()
+    | list_lit_form()
+    | cons_form().
 
 -type literal() ::
-    atom |
-    bool |
-    float |
-    int |
-    string.
+    atom
+    | bool
+    | float
+    | int
+    | string.
 
 %% Operators
 
@@ -84,21 +85,21 @@
 
 %% rufus_form represents a node in the parse tree.
 -type rufus_form() ::
-    atom_lit_form() |
-    bool_lit_form() |
-    float_lit_form() |
-    int_lit_form() |
-    string_lit_form() |
-    list_lit_form() |
-    cons_form() |
-    module_form() |
-    func_form() |
-    param_form() |
-    identifier_form() |
-    type_form() |
-    binary_op_form() |
-    match_form() |
-    call_form().
+    atom_lit_form()
+    | bool_lit_form()
+    | float_lit_form()
+    | int_lit_form()
+    | string_lit_form()
+    | list_lit_form()
+    | cons_form()
+    | module_form()
+    | func_form()
+    | param_form()
+    | identifier_form()
+    | type_form()
+    | binary_op_form()
+    | match_form()
+    | call_form().
 
 %% rufus_forms is a list of rufus_form instances and typically represents an
 %% entire module.
@@ -114,10 +115,10 @@
 -type unmatched_operand_type_error() :: unmatched_operand_type.
 -type unsupported_operand_type_error() :: unsupported_operand_type.
 -type rufus_error() ::
-    unknown_variable_error() |
-    unmatched_return_type_error() |
-    unmatched_operand_type_error() |
-    unsupported_operand_type_error().
+    unknown_variable_error()
+    | unmatched_return_type_error()
+    | unmatched_operand_type_error()
+    | unsupported_operand_type_error().
 
 %% Erlang forms
 
@@ -125,8 +126,8 @@
 -type erlang4_form() :: {_, _, _, _}.
 -type erlang5_form() :: {_, _, _, _, _}.
 -type erlang_form() ::
-    erlang3_form() |
-    erlang4_form() |
-    erlang5_form().
+    erlang3_form()
+    | erlang4_form()
+    | erlang5_form().
 
 -type export_attribute_erlang_form() :: {attribute, integer(), export, list()}.

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -306,8 +306,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
             ]
         },
         locals => #{
-            n =>
-                {type, #{line => 5, spec => int}}
+            n => [{type, #{line => 5, spec => int}}]
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_compile:eval(RufusText)).
@@ -409,8 +408,7 @@ eval_function_with_a_match_that_has_a_right_call_operand_with_a_mismatched_left_
                     {type, #{line => 5, spec => string}}
             }},
         locals => #{
-            n =>
-                {type, #{line => 5, spec => string}}
+            n => [{type, #{line => 5, spec => string}}]
         },
         right =>
             {call, #{
@@ -469,10 +467,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
         form =>
             {identifier, #{
                 line => 5,
-                locals => #{
-                    value =>
-                        {type, #{line => 4, spec => int}}
-                },
+                locals => #{value => [{type, #{line => 4, spec => int}}]},
                 spec => unbound
             }},
         globals => #{
@@ -481,16 +476,12 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                     kind => func,
                     line => 3,
                     param_types => [],
-                    return_type =>
-                        {type, #{line => 3, spec => int}},
+                    return_type => {type, #{line => 3, spec => int}},
                     spec => 'func() int'
                 }}
             ]
         },
-        locals => #{
-            value =>
-                {type, #{line => 4, spec => int}}
-        },
+        locals => #{value => [{type, #{line => 4, spec => int}}]},
         stack => [
             {match_right, #{line => 5}},
             {match, #{
@@ -508,11 +499,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                             {int_lit, #{
                                 line => 4,
                                 spec => 1,
-                                type =>
-                                    {type, #{
-                                        line => 4,
-                                        spec => int
-                                    }}
+                                type => {type, #{line => 4, spec => int}}
                             }}
                     }},
                     {match, #{
@@ -525,16 +512,14 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                 line => 3,
                 locals => #{},
                 params => [],
-                return_type =>
-                    {type, #{line => 3, spec => int}},
+                return_type => {type, #{line => 3, spec => int}},
                 spec => 'Broken',
                 type =>
                     {type, #{
                         kind => func,
                         line => 3,
                         param_types => [],
-                        return_type =>
-                            {type, #{line => 3, spec => int}},
+                        return_type => {type, #{line => 3, spec => int}},
                         spec => 'func() int'
                     }}
             }}
@@ -636,10 +621,8 @@ eval_function_with_a_match_that_has_unmatched_types_test() ->
                     {type, #{line => 4, spec => atom}}
             }},
         locals => #{
-            a =>
-                {type, #{line => 4, spec => atom}},
-            i =>
-                {type, #{line => 5, spec => int}}
+            a => [{type, #{line => 4, spec => atom}}],
+            i => [{type, #{line => 5, spec => int}}]
         },
         right =>
             {identifier, #{

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -17,11 +17,12 @@ typecheck_and_annotate_with_function_calling_an_unknown_function_test() ->
                 args => [],
                 line => 3,
                 locals => #{
-                    text =>
+                    text => [
                         {type, #{
                             line => 3,
                             spec => string
                         }}
+                    ]
                 },
                 spec => 'Ping'
             }},

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -2313,11 +2313,12 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        head =>
+                                        head => [
                                             {type, #{
                                                 line => 4,
                                                 spec => int
                                             }}
+                                        ]
                                     },
                                     spec => tail,
                                     type =>
@@ -2930,7 +2931,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
             {identifier, #{
                 line => 8,
                 locals => #{
-                    fn =>
+                    fn => [
                         {type, #{
                             kind => func,
                             line => 4,
@@ -2942,6 +2943,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                                 }},
                             spec => 'func() int'
                         }}
+                    ]
                 },
                 spec => num
             }},
@@ -2968,7 +2970,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
             ]
         },
         locals => #{
-            fn =>
+            fn => [
                 {type, #{
                     kind => func,
                     line => 4,
@@ -2977,6 +2979,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                         {type, #{line => 4, spec => int}},
                     spec => 'func() int'
                 }}
+            ]
         },
         stack => [
             {match_right, #{line => 8}},

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -752,11 +752,12 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                         {identifier, #{
                             line => 5,
                             locals => #{
-                                head =>
+                                head => [
                                     {type, #{
                                         line => 4,
                                         spec => int
                                     }}
+                                ]
                             },
                             spec => tail,
                             type =>
@@ -1265,11 +1266,12 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_it_test
                         {identifier, #{
                             line => 3,
                             locals => #{
-                                head =>
+                                head => [
                                     {type, #{
                                         line => 3,
                                         spec => int
                                     }}
+                                ]
                             },
                             spec => tail,
                             type =>
@@ -1371,11 +1373,12 @@ typecheck_and_annotate_with_function_taking_a_cons_pattern_and_returning_the_hea
                         {identifier, #{
                             line => 3,
                             locals => #{
-                                head =>
+                                head => [
                                     {type, #{
                                         line => 3,
                                         spec => int
                                     }}
+                                ]
                             },
                             spec => tail,
                             type =>
@@ -1702,11 +1705,12 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {identifier, #{
                             line => 3,
                             locals => #{
-                                a =>
+                                a => [
                                     {type, #{
                                         line => 3,
                                         spec => int
                                     }}
+                                ]
                             },
                             spec => b,
                             type =>
@@ -1718,16 +1722,18 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
                         {identifier, #{
                             line => 3,
                             locals => #{
-                                a =>
-                                    {type, #{
-                                        line => 3,
-                                        spec => int
-                                    }},
-                                b =>
+                                a => [
                                     {type, #{
                                         line => 3,
                                         spec => int
                                     }}
+                                ],
+                                b => [
+                                    {type, #{
+                                        line => 3,
+                                        spec => int
+                                    }}
+                                ]
                             },
                             spec => c,
                             type =>

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -469,7 +469,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        names =>
+                                        names => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -480,6 +480,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
                                                 line => 3,
                                                 spec => 'list[string]'
                                             }}
+                                        ]
                                     },
                                     spec => name,
                                     type =>
@@ -609,7 +610,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        items =>
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -620,6 +621,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => head,
                                     type =>
@@ -633,12 +635,13 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        head =>
+                                        head => [
                                             {type, #{
                                                 line => 4,
                                                 spec => int
-                                            }},
-                                        items =>
+                                            }}
+                                        ],
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -649,6 +652,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => tail,
                                     type =>
@@ -813,7 +817,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        items =>
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -824,6 +828,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => head,
                                     type =>
@@ -986,7 +991,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                 {identifier, #{
                                     line => 4,
                                     locals => #{
-                                        items =>
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -997,6 +1002,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => tail,
                                     type =>
@@ -1162,11 +1168,12 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
                         {identifier, #{
                             line => 3,
                             locals => #{
-                                a =>
+                                a => [
                                     {type, #{
                                         line => 3,
                                         spec => int
                                     }}
+                                ]
                             },
                             spec => b,
                             type =>
@@ -1300,7 +1307,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                 {identifier, #{
                                     line => 3,
                                     locals => #{
-                                        items =>
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -1311,6 +1318,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => head,
                                     type =>
@@ -1324,12 +1332,13 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                 {identifier, #{
                                     line => 3,
                                     locals => #{
-                                        head =>
+                                        head => [
                                             {type, #{
                                                 line => 3,
                                                 spec => int
-                                            }},
-                                        items =>
+                                            }}
+                                        ],
+                                        items => [
                                             {type, #{
                                                 kind => list,
                                                 element_type =>
@@ -1340,6 +1349,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
                                                 line => 3,
                                                 spec => 'list[int]'
                                             }}
+                                        ]
                                     },
                                     spec => tail,
                                     type =>
@@ -1939,8 +1949,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
             ]
         },
         locals => #{
-            n =>
-                {type, #{line => 5, spec => int}}
+            n => [{type, #{line => 5, spec => int}}]
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -2010,8 +2019,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
             ]
         },
         locals => #{
-            n =>
-                {type, #{line => 4, spec => int}}
+            n => [{type, #{line => 4, spec => int}}]
         }
     },
     ?assertEqual({error, illegal_pattern, Data}, rufus_expr:typecheck_and_annotate(Forms)).
@@ -2117,8 +2125,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
                     {type, #{line => 5, spec => string}}
             }},
         locals => #{
-            n =>
-                {type, #{line => 5, spec => string}}
+            n => [{type, #{line => 5, spec => string}}]
         },
         right =>
             {call, #{
@@ -2182,8 +2189,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
             {identifier, #{
                 line => 5,
                 locals => #{
-                    value =>
-                        {type, #{line => 4, spec => int}}
+                    value => [{type, #{line => 4, spec => int}}]
                 },
                 spec => unbound
             }},
@@ -2200,8 +2206,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
             ]
         },
         locals => #{
-            value =>
-                {type, #{line => 4, spec => int}}
+            value => [{type, #{line => 4, spec => int}}]
         },
         stack => [
             {match_right, #{line => 5}},
@@ -2352,10 +2357,8 @@ typecheck_and_annotate_function_with_a_match_that_has_unmatched_types_test() ->
                     {type, #{line => 4, spec => atom}}
             }},
         locals => #{
-            a =>
-                {type, #{line => 4, spec => atom}},
-            i =>
-                {type, #{line => 5, spec => int}}
+            a => [{type, #{line => 4, spec => atom}}],
+            i => [{type, #{line => 5, spec => int}}]
         },
         right =>
             {identifier, #{

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -38,7 +38,7 @@ has_type_test() ->
 has_type_infers_identifier_type_from_locals_test() ->
     Type = rufus_form:make_type(int, 27),
     {FormType, Context} = rufus_form:make_identifier(number, 13),
-    Locals = #{number => Type},
+    Locals = #{number => [Type]},
     Form = {FormType, Context#{locals => Locals}},
     ?assertEqual(true, rufus_form:has_type(Form)).
 
@@ -83,7 +83,7 @@ type_spec_with_type_form_test() ->
     ?assertEqual(int, rufus_form:type_spec(Type)).
 
 type_spec_with_locals_test() ->
-    Locals = #{t => rufus_form:make_type(string, 3)},
+    Locals = #{t => [rufus_form:make_type(string, 3)]},
     Form =
         {identifier, #{
             line => 3,
@@ -93,7 +93,7 @@ type_spec_with_locals_test() ->
     ?assertEqual(string, rufus_form:type_spec(Form)).
 
 type_spec_with_unknown_form_test() ->
-    Locals = #{other => rufus_form:make_type(string, 3)},
+    Locals = #{other => [rufus_form:make_type(string, 3)]},
     Form =
         {identifier, #{
             line => 3,


### PR DESCRIPTION
Local symbols are stored in the same format as global symbols, a `map` of `atom` specs to a `list` of `type` forms. This eliminates some special case logic and lays the groundwork for supporting anonymous functions with more than one function clause.