### PR TITLE
compiler: Parse and typecheck functions with a mix of params and patterns in the parameter list

### DIFF
--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -114,9 +114,9 @@ list_type -> list '[' type ']'   : rufus_form:make_type(list, '$3', line('$1')).
 match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
 match_param -> expr '=' param    : rufus_form:make_match('$1', '$3', line('$2')).
 
-params -> param params           : ['$1'|'$2'].
+params -> param ',' params       : ['$1'|'$3'].
+params -> param                  : ['$1'].
 params -> '$empty'               : [].
-param -> identifier type ','     : rufus_form:make_param(list_to_atom(text('$1')), '$2', line('$1')).
 param -> identifier type         : rufus_form:make_param(list_to_atom(text('$1')), '$2', line('$1')).
 param -> atom_lit                : rufus_form:make_literal(atom, text('$1'), line('$1')).
 param -> bool_lit                : rufus_form:make_literal(bool, text('$1'), line('$1')).

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -208,19 +208,47 @@ resolve_call_type(
                 {error, Reason1, Data1} ->
                     throw({error, Reason1, Data1});
                 {ok, MatchingTypes} when length(MatchingTypes) > 1 ->
-                    %% TODO(jkakar): We need to handle cases where more than one
-                    %% function matches a given set of parameters. For example,
-                    %% consider two functions:
-                    %%
-                    %% func Echo(:hello) atom { :hello }
-                    %% func Echo(:goodbye) string { "goodbye" }
-                    %%
-                    %% These both match an args list with a single atom arg
-                    %% type, but they have different return types. We need to
-                    %% account for all possible return types. When a callsite
-                    %% specifies a literal value such as :hello or :goodbye we
-                    %% should select the correct singular return type.
-                    erlang:error({not_implemented, [Stack, Globals, Form]});
+                    case
+                        length(
+                            lists:usort(
+                                fun
+                                    (
+                                        {type, #{
+                                            kind := func,
+                                            return_value := {type, #{spec := ReturnValueSpec}}
+                                        }},
+                                        {type, #{
+                                            kind := func,
+                                            return_value := {type, #{spec := ReturnValueSpec}}
+                                        }}
+                                    ) ->
+                                        false;
+                                    (_, _) ->
+                                        true
+                                end,
+                                MatchingTypes
+                            )
+                        )
+                    of
+                        1 ->
+                            [Type | _Tail] = MatchingTypes,
+                            {ok, rufus_form:return_type(Type)};
+                        _ ->
+                            %% TODO(jkakar): We need to handle cases where more
+                            %% than one function matches a given set of
+                            %% parameters. For example, consider two functions:
+                            %%
+                            %% func Echo(:hello) atom { :hello }
+                            %% func Echo(:goodbye) string { "goodbye" }
+                            %%
+                            %% These both match an args list with a single atom
+                            %% arg type, but they have different return types.
+                            %% We need to account for all possible return types.
+                            %% When a callsite specifies a literal value such as
+                            %% :hello or :goodbye we should select the correct
+                            %% singular return type.
+                            erlang:error({not_implemented, [Stack, Globals, Form]})
+                    end;
                 {ok, MatchingTypes} when length(MatchingTypes) =:= 1 ->
                     [Type] = MatchingTypes,
                     {ok, rufus_form:return_type(Type)}

--- a/rf/test/rufus_compile_func_test.erl
+++ b/rf/test/rufus_compile_func_test.erl
@@ -462,7 +462,7 @@ eval_for_anonymous_function_taking_a_string_and_returning_a_string_literal_test(
     ?assert(is_function(EchoFunc)),
     ?assertEqual({string, <<"rufus">>}, EchoFunc({string, <<"rufus">>})).
 
-typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
+eval_for_anonymous_function_taking_a_cons_expression_test() ->
     RufusText =
         "\n"
         "    module example\n"
@@ -476,7 +476,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_cons_expression_test() ->
     ?assert(is_function(EchoNumberListFunc)),
     ?assertEqual([1, 2, 3], EchoNumberListFunc([1, 2, 3])).
 
-typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
+eval_for_anonymous_function_taking_a_list_literal_test() ->
     RufusText =
         "\n"
         "    module example\n"
@@ -490,7 +490,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
     ?assert(is_function(EchoNumberListFunc)),
     ?assertEqual([1, 2, 3], EchoNumberListFunc([1, 2, 3])).
 
-typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
+eval_for_anonymous_function_taking_a_match_param_test() ->
     RufusText =
         "\n"
         "    module example\n"
@@ -506,7 +506,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
     ?assert(is_function(EchoFortyTwoFunc)),
     ?assertEqual(42, EchoFortyTwoFunc(42)).
 
-typecheck_and_annotate_closure_test() ->
+eval_closure_test() ->
     RufusText =
         "\n"
         "    module example\n"
@@ -520,3 +520,34 @@ typecheck_and_annotate_closure_test() ->
     ?assert(is_function(FortyTwoFunc)),
     ?assertEqual(42, FortyTwoFunc()),
     ?assertEqual(42, FortyTwoFunc()).
+
+%% Functions with multiple parameters
+
+eval_function_with_mixed_params_and_patterns_in_parameter_list_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Map(items list[int], fn func(int) int) list[int] {\n"
+        "        mapOver(list[int]{}, items, fn)\n"
+        "    }\n"
+        "    func mapOver(acc list[int], list[int]{head|tail}, fn func(int) int) list[int] {\n"
+        "        result = fn(head)\n"
+        "        mapOver(list[int]{result|acc}, tail, fn)\n"
+        "    }\n"
+        "    func mapOver(acc list[int], list[int]{}, fn func(int) int) list[int] {\n"
+        "        reverse(acc)\n"
+        "    }\n"
+        "    func reverse(items list[int]) list[int] {\n"
+        "        reverse(list[int]{}, items)\n"
+        "    }\n"
+        "    func reverse(acc list[int], list[int]{head|tail}) list[int] {\n"
+        "        reverse(list[int]{head|acc}, tail)\n"
+        "    }\n"
+        "    func reverse(acc list[int], list[int]{}) list[int] {\n"
+        "        acc\n"
+        "    }\n"
+        "    ",
+    Result = rufus_compile:eval(RufusText),
+    ?assertEqual({ok, example}, Result),
+    Items = example:'Map'([1, 2, 4], fun(Num) -> Num * 2 end),
+    ?assertEqual([2, 4, 8], Items).

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -318,7 +318,7 @@ typecheck_and_annotate_with_function_calling_a_function_with_two_arguments_test(
 
 %% Function calls with binary_op arguments
 
-eval_with_function_call_with_binary_op_argument_test() ->
+typecheck_and_annotate_function_call_with_binary_op_argument_test() ->
     RufusText =
         "\n"
         "    module example\n"
@@ -454,7 +454,7 @@ eval_with_function_call_with_binary_op_argument_test() ->
 
 %% Function calls with match arguments
 
-eval_with_function_call_with_match_argument_test() ->
+typecheck_and_annotate_function_call_with_match_argument_test() ->
     RufusText =
         "\n"
         "    module example\n"

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -3066,3 +3066,368 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
         ]
     },
     ?assertEqual({error, unknown_identifier, Data}, Result).
+
+%% Functions with multiple parameters
+
+typecheck_and_annotate_function_with_mixed_params_and_patterns_in_parameter_list_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Map(acc list[int], list[int]{head|tail}, fn func(int) int) list[int] {\n"
+        "        item = fn(head)\n"
+        "        Map(list[int]{item|acc}, tail, fn)\n"
+        "    }\n"
+        "    func Map(acc list[int], list[int]{}, fn func(int) int) list[int] {\n"
+        "        acc\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{
+                                acc => [
+                                    {type, #{
+                                        element_type =>
+                                            {type, #{line => 3, spec => int}},
+                                        kind => list,
+                                        line => 3,
+                                        spec => 'list[int]'
+                                    }}
+                                ],
+                                fn => [
+                                    {type, #{
+                                        kind => func,
+                                        line => 3,
+                                        param_types => [{type, #{line => 3, spec => int}}],
+                                        return_type =>
+                                            {type, #{line => 3, spec => int}},
+                                        spec => 'func(int) int'
+                                    }}
+                                ],
+                                head => [{type, #{line => 3, spec => int}}],
+                                tail => [
+                                    {type, #{
+                                        element_type =>
+                                            {type, #{line => 3, spec => int}},
+                                        kind => list,
+                                        line => 3,
+                                        spec => 'list[int]'
+                                    }}
+                                ]
+                            },
+                            spec => item,
+                            type => {type, #{line => 3, spec => int}}
+                        }},
+                    line => 4,
+                    right =>
+                        {call, #{
+                            args => [
+                                {identifier, #{
+                                    line => 4,
+                                    spec => head,
+                                    type => {type, #{line => 3, spec => int}}
+                                }}
+                            ],
+                            kind => anonymous,
+                            line => 4,
+                            spec => fn,
+                            type => {type, #{line => 3, spec => int}}
+                        }},
+                    type => {type, #{line => 3, spec => int}}
+                }},
+                {call, #{
+                    args => [
+                        {cons, #{
+                            head =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => item,
+                                    type => {type, #{line => 3, spec => int}}
+                                }},
+                            line => 5,
+                            tail =>
+                                {identifier, #{
+                                    line => 5,
+                                    spec => acc,
+                                    type =>
+                                        {type, #{
+                                            element_type =>
+                                                {type, #{line => 3, spec => int}},
+                                            kind => list,
+                                            line => 3,
+                                            spec => 'list[int]'
+                                        }}
+                                }},
+                            type =>
+                                {type, #{
+                                    element_type =>
+                                        {type, #{line => 5, spec => int}},
+                                    kind => list,
+                                    line => 5,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 5,
+                            spec => tail,
+                            type =>
+                                {type, #{
+                                    element_type =>
+                                        {type, #{line => 3, spec => int}},
+                                    kind => list,
+                                    line => 3,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                        {identifier, #{
+                            line => 5,
+                            spec => fn,
+                            type =>
+                                {type, #{
+                                    kind => func,
+                                    line => 3,
+                                    param_types => [{type, #{line => 3, spec => int}}],
+                                    return_type =>
+                                        {type, #{line => 3, spec => int}},
+                                    spec => 'func(int) int'
+                                }}
+                        }}
+                    ],
+                    line => 5,
+                    spec => 'Map',
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => acc,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {cons, #{
+                    head =>
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                acc => [
+                                    {type, #{
+                                        element_type =>
+                                            {type, #{line => 3, spec => int}},
+                                        kind => list,
+                                        line => 3,
+                                        spec => 'list[int]'
+                                    }}
+                                ]
+                            },
+                            spec => head,
+                            type => {type, #{line => 3, spec => int}}
+                        }},
+                    line => 3,
+                    tail =>
+                        {identifier, #{
+                            line => 3,
+                            locals => #{
+                                acc => [
+                                    {type, #{
+                                        element_type =>
+                                            {type, #{line => 3, spec => int}},
+                                        kind => list,
+                                        line => 3,
+                                        spec => 'list[int]'
+                                    }}
+                                ],
+                                head => [{type, #{line => 3, spec => int}}]
+                            },
+                            spec => tail,
+                            type =>
+                                {type, #{
+                                    element_type =>
+                                        {type, #{line => 3, spec => int}},
+                                    kind => list,
+                                    line => 3,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {param, #{
+                    line => 3,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [{type, #{line => 3, spec => int}}],
+                            return_type => {type, #{line => 3, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    element_type => {type, #{line => 3, spec => int}},
+                    kind => list,
+                    line => 3,
+                    spec => 'list[int]'
+                }},
+            spec => 'Map',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }},
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }},
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [{type, #{line => 3, spec => int}}],
+                            return_type => {type, #{line => 3, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                    ],
+                    return_type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }},
+                    spec =>
+                        'func(list[int], list[int], func(int) int) list[int]'
+                }}
+        }},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 8,
+                    spec => acc,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }}
+                }}
+            ],
+            line => 7,
+            params => [
+                {param, #{
+                    line => 7,
+                    spec => acc,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {list_lit, #{
+                    elements => [],
+                    line => 7,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {param, #{
+                    line => 7,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 7,
+                            param_types => [{type, #{line => 7, spec => int}}],
+                            return_type => {type, #{line => 7, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    element_type => {type, #{line => 7, spec => int}},
+                    kind => list,
+                    line => 7,
+                    spec => 'list[int]'
+                }},
+            spec => 'Map',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 7,
+                    param_types => [
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }},
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }},
+                        {type, #{
+                            kind => func,
+                            line => 7,
+                            param_types => [{type, #{line => 7, spec => int}}],
+                            return_type => {type, #{line => 7, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                    ],
+                    return_type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }},
+                    spec =>
+                        'func(list[int], list[int], func(int) int) list[int]'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -913,3 +913,153 @@ parse_function_returning_a_nested_function_test() ->
         }}
     ],
     ?assertEqual(Expected, Forms).
+
+%% Functions with multiple parameters
+
+parse_function_with_mixed_params_and_patterns_in_parameter_list_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Map(acc list[int], list[int]{head|tail}, fn func(int) int) list[int] {\n"
+        "        item = fn(head)\n"
+        "        Map(list[int]{item|acc}, tail, fn)\n"
+        "    }\n"
+        "    func Map(acc list[int], list[int]{}, fn func(int) int) list[int] {\n"
+        "        acc\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs => [
+                {match, #{
+                    left => {identifier, #{line => 4, spec => item}},
+                    line => 4,
+                    right =>
+                        {call, #{
+                            args => [{identifier, #{line => 4, spec => head}}],
+                            line => 4,
+                            spec => fn
+                        }}
+                }},
+                {call, #{
+                    args => [
+                        {cons, #{
+                            head => {identifier, #{line => 5, spec => item}},
+                            line => 5,
+                            tail => {identifier, #{line => 5, spec => acc}},
+                            type =>
+                                {type, #{
+                                    element_type =>
+                                        {type, #{line => 5, spec => int}},
+                                    kind => list,
+                                    line => 5,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                        {identifier, #{line => 5, spec => tail}},
+                        {identifier, #{line => 5, spec => fn}}
+                    ],
+                    line => 5,
+                    spec => 'Map'
+                }}
+            ],
+            line => 3,
+            params => [
+                {param, #{
+                    line => 3,
+                    spec => acc,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {cons, #{
+                    head => {identifier, #{line => 3, spec => head}},
+                    line => 3,
+                    tail => {identifier, #{line => 3, spec => tail}},
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 3, spec => int}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {param, #{
+                    line => 3,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 3,
+                            param_types => [{type, #{line => 3, spec => int}}],
+                            return_type => {type, #{line => 3, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    element_type => {type, #{line => 3, spec => int}},
+                    kind => list,
+                    line => 3,
+                    spec => 'list[int]'
+                }},
+            spec => 'Map'
+        }},
+        {func, #{
+            exprs => [{identifier, #{line => 8, spec => acc}}],
+            line => 7,
+            params => [
+                {param, #{
+                    line => 7,
+                    spec => acc,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {list_lit, #{
+                    elements => [],
+                    line => 7,
+                    type =>
+                        {type, #{
+                            element_type => {type, #{line => 7, spec => int}},
+                            kind => list,
+                            line => 7,
+                            spec => 'list[int]'
+                        }}
+                }},
+                {param, #{
+                    line => 7,
+                    spec => fn,
+                    type =>
+                        {type, #{
+                            kind => func,
+                            line => 7,
+                            param_types => [{type, #{line => 7, spec => int}}],
+                            return_type => {type, #{line => 7, spec => int}},
+                            spec => 'func(int) int'
+                        }}
+                }}
+            ],
+            return_type =>
+                {type, #{
+                    element_type => {type, #{line => 7, spec => int}},
+                    kind => list,
+                    line => 7,
+                    spec => 'list[int]'
+                }},
+            spec => 'Map'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).


### PR DESCRIPTION
`rufus_parse:parse/1` is updated to allow comma-separated params and patterns in function parameters lists. `rufus_type:resolve/2` doesn't raise a `{error, not_implemented, Data}` exception if a function had multiple heads with identical type signatures.