### PR TITLE
compiler: Rename match form to match_op

### DIFF
--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -131,7 +131,7 @@ forms(Acc, [{int_lit, _Context} = IntLit | T]) ->
 forms(Acc, [{list_lit, _Context} = ListLit | T]) ->
     Form = box(ListLit),
     forms([Form | Acc], T);
-forms(Acc, [{match, #{line := Line, left := Left, right := Right}} | T]) ->
+forms(Acc, [{match_op, #{line := Line, left := Left, right := Right}} | T]) ->
     {ok, [LeftForm]} = forms([], [Left]),
     {ok, [RightForm]} = forms([], [Right]),
     Form = {match, Line, LeftForm, RightForm},
@@ -237,12 +237,12 @@ guard_forms(Acc, []) ->
 %% float and int are all represented as scalar values in Erlang, while string is
 %% represented as an annotated {string, BinaryValue} tuple.
 -spec box(
-    atom_lit_form() |
-    bool_lit_form() |
-    float_lit_form() |
-    int_lit_form() |
-    list_lit_form() |
-    string_lit_form()
+    atom_lit_form()
+    | bool_lit_form()
+    | float_lit_form()
+    | int_lit_form()
+    | list_lit_form()
+    | string_lit_form()
 ) -> (erlang3_form() | erlang4_form()).
 box({atom_lit, #{spec := Value, line := Line}}) ->
     {atom, Line, Value};

--- a/rf/src/rufus_erlang.erl
+++ b/rf/src/rufus_erlang.erl
@@ -237,12 +237,12 @@ guard_forms(Acc, []) ->
 %% float and int are all represented as scalar values in Erlang, while string is
 %% represented as an annotated {string, BinaryValue} tuple.
 -spec box(
-    atom_lit_form()
-    | bool_lit_form()
-    | float_lit_form()
-    | int_lit_form()
-    | list_lit_form()
-    | string_lit_form()
+    atom_lit_form() |
+    bool_lit_form() |
+    float_lit_form() |
+    int_lit_form() |
+    list_lit_form() |
+    string_lit_form()
 ) -> (erlang3_form() | erlang4_form()).
 box({atom_lit, #{spec := Value, line := Line}}) ->
     {atom, Line, Value};

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -28,9 +28,9 @@
     make_import/2,
     make_literal/3,
     make_literal/4,
-    make_match/3,
-    make_match_left/1,
-    make_match_right/1,
+    make_match_op/3,
+    make_match_op_left/1,
+    make_match_op_right/1,
     make_module/2,
     make_param/3,
     make_try_catch_after/4,
@@ -234,23 +234,23 @@ make_literal(list, Type, Elements, Line) ->
         line => Line
     }}.
 
-%% match form builder API
+%% match_op form builder API
 
-%% make_match returns a form for a match expression.
--spec make_match(rufus_form(), rufus_form(), integer()) ->
-    {match, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
-make_match(Left, Right, Line) ->
-    {match, #{left => Left, right => Right, line => Line}}.
+%% make_match_op returns a form for a match_op expression.
+-spec make_match_op(rufus_form(), rufus_form(), integer()) ->
+    {match_op, #{left => rufus_form(), right => rufus_form(), line => integer()}}.
+make_match_op(Left, Right, Line) ->
+    {match_op, #{left => Left, right => Right, line => Line}}.
 
-%% make_match_left returns a left form from a binary_op or match expression.
--spec make_match_left(match_form()) -> match_left_form().
-make_match_left({match, #{line := Line}}) ->
-    {match_left, #{line => Line}}.
+%% make_match_op_left returns a left form from a binary_op or match_op expression.
+-spec make_match_op_left(match_op_form()) -> match_op_left_form().
+make_match_op_left({match_op, #{line := Line}}) ->
+    {match_op_left, #{line => Line}}.
 
-%% make_match_right returns a right form from a binary_op or match expression.
--spec make_match_right(match_form()) -> match_right_form().
-make_match_right({match, #{line := Line}}) ->
-    {match_right, #{line => Line}}.
+%% make_match_op_right returns a right form from a binary_op or match_op expression.
+-spec make_match_op_right(match_op_form()) -> match_op_right_form().
+make_match_op_right({match_op, #{line := Line}}) ->
+    {match_op_right, #{line => Line}}.
 
 %% module form builder API
 

--- a/rf/src/rufus_forms.erl
+++ b/rf/src/rufus_forms.erl
@@ -40,7 +40,7 @@ each([Form = {list_lit, #{elements := Elements}} | T], Fun) ->
     each(Elements, Fun),
     Fun(Form),
     each(T, Fun);
-each([Form = {match, #{left := Left, right := Right}} | T], Fun) ->
+each([Form = {match_op, #{left := Left, right := Right}} | T], Fun) ->
     Fun(Left),
     Fun(Right),
     Fun(Form),
@@ -86,10 +86,10 @@ map(Acc, [{list_lit, Context = #{elements := Elements}} | T], Fun) ->
     AnnotatedElements = map(Elements, Fun),
     AnnotatedForm = Fun({list_lit, Context#{elements => AnnotatedElements}}),
     map([AnnotatedForm | Acc], T, Fun);
-map(Acc, [{match, Context = #{left := Left, right := Right}} | T], Fun) ->
+map(Acc, [{match_op, Context = #{left := Left, right := Right}} | T], Fun) ->
     AnnotatedLeft = Fun(Left),
     AnnotatedRight = Fun(Right),
-    AnnotatedForm = Fun({match, Context#{left => AnnotatedLeft, right => AnnotatedRight}}),
+    AnnotatedForm = Fun({match_op, Context#{left => AnnotatedLeft, right => AnnotatedRight}}),
     map([AnnotatedForm | Acc], T, Fun);
 map(Acc, [Form | T], Fun) ->
     AnnotatedForm = Fun(Form),

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -6,7 +6,7 @@ Nonterminals
     root decl
     type types block param params args
     expr exprs literal_expr catch_expr
-    binary_op call cons match match_param
+    binary_op call cons match_op match_op_param
     list_lit list_type.
 
 Terminals
@@ -102,7 +102,7 @@ expr  -> literal_expr            : '$1'.
 expr  -> identifier              : rufus_form:make_identifier(list_to_atom(text('$1')), line('$1')).
 expr  -> binary_op               : '$1'.
 expr  -> cons                    : '$1'.
-expr  -> match                   : '$1'.
+expr  -> match_op                : '$1'.
 expr  -> call                    : '$1'.
 expr  -> list_lit                : '$1'.
 expr  -> func '(' params ')' type '{' exprs '}' :
@@ -123,8 +123,8 @@ list_lit -> list_type '{' args '}' :
 
 list_type -> list '[' type ']'   : rufus_form:make_type(list, '$3', line('$1')).
 
-match -> expr '=' expr           : rufus_form:make_match('$1', '$3', line('$2')).
-match_param -> expr '=' param    : rufus_form:make_match('$1', '$3', line('$2')).
+match_op -> expr '=' expr        : rufus_form:make_match_op('$1', '$3', line('$2')).
+match_op_param -> expr '=' param : rufus_form:make_match_op('$1', '$3', line('$2')).
 
 params -> param ',' params       : ['$1'|'$3'].
 params -> param                  : ['$1'].
@@ -137,7 +137,7 @@ param -> float_lit               : rufus_form:make_literal(float, text('$1'), li
 param -> int_lit                 : rufus_form:make_literal(int, text('$1'), line('$1')).
 param -> list_lit                : '$1'.
 param -> string_lit              : rufus_form:make_literal(string, list_to_binary(text('$1')), line('$1')).
-param -> match_param             : '$1'.
+param -> match_op_param          : '$1'.
 
 type -> atom                     : rufus_form:make_type(atom, line('$1')).
 type -> bool                     : rufus_form:make_type(bool, line('$1')).

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -382,17 +382,17 @@ lookup_identifier_type([{list_lit, #{type := Type}} | _T], Stack) ->
             throw({error, unknown_identifier, Data})
     end;
 lookup_identifier_type(
-    [{match_left, _Context1} | [{match, #{right := {_FormSpec, #{type := Type}}}} | _T]],
+    [{match_op_left, _Context1} | [{match_op, #{right := {_FormSpec, #{type := Type}}}} | _T]],
     _Stack
 ) ->
     {ok, Type};
 lookup_identifier_type(
-    [{match_right, _Context1} | [{match, #{right := {_FormSpec, #{type := Type}}}} | _T]],
+    [{match_op_right, _Context1} | [{match_op, #{right := {_FormSpec, #{type := Type}}}} | _T]],
     _Stack
 ) ->
     {ok, Type};
 lookup_identifier_type(
-    [{match_right, _Context1} | [{match, #{right := _Context2}} | _T]],
+    [{match_op_right, _Context1} | [{match_op, #{right := _Context2}} | _T]],
     Stack
 ) ->
     Data = #{stack => Stack},
@@ -412,7 +412,7 @@ allow_variable_binding(Stack) ->
         fun
             ({func_params, _Context}) ->
                 true;
-            ({match_left, _Context}) ->
+            ({match_op_left, _Context}) ->
                 true;
             (_Form) ->
                 false

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -67,7 +67,7 @@
 -type param_form() :: {param, context()}.
 -type identifier_form() :: {identifier, context()}.
 -type binary_op_form() :: {binary_op, context()}.
--type match_form() :: {match, context()}.
+-type match_op_form() :: {match_op, context()}.
 -type call_form() :: {call, context()}.
 
 %% Virtual forms
@@ -78,8 +78,8 @@
 -type cons_tail_form() :: {cons_tail, context()}.
 -type func_exprs_form() :: {func_exprs, context()}.
 -type func_params_form() :: {func_params, context()}.
--type match_left_form() :: {match_left, context()}.
--type match_right_form() :: {match_right, context()}.
+-type match_op_left_form() :: {match_op_left, context()}.
+-type match_op_right_form() :: {match_op_right, context()}.
 
 %% Rufus forms
 
@@ -98,7 +98,7 @@
     | identifier_form()
     | type_form()
     | binary_op_form()
-    | match_form()
+    | match_op_form()
     | call_form().
 
 %% rufus_forms is a list of rufus_form instances and typically represents an

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -40,20 +40,20 @@
 -type cons_form() :: {cons, context()}.
 
 -type literal_form() ::
-    atom_lit_form()
-    | bool_lit_form()
-    | float_lit_form()
-    | int_lit_form()
-    | string_lit_form()
-    | list_lit_form()
-    | cons_form().
+    atom_lit_form() |
+    bool_lit_form() |
+    float_lit_form() |
+    int_lit_form() |
+    string_lit_form() |
+    list_lit_form() |
+    cons_form().
 
 -type literal() ::
-    atom
-    | bool
-    | float
-    | int
-    | string.
+    atom |
+    bool |
+    float |
+    int |
+    string.
 
 %% Operators
 
@@ -85,21 +85,21 @@
 
 %% rufus_form represents a node in the parse tree.
 -type rufus_form() ::
-    atom_lit_form()
-    | bool_lit_form()
-    | float_lit_form()
-    | int_lit_form()
-    | string_lit_form()
-    | list_lit_form()
-    | cons_form()
-    | module_form()
-    | func_form()
-    | param_form()
-    | identifier_form()
-    | type_form()
-    | binary_op_form()
-    | match_op_form()
-    | call_form().
+    atom_lit_form() |
+    bool_lit_form() |
+    float_lit_form() |
+    int_lit_form() |
+    string_lit_form() |
+    list_lit_form() |
+    cons_form() |
+    module_form() |
+    func_form() |
+    param_form() |
+    identifier_form() |
+    type_form() |
+    binary_op_form() |
+    match_op_form() |
+    call_form().
 
 %% rufus_forms is a list of rufus_form instances and typically represents an
 %% entire module.
@@ -115,10 +115,10 @@
 -type unmatched_operand_type_error() :: unmatched_operand_type.
 -type unsupported_operand_type_error() :: unsupported_operand_type.
 -type rufus_error() ::
-    unknown_variable_error()
-    | unmatched_return_type_error()
-    | unmatched_operand_type_error()
-    | unsupported_operand_type_error().
+    unknown_variable_error() |
+    unmatched_return_type_error() |
+    unmatched_operand_type_error() |
+    unsupported_operand_type_error().
 
 %% Erlang forms
 
@@ -126,8 +126,8 @@
 -type erlang4_form() :: {_, _, _, _}.
 -type erlang5_form() :: {_, _, _, _, _}.
 -type erlang_form() ::
-    erlang3_form()
-    | erlang4_form()
-    | erlang5_form().
+    erlang3_form() |
+    erlang4_form() |
+    erlang5_form().
 
 -type export_attribute_erlang_form() :: {attribute, integer(), export, list()}.

--- a/rf/test/rufus_compile_match_test.erl
+++ b/rf/test/rufus_compile_match_test.erl
@@ -185,7 +185,7 @@ eval_function_with_a_match_that_has_a_left_call_operand_test() ->
         "    ",
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {call, #{
                         args => [],
@@ -243,7 +243,7 @@ eval_function_with_a_match_that_has_a_left_binary_op_operand_with_a_call_operand
         "    ",
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {binary_op, #{
                         left =>
@@ -320,7 +320,7 @@ eval_function_with_a_match_that_has_a_left_and_right_call_operand_test() ->
         "    ",
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {call, #{
                         args => [],
@@ -483,8 +483,8 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
         },
         locals => #{value => [{type, #{line => 4, spec => int}}]},
         stack => [
-            {match_right, #{line => 5}},
-            {match, #{
+            {match_op_right, #{line => 5}},
+            {match_op, #{
                 left => {identifier, #{line => 5, spec => value}},
                 line => 5,
                 right => {identifier, #{line => 5, spec => unbound}}
@@ -492,7 +492,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
             {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 4, spec => value}},
                         line => 4,
                         right =>
@@ -502,7 +502,7 @@ eval_function_with_a_match_that_has_an_unbound_variable_test() ->
                                 type => {type, #{line => 4, spec => int}}
                             }}
                     }},
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 5, spec => value}},
                         line => 5,
                         right =>
@@ -552,8 +552,8 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
         },
         locals => #{},
         stack => [
-            {match_right, #{line => 4}},
-            {match, #{
+            {match_op_right, #{line => 4}},
+            {match_op, #{
                 left => {identifier, #{line => 4, spec => unbound1}},
                 line => 4,
                 right => {identifier, #{line => 4, spec => unbound2}}
@@ -561,7 +561,7 @@ eval_function_with_a_match_that_has_unbound_variables_test() ->
             {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
-                    {match, #{
+                    {match_op, #{
                         left =>
                             {identifier, #{line => 4, spec => unbound1}},
                         line => 4,

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -499,7 +499,7 @@ typecheck_and_annotate_function_call_with_match_argument_test() ->
         }},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {int_lit, #{
                             line => 4,

--- a/rf/test/rufus_expr_func_test.erl
+++ b/rf/test/rufus_expr_func_test.erl
@@ -229,7 +229,7 @@ typecheck_and_annotate_does_not_rely_on_function_definition_order_test() ->
             ],
             line => 6,
             params => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {list_lit, #{
                             elements => [
@@ -1442,7 +1442,7 @@ typecheck_and_annotate_function_returning_a_function_variable_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -1586,7 +1586,7 @@ typecheck_and_annotate_function_returning_a_nested_function_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -2486,7 +2486,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_list_literal_test() ->
                     ],
                     line => 4,
                     params => [
-                        {match, #{
+                        {match_op, #{
                             left =>
                                 {identifier, #{
                                     line => 4,
@@ -2698,7 +2698,7 @@ typecheck_and_annotate_for_anonymous_function_taking_a_match_param_test() ->
                     ],
                     line => 4,
                     params => [
-                        {match, #{
+                        {match_op, #{
                             left =>
                                 {int_lit, #{
                                     line => 4,
@@ -2982,8 +2982,8 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
             ]
         },
         stack => [
-            {match_right, #{line => 8}},
-            {match, #{
+            {match_op_right, #{line => 8}},
+            {match_op, #{
                 left => {identifier, #{line => 8, spec => escape}},
                 line => 8,
                 right => {identifier, #{line => 8, spec => num}}
@@ -2991,13 +2991,13 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
             {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 4, spec => fn}},
                         line => 4,
                         right =>
                             {func, #{
                                 exprs => [
-                                    {match, #{
+                                    {match_op, #{
                                         left =>
                                             {identifier, #{line => 5, spec => num}},
                                         line => 5,
@@ -3023,7 +3023,7 @@ typecheck_and_annotate_does_not_allow_locals_to_escape_anonymous_function_scope_
                                     }}
                             }}
                     }},
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 8, spec => escape}},
                         line => 8,
                         right => {identifier, #{line => 8, spec => num}}
@@ -3088,7 +3088,7 @@ typecheck_and_annotate_function_with_mixed_params_and_patterns_in_parameter_list
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -727,7 +727,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -747,7 +747,7 @@ typecheck_and_annotate_with_function_returning_a_cons_literal_with_variable_pair
                     type =>
                         {type, #{line => 4, spec => int}}
                 }},
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 5,

--- a/rf/test/rufus_expr_match_test.erl
+++ b/rf/test/rufus_expr_match_test.erl
@@ -20,7 +20,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_atom_literal_test() -
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -87,7 +87,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_bool_literal_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -154,7 +154,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_float_literal_test() -
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -221,7 +221,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_an_int_literal_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -282,7 +282,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_string_literal_test() 
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -349,7 +349,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_of_int_literal_te
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -462,7 +462,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_list_literal_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {list_lit, #{
                             elements => [
@@ -603,7 +603,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head =>
@@ -810,7 +810,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_head_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head =>
@@ -973,7 +973,7 @@ typecheck_and_annotate_function_with_a_match_that_binds_a_cons_tail_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head =>
@@ -1163,7 +1163,7 @@ typecheck_and_annotate_function_taking_a_match_pattern_test() ->
             ],
             line => 3,
             params => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -1237,7 +1237,7 @@ typecheck_and_annotate_function_taking_a_match_pattern_with_a_literal_left_opera
             ],
             line => 3,
             params => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {int_lit, #{
                             line => 3,
@@ -1300,7 +1300,7 @@ typecheck_and_annotate_function_taking_a_cons_in_match_pattern_test() ->
             ],
             line => 3,
             params => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head =>
@@ -1486,7 +1486,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -1506,7 +1506,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_t
                     type =>
                         {type, #{line => 4, spec => int}}
                 }},
-                {match, #{
+                {match_op, #{
                     left =>
                         {binary_op, #{
                             left =>
@@ -1577,7 +1577,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_binary_op_operand_
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -1651,7 +1651,7 @@ typecheck_and_annotate_function_with_a_match_that_has_left_and_right_binary_op_o
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {binary_op, #{
                             left =>
@@ -1769,7 +1769,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_right_call_operand_test(
         }},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,
@@ -1826,7 +1826,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_call_operand_test()
     {ok, Forms} = rufus_parse:parse(Tokens),
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {call, #{
                         args => [],
@@ -1886,7 +1886,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
     {ok, Forms} = rufus_parse:parse(Tokens),
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {binary_op, #{
                         left =>
@@ -1967,7 +1967,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_binary_op_operand_w
     {ok, Forms} = rufus_parse:parse(Tokens),
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {binary_op, #{
                         left =>
@@ -2035,7 +2035,7 @@ typecheck_and_annotate_function_with_a_match_that_has_a_left_and_right_call_oper
     {ok, Forms} = rufus_parse:parse(Tokens),
     Data = #{
         form =>
-            {match, #{
+            {match_op, #{
                 left =>
                     {call, #{
                         args => [],
@@ -2209,8 +2209,8 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
             value => [{type, #{line => 4, spec => int}}]
         },
         stack => [
-            {match_right, #{line => 5}},
-            {match, #{
+            {match_op_right, #{line => 5}},
+            {match_op, #{
                 left => {identifier, #{line => 5, spec => value}},
                 line => 5,
                 right => {identifier, #{line => 5, spec => unbound}}
@@ -2218,7 +2218,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
             {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 4, spec => value}},
                         line => 4,
                         right =>
@@ -2232,7 +2232,7 @@ typecheck_and_annotate_function_with_a_match_that_has_an_unbound_variable_test()
                                     }}
                             }}
                     }},
-                    {match, #{
+                    {match_op, #{
                         left => {identifier, #{line => 5, spec => value}},
                         line => 5,
                         right =>
@@ -2286,8 +2286,8 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
         },
         locals => #{},
         stack => [
-            {match_right, #{line => 4}},
-            {match, #{
+            {match_op_right, #{line => 4}},
+            {match_op, #{
                 left => {identifier, #{line => 4, spec => unbound1}},
                 line => 4,
                 right => {identifier, #{line => 4, spec => unbound2}}
@@ -2295,7 +2295,7 @@ typecheck_and_annotate_function_with_a_match_that_has_unbound_variables_test() -
             {func_exprs, #{line => 3}},
             {func, #{
                 exprs => [
-                    {match, #{
+                    {match_op, #{
                         left =>
                             {identifier, #{line => 4, spec => unbound1}},
                         line => 4,

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -279,46 +279,46 @@ make_literal_for_string_lit_test() ->
         }},
     ?assertEqual(Expected, rufus_form:make_literal(string, <<"hello">>, 9)).
 
-make_match_test() ->
+make_match_op_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
     Expected =
-        {match, #{
+        {match_op, #{
             left => Left,
             right => Right,
             line => 3
         }},
-    ?assertEqual(Expected, rufus_form:make_match(Left, Right, 3)).
+    ?assertEqual(Expected, rufus_form:make_match_op(Left, Right, 3)).
 
-make_match_left_test() ->
+make_match_op_left_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
     Form =
-        {match, #{
+        {match_op, #{
             left => Left,
             right => Right,
             line => 3
         }},
     Expected =
-        {match_left, #{
+        {match_op_left, #{
             line => 3
         }},
-    ?assertEqual(Expected, rufus_form:make_match_left(Form)).
+    ?assertEqual(Expected, rufus_form:make_match_op_left(Form)).
 
-make_match_right_test() ->
+make_match_op_right_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
     Form =
-        {match, #{
+        {match_op, #{
             left => Left,
             right => Right,
             line => 3
         }},
     Expected =
-        {match_right, #{
+        {match_op_right, #{
             line => 3
         }},
-    ?assertEqual(Expected, rufus_form:make_match_right(Form)).
+    ?assertEqual(Expected, rufus_form:make_match_op_right(Form)).
 
 make_module_test() ->
     Expected =

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -115,10 +115,10 @@ map_with_list_lit_test() ->
 map_with_match_test() ->
     Left = rufus_form:make_identifier(n, 3),
     Right = rufus_form:make_identifier(m, 3),
-    Form = rufus_form:make_match(Left, Right, 3),
+    Form = rufus_form:make_match_op(Left, Right, 3),
     ?assertMatch(
         [
-            {match, #{
+            {match_op, #{
                 left := {_, #{annotated := true}},
                 right := {_, #{annotated := true}},
                 annotated := true

--- a/rf/test/rufus_parse_func_test.erl
+++ b/rf/test/rufus_parse_func_test.erl
@@ -781,7 +781,7 @@ parse_function_returning_a_function_variable_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left => {identifier, #{line => 3, spec => fn}},
                     line => 3,
                     right =>
@@ -853,7 +853,7 @@ parse_function_returning_a_nested_function_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left => {identifier, #{line => 4, spec => f}},
                     line => 4,
                     right =>
@@ -934,7 +934,7 @@ parse_function_with_mixed_params_and_patterns_in_parameter_list_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left => {identifier, #{line => 4, spec => item}},
                     line => 4,
                     right =>

--- a/rf/test/rufus_parse_list_test.erl
+++ b/rf/test/rufus_parse_list_test.erl
@@ -503,7 +503,7 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -521,7 +521,7 @@ parse_function_that_creates_cons_expression_from_head_and_tail_variables_test() 
                                 }}
                         }}
                 }},
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 4,

--- a/rf/test/rufus_parse_match_test.erl
+++ b/rf/test/rufus_parse_match_test.erl
@@ -15,7 +15,7 @@ parse_function_with_a_match_that_binds_an_atom_literal_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -63,7 +63,7 @@ parse_function_with_a_match_that_binds_a_bool_literal_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -111,7 +111,7 @@ parse_function_with_a_match_that_binds_a_float_literal_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -159,7 +159,7 @@ parse_function_with_a_match_that_binds_a_string_literal_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -207,7 +207,7 @@ parse_function_with_a_match_that_binds_a_list_literal_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {list_lit, #{
                             elements => [{identifier, #{line => 3, spec => name}}],
@@ -269,7 +269,7 @@ parse_function_with_a_match_that_binds_a_cons_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head => {identifier, #{line => 4, spec => head}},
@@ -347,7 +347,7 @@ parse_function_with_a_match_that_binds_a_cons_head_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head => {identifier, #{line => 4, spec => head}},
@@ -441,7 +441,7 @@ parse_function_with_a_match_that_binds_a_cons_tail_test() ->
         {module, #{line => 2, spec => example}},
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {cons, #{
                             head =>
@@ -515,7 +515,7 @@ parse_function_with_a_match_that_binds_a_variable_test() ->
     Expected = [
         {func, #{
             exprs => [
-                {match, #{
+                {match_op, #{
                     left =>
                         {identifier, #{
                             line => 3,
@@ -571,7 +571,7 @@ parse_function_taking_a_match_pattern_test() ->
             ],
             line => 1,
             params => [
-                {match, #{
+                {match_op, #{
                     left => {identifier, #{line => 1, spec => b}},
                     line => 1,
                     right =>


### PR DESCRIPTION
The `match` form has been renamed to `match_op` to be consistent with `binary_op`. Callsites and tests have been updated.