### PR TITLE
compiler: Parse try/catch/after expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ func mapOver(acc list[int], list[int]{}, func(int) int) list[int] {
 }
 ```
 
+Anonymous function with multiple heads:
+
+```rufus
+fn = func {
+match (int) int ->
+    // ...
+match (string) string ->
+    // ...
+}
+```
+
 Named tuple:
 
 ```rufus
@@ -114,10 +125,10 @@ Pattern match expression:
 
 ```rufus
 point = Point{X => 3, Y => -6, Z => 13}
-switch Teleport(point) {
-case :ok =>
+case Teleport(point) {
+match :ok ->
     // ...
-case err error.T =>
+match err error.T ->
     // ...
 }
 ```
@@ -149,3 +160,36 @@ func mapOver(acc list[T?], list[T?]{}, func(T?) T?) list[T?] {
 ```
 
 The first type that binds to `T?` is substitued everywhere `T?` is mentioned.
+
+Error handling:
+
+```rufus
+file = os.OpenFile("/path/to/file")
+try {
+    // ...
+} catch os.ReadError {
+    // ...
+} after {
+    os.CloseFile(file)
+}
+```
+
+```rufus
+try {
+    os.OpenFile("/path/to/file")
+} catch {
+match os.FileNotFound ->
+    // ...
+match RuntimeError ->
+    // ...
+}
+```
+
+```rufus
+file = os.OpenFile("/path/to/file")
+try {
+    // ...
+} after {
+    os.CloseFile(file)
+}
+```

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -16,6 +16,7 @@
     make_binary_op_left/1,
     make_binary_op_right/1,
     make_call/3,
+    make_catch_clause/3,
     make_cons/4,
     make_cons_head/1,
     make_cons_tail/1,
@@ -32,6 +33,7 @@
     make_match_right/1,
     make_module/2,
     make_param/3,
+    make_try_catch_after/4,
     make_type/2,
     make_type/3,
     make_type/4
@@ -256,6 +258,19 @@ make_match_right({match, #{line := Line}}) ->
 -spec make_module(atom(), integer()) -> {module, #{spec => atom(), line => integer()}}.
 make_module(Spec, Line) ->
     {module, #{spec => Spec, line => Line}}.
+
+%% try/catch/after form builder API
+
+make_catch_clause(MatchExpr, Exprs, Line) ->
+    {catch_clause, #{match_expr => MatchExpr, expr => Exprs, line => Line}}.
+
+make_try_catch_after(TryExprs, CatchClauses, AfterExprs, Line) ->
+    {try_catch_after, #{
+        try_exprs => TryExprs,
+        catch_clauses => CatchClauses,
+        after_exprs => AfterExprs,
+        line => Line
+    }}.
 
 %% type form builder API
 

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -262,7 +262,7 @@ make_module(Spec, Line) ->
 %% try/catch/after form builder API
 
 make_catch_clause(MatchExpr, Exprs, Line) ->
-    {catch_clause, #{match_expr => MatchExpr, expr => Exprs, line => Line}}.
+    {catch_clause, #{match_expr => MatchExpr, exprs => Exprs, line => Line}}.
 
 make_try_catch_after(TryExprs, CatchClauses, AfterExprs, Line) ->
     {try_catch_after, #{

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -4,7 +4,8 @@
 
 Nonterminals
     root decl
-    type types block param params args expr exprs
+    type types block param params args
+    expr exprs literal_expr catch_expr
     binary_op call cons match match_param
     list_lit list_type.
 
@@ -17,6 +18,7 @@ Terminals
     '<' '<=' '>' '>='
     module import
     func identifier
+    try catch
     atom atom_lit
     bool bool_lit
     float float_lit
@@ -88,11 +90,15 @@ cons -> list_type '{' expr '|' expr '}' :
 cons -> list_type '{' expr '|' '{' args '}' '}' :
                                    rufus_form:make_cons('$1', '$3', rufus_form:make_literal(list, '$1', '$6', line('$6')), line('$1')).
 
-expr  -> atom_lit                : rufus_form:make_literal(atom, text('$1'), line('$1')).
-expr  -> bool_lit                : rufus_form:make_literal(bool, text('$1'), line('$1')).
-expr  -> float_lit               : rufus_form:make_literal(float, text('$1'), line('$1')).
-expr  -> int_lit                 : rufus_form:make_literal(int, text('$1'), line('$1')).
-expr  -> string_lit              : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
+literal_expr -> atom_lit         : rufus_form:make_literal(atom, text('$1'), line('$1')).
+literal_expr -> bool_lit         : rufus_form:make_literal(bool, text('$1'), line('$1')).
+literal_expr -> float_lit        : rufus_form:make_literal(float, text('$1'), line('$1')).
+literal_expr -> int_lit          : rufus_form:make_literal(int, text('$1'), line('$1')).
+literal_expr -> string_lit       : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
+
+catch_expr -> literal_expr       : '$1'.
+
+expr  -> literal_expr            : '$1'.
 expr  -> identifier              : rufus_form:make_identifier(list_to_atom(text('$1')), line('$1')).
 expr  -> binary_op               : '$1'.
 expr  -> cons                    : '$1'.
@@ -101,6 +107,8 @@ expr  -> call                    : '$1'.
 expr  -> list_lit                : '$1'.
 expr  -> func '(' params ')' type '{' exprs '}' :
                                    rufus_form:make_func('$3', '$5', '$7', line('$1')).
+expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
+                                   rufus_form:make_try_catch('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], line('$1')).
 
 exprs -> expr ';' exprs          : ['$1'|'$3'].
 exprs -> expr                    : ['$1'].

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -18,7 +18,7 @@ Terminals
     '<' '<=' '>' '>='
     module import
     func identifier
-    try catch
+    try catch after
     atom atom_lit
     bool bool_lit
     float float_lit
@@ -107,8 +107,12 @@ expr  -> call                    : '$1'.
 expr  -> list_lit                : '$1'.
 expr  -> func '(' params ')' type '{' exprs '}' :
                                    rufus_form:make_func('$3', '$5', '$7', line('$1')).
+expr  -> try '{' exprs '}' after '{' exprs '}' :
+                                   rufus_form:make_try_catch_after('$3', [], '$7', line('$1')).
+expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' after '{' exprs '}' :
+                                   rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], '$12', line('$1')).
 expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
-                                   rufus_form:make_try_catch('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], line('$1')).
+                                   rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], [], line('$1')).
 
 exprs -> expr ';' exprs          : ['$1'|'$3'].
 exprs -> expr                    : ['$1'].

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -1,111 +1,115 @@
 Definitions.
 
-Newline            = \n
-Colon              = \:
-Semicolon          = \;
-UnicodeLetter      = [A-Za-z]
-Digit              = [0-9]
-Letter             = ({UnicodeLetter}|'_')
-Whitespace         = [\s\t]
+Newline              = \n
+Colon                = \:
+Semicolon            = \;
+UnicodeLetter        = [A-Za-z]
+Digit                = [0-9]
+Letter               = ({UnicodeLetter}|'_')
+Whitespace           = [\s\t]
 
-Module             = module
-Import             = import
-Const              = const
-Func               = func
+Module               = module
+Import               = import
+Const                = const
+Func                 = func
+Match                = match
+Arrow                = \->
 
-List               = list
+List                 = list
 
-AtomType           = atom
-BoolType           = bool
-FloatType          = float
-IntType            = int
-StringType         = string
-ListType           = {List}\[Identifier\]
+AtomType             = atom
+BoolType             = bool
+FloatType            = float
+IntType              = int
+StringType           = string
+ListType             = {List}\[Identifier\]
 
-AtomLiteral        = {Colon}({UnicodeLetter}+({Digit}|{UnicodeLetter})?|\'({Digit}|{UnicodeLetter}|{Whitespace})+\')
-BoolLiteral        = (true|false)
-Exponent           = (e|E)?(\+|\-)?{Digit}+
-FloatLiteral       = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
-IntLiteral         = (\+|\-)?{Digit}+
-StringLiteral      = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
+AtomLiteral          = {Colon}({UnicodeLetter}+({Digit}|{UnicodeLetter})?|\'({Digit}|{UnicodeLetter}|{Whitespace})+\')
+BoolLiteral          = (true|false)
+Exponent             = (e|E)?(\+|\-)?{Digit}+
+FloatLiteral         = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
+IntLiteral           = (\+|\-)?{Digit}+
+StringLiteral        = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
 
-LeftBrace          = \{
-RightBrace         = \}
-LeftBracket        = \[
-RightBracket       = \]
-LeftParen          = \(
-RightParen         = \)
-Comma              = ,
-Match              = =
-Cons               = \|
-Plus               = \+
-Minus              = \-
-Multiply           = \*
-Divide             = \/
-Remainder          = \%
-And                = and
-Or                 = or
-Equal              = ==
-NotEqual           = !=
-LessThan           = <
-LessThanOrEqual    = <=
-GreaterThan        = >
-GreaterThanOrEqual = >=
+LeftBrace            = \{
+RightBrace           = \}
+LeftBracket          = \[
+RightBracket         = \]
+LeftParen            = \(
+RightParen           = \)
+Comma                = ,
+MatchOp              = =
+ConsOp               = \|
+PlusOp               = \+
+MinusOp              = \-
+MultiplyOp           = \*
+DivideOp             = \/
+RemainderOp          = \%
+AndOp                = and
+OrOp                 = or
+EqualOp              = ==
+NotEqualOp           = !=
+LessThanOp           = <
+LessThanOrEqualOp    = <=
+GreaterThanOp        = >
+GreaterThanOrEqualOp = >=
 
-Identifier         = {Letter}({Letter}|{Digit})*
+Identifier           = {Letter}({Letter}|{Digit})*
 
 Rules.
 
-{Whitespace}+        : skip_token.
-{Newline}+           : {token, {eol, TokenLine}}.
-{Semicolon}+         : {token, {';', TokenLine}}.
+{Whitespace}+          : skip_token.
+{Newline}+             : {token, {eol, TokenLine}}.
+{Semicolon}+           : {token, {';', TokenLine}}.
 
-{Module}             : {token, {module, TokenLine}}.
-{Import}             : {token, {import, TokenLine}}.
-{Const}              : {token, {const, TokenLine}}.
-{Func}               : {token, {func, TokenLine}}.
+{Module}               : {token, {module, TokenLine}}.
+{Import}               : {token, {import, TokenLine}}.
+{Const}                : {token, {const, TokenLine}}.
+{Func}                 : {token, {func, TokenLine}}.
+{Match}                : {token, {match, TokenLine}}.
+{Arrow}                : {token, {'->', TokenLine}}.
 
-{List}               : {token, {list, TokenLine}}.
+{List}                 : {token, {list, TokenLine}}.
 
-{AtomType}           : {token, {atom, TokenLine}}.
-{BoolType}           : {token, {bool, TokenLine}}.
-{FloatType}          : {token, {float, TokenLine}}.
-{IntType}            : {token, {int, TokenLine}}.
-{StringType}         : {token, {string, TokenLine}}.
-{ListType}           : {token, {list, TokenLine}}.
+{AtomType}             : {token, {atom, TokenLine}}.
+{BoolType}             : {token, {bool, TokenLine}}.
+{FloatType}            : {token, {float, TokenLine}}.
+{IntType}              : {token, {int, TokenLine}}.
+{StringType}           : {token, {string, TokenLine}}.
+{ListType}             : {token, {list, TokenLine}}.
 
-{AtomLiteral}        : A = trim_atom_markup(TokenChars, TokenLen),
-                       {token, {atom_lit, TokenLine, A}}.
-{BoolLiteral}        : {token, {bool_lit, TokenLine, list_to_atom(TokenChars)}}.
-{FloatLiteral}       : {token, {float_lit, TokenLine, list_to_float(TokenChars)}}.
-{IntLiteral}         : {token, {int_lit, TokenLine, list_to_integer(TokenChars)}}.
-{StringLiteral}      : S = trim_quotes(TokenChars, TokenLen),
-                       {token, {string_lit, TokenLine, S}}.
+{AtomLiteral}          : A = trim_atom_markup(TokenChars, TokenLen),
+                         {token, {atom_lit, TokenLine, A}}.
+{BoolLiteral}          : {token, {bool_lit, TokenLine, list_to_atom(TokenChars)}}.
+{FloatLiteral}         : {token, {float_lit, TokenLine, list_to_float(TokenChars)}}.
+{IntLiteral}           : {token, {int_lit, TokenLine, list_to_integer(TokenChars)}}.
+{StringLiteral}        : S = trim_quotes(TokenChars, TokenLen),
+                         {token, {string_lit, TokenLine, S}}.
 
-{LeftBrace}          : {token, {'{', TokenLine}}.
-{RightBrace}         : {token, {'}', TokenLine}}.
-{LeftBracket}        : {token, {'[', TokenLine}}.
-{RightBracket}       : {token, {']', TokenLine}}.
-{LeftParen}          : {token, {'(', TokenLine}}.
-{RightParen}         : {token, {')', TokenLine}}.
-{Comma}              : {token, {',', TokenLine}}.
-{Match}              : {token, {'=', TokenLine}}.
-{Cons}               : {token, {'|', TokenLine}}.
-{Plus}               : {token, {'+', TokenLine}}.
-{Minus}              : {token, {'-', TokenLine}}.
-{Multiply}           : {token, {'*', TokenLine}}.
-{Divide}             : {token, {'/', TokenLine}}.
-{Remainder}          : {token, {'%', TokenLine}}.
-{And}                : {token, {'and', TokenLine}}.
-{Or}                 : {token, {'or', TokenLine}}.
-{Equal}              : {token, {'==', TokenLine}}.
-{NotEqual}           : {token, {'!=', TokenLine}}.
-{LessThan}           : {token, {'<', TokenLine}}.
-{LessThanOrEqual}    : {token, {'<=', TokenLine}}.
-{GreaterThan}        : {token, {'>', TokenLine}}.
-{GreaterThanOrEqual} : {token, {'>=', TokenLine}}.
+{LeftBrace}            : {token, {'{', TokenLine}}.
+{RightBrace}           : {token, {'}', TokenLine}}.
+{LeftBracket}          : {token, {'[', TokenLine}}.
+{RightBracket}         : {token, {']', TokenLine}}.
+{LeftParen}            : {token, {'(', TokenLine}}.
+{RightParen}           : {token, {')', TokenLine}}.
+{Comma}                : {token, {',', TokenLine}}.
+{MatchOp}              : {token, {'=', TokenLine}}.
+{ConsOp}               : {token, {'|', TokenLine}}.
+{PlusOp}               : {token, {'+', TokenLine}}.
+{MinusOp}              : {token, {'-', TokenLine}}.
+{MultiplyOp}           : {token, {'*', TokenLine}}.
+{DivideOp}             : {token, {'/', TokenLine}}.
+{RemainderOp}          : {token, {'%', TokenLine}}.
+{AndOp}                : {token, {'and', TokenLine}}.
+{OrOp}                 : {token, {'or', TokenLine}}.
+{EqualOp}              : {token, {'==', TokenLine}}.
+{NotEqualOp}           : {token, {'!=', TokenLine}}.
+{LessThanOp}           : {token, {'<', TokenLine}}.
+{LessThanOrEqualOp}    : {token, {'<=', TokenLine}}.
+{GreaterThanOp}        : {token, {'>', TokenLine}}.
+{GreaterThanOrEqualOp} : {token, {'>=', TokenLine}}.
 
-{Identifier}         : {token, {identifier, TokenLine, TokenChars}}.
+{Identifier}           : {token, {identifier, TokenLine, TokenChars}}.
 
 Erlang code.
 

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -12,6 +12,9 @@ Module               = module
 Import               = import
 Const                = const
 Func                 = func
+Try                  = try
+Catch                = catch
+After                = after
 Match                = match
 Arrow                = \->
 
@@ -66,6 +69,9 @@ Rules.
 {Import}               : {token, {import, TokenLine}}.
 {Const}                : {token, {const, TokenLine}}.
 {Func}                 : {token, {func, TokenLine}}.
+{Try}                  : {token, {'try', TokenLine}}.
+{Catch}                : {token, {'catch', TokenLine}}.
+{After}                : {token, {'after', TokenLine}}.
 {Match}                : {token, {match, TokenLine}}.
 {Arrow}                : {token, {'->', TokenLine}}.
 

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -1729,7 +1729,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-%% %% match expressions involving function calls
+%% match expressions involving function calls
 
 typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test() ->
     RufusText =
@@ -2171,7 +2171,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_with_
     },
     ?assertEqual({error, unmatched_args, Data}, rufus_expr:typecheck_and_annotate(Forms)).
 
-%% %% match expressions with type constraint violations
+%% match expressions with type constraint violations
 
 typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test() ->
     RufusText =

--- a/rf/test/rufus_parse_try_catch_test.erl
+++ b/rf/test/rufus_parse_try_catch_test.erl
@@ -1,0 +1,17 @@
+-module(rufus_parse_try_catch_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_function_with_try_catch_block_with_single_clause_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_try_catch_test.erl
+++ b/rf/test/rufus_parse_try_catch_test.erl
@@ -13,5 +13,140 @@ parse_function_with_try_catch_block_with_single_clause_test() ->
         "}",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    Expected = [],
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            expr => [
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                            ],
+                            line => 4,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 4,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 4, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_try_after_block_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [
+                        {call, #{args => [], line => 5, spec => cleanup}}
+                    ],
+                    catch_clauses => [],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [
+                        {call, #{args => [], line => 7, spec => cleanup}}
+                    ],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            expr => [
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                            ],
+                            line => 4,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 4,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 4, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
     ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_try_catch_test.erl
+++ b/rf/test/rufus_parse_try_catch_test.erl
@@ -20,7 +20,7 @@ parse_function_with_try_catch_block_with_single_clause_test() ->
                     after_exprs => [],
                     catch_clauses => [
                         {catch_clause, #{
-                            expr => [
+                            exprs => [
                                 {atom_lit, #{
                                     line => 5,
                                     spec => error,
@@ -115,7 +115,7 @@ parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
                     ],
                     catch_clauses => [
                         {catch_clause, #{
-                            expr => [
+                            exprs => [
                                 {atom_lit, #{
                                     line => 5,
                                     spec => error,

--- a/rf/test/rufus_raw_tokenize_try_catch_test.erl
+++ b/rf/test/rufus_raw_tokenize_try_catch_test.erl
@@ -2,17 +2,155 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-string_with_function_returning_a_bool_test() ->
-    {ok, Tokens, _} = rufus_raw_tokenize:string("catch { match :error -> :error }"),
+string_with_try_catch_block_with_single_clause_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "try {\n"
+        "    \"42\"\n"
+        "} catch :error {\n"
+        "    :error\n"
+        "}"
+    ),
     ?assertEqual(
         [
-            {identifier, 1, "catch"},
+            {'try', 1},
             {'{', 1},
-            {match, 1},
-            {atom_lit, 1, error},
-            {'->', 1},
-            {atom_lit, 1, error},
-            {'}', 1}
+            {eol, 1},
+            {string_lit, 2, "42"},
+            {eol, 2},
+            {'}', 3},
+            {'catch', 3},
+            {atom_lit, 3, error},
+            {'{', 3},
+            {eol, 3},
+            {atom_lit, 4, error},
+            {eol, 4},
+            {'}', 5}
+        ],
+        Tokens
+    ).
+
+string_with_try_catch_block_with_single_clause_and_after_block_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "try {\n"
+        "    \"42\"\n"
+        "} catch :error {\n"
+        "    :error\n"
+        "} after {\n"
+        "    cleanup()\n"
+        "}"
+    ),
+    ?assertEqual(
+        [
+            {'try', 1},
+            {'{', 1},
+            {eol, 1},
+            {string_lit, 2, "42"},
+            {eol, 2},
+            {'}', 3},
+            {'catch', 3},
+            {atom_lit, 3, error},
+            {'{', 3},
+            {eol, 3},
+            {atom_lit, 4, error},
+            {eol, 4},
+            {'}', 5},
+            {'after', 5},
+            {'{', 5},
+            {eol, 5},
+            {identifier, 6, "cleanup"},
+            {'(', 6},
+            {')', 6},
+            {eol, 6},
+            {'}', 7}
+        ],
+        Tokens
+    ).
+
+string_with_try_catch_block_with_multiple_clauses_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "try {\n"
+        "    \"42\"\n"
+        "} catch {\n"
+        "match :first ->\n"
+        "    :first\n"
+        "match :second ->\n"
+        "    :second\n"
+        "}"
+    ),
+    ?assertEqual(
+        [
+            {'try', 1},
+            {'{', 1},
+            {eol, 1},
+            {string_lit, 2, "42"},
+            {eol, 2},
+            {'}', 3},
+            {'catch', 3},
+            {'{', 3},
+            {eol, 3},
+            {match, 4},
+            {atom_lit, 4, first},
+            {'->', 4},
+            {eol, 4},
+            {atom_lit, 5, first},
+            {eol, 5},
+            {match, 6},
+            {atom_lit, 6, second},
+            {'->', 6},
+            {eol, 6},
+            {atom_lit, 7, second},
+            {eol, 7},
+            {'}', 8}
+        ],
+        Tokens
+    ).
+
+string_with_try_catch_block_with_multiple_clauses_and_after_block_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "try {\n"
+        "    \"42\"\n"
+        "} catch {\n"
+        "match :first ->\n"
+        "    :first\n"
+        "match :second ->\n"
+        "    :second\n"
+        "} after {\n"
+        "    cleanup()\n"
+        "}\n"
+    ),
+    ?assertEqual(
+        [
+            {'try', 1},
+            {'{', 1},
+            {eol, 1},
+            {string_lit, 2, "42"},
+            {eol, 2},
+            {'}', 3},
+            {'catch', 3},
+            {'{', 3},
+            {eol, 3},
+            {match, 4},
+            {atom_lit, 4, first},
+            {'->', 4},
+            {eol, 4},
+            {atom_lit, 5, first},
+            {eol, 5},
+            {match, 6},
+            {atom_lit, 6, second},
+            {'->', 6},
+            {eol, 6},
+            {atom_lit, 7, second},
+            {eol, 7},
+            {'}', 8},
+            {'after', 8},
+            {'{', 8},
+            {eol, 8},
+            {identifier, 9, "cleanup"},
+            {'(', 9},
+            {')', 9},
+            {eol, 9},
+            {'}', 10},
+            {eol, 10}
         ],
         Tokens
     ).

--- a/rf/test/rufus_raw_tokenize_try_catch_test.erl
+++ b/rf/test/rufus_raw_tokenize_try_catch_test.erl
@@ -1,0 +1,18 @@
+-module(rufus_raw_tokenize_try_catch_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+string_with_function_returning_a_bool_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("catch { match :error -> :error }"),
+    ?assertEqual(
+        [
+            {identifier, 1, "catch"},
+            {'{', 1},
+            {match, 1},
+            {atom_lit, 1, error},
+            {'->', 1},
+            {atom_lit, 1, error},
+            {'}', 1}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_tokenize_test.erl
+++ b/rf/test/rufus_tokenize_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% %% Automatic semicolon insertion.
+%% Automatic semicolon insertion.
 
 string_inserts_semicolon_after_last_identifier_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("module empty"),
@@ -256,7 +256,7 @@ string_does_not_insert_a_duplicate_semicolon_for_the_closing_brace_when_the_last
         Tokens
     ).
 
-%% %% Arbitrary whitespace.
+%% Arbitrary whitespace.
 
 string_with_newlines_test() ->
     RufusText =
@@ -325,7 +325,7 @@ string_with_newline_in_expression_after_reserved_word_test() ->
         Tokens
     ).
 
-%% %% Lists
+%% Lists
 
 string_with_list_test() ->
     RufusText = "func Numbers() list[int] { list[int]{42, 17, 3} }",


### PR DESCRIPTION
`rufus_raw_tokenizer` can read new `try`, `catch`, `after`, `match`, and `->` tokens to scan try/catch/after expressions. Tokens that refer to operators now have an `Op` suffix to clearly differentiate them from other types of tokens. `rufus_parse` has support to parse simple permutations of try/catch/after expressions. Support for multi-clause catch blocks is not implemented.