### PR TITLE
compiler: Parse try/catch/after expressions with multiple catch clauses

### DIFF
--- a/rf/test/rufus_parse_try_catch_test.erl
+++ b/rf/test/rufus_parse_try_catch_test.erl
@@ -56,6 +56,136 @@ parse_function_with_try_catch_block_with_single_clause_test() ->
     ],
     ?assertEqual(Expected, Forms).
 
+parse_function_with_try_catch_block_with_single_match_clause_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "    match :error ->\n"
+        "        :error\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 6,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_try_catch_block_with_multiple_clauses_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "    match :error ->\n"
+        "        :error\n"
+        "    match :failure ->\n"
+        "        :failure\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 6,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                        }},
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 8,
+                                    spec => failure,
+                                    type =>
+                                        {type, #{line => 8, spec => atom}}
+                                }}
+                            ],
+                            line => 7,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 7,
+                                    spec => failure,
+                                    type =>
+                                        {type, #{line => 7, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
 parse_function_with_try_after_block_test() ->
     RufusText =
         "func example() atom {\n"
@@ -130,6 +260,140 @@ parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
                                     spec => error,
                                     type =>
                                         {type, #{line => 4, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_try_catch_block_with_single_match_clause_and_after_block_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "    match :error ->\n"
+        "        :error\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [{call, #{args => [], line => 8, spec => cleanup}}],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 6,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => example
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_try_catch_block_with_multiple_clauses_and_after_block_test() ->
+    RufusText =
+        "func example() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "    match :error ->\n"
+        "        :error\n"
+        "    match :error ->\n"
+        "        :failure\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [{call, #{args => [], line => 10, spec => cleanup}}],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 6,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                        }},
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 8,
+                                    spec => failure,
+                                    type =>
+                                        {type, #{line => 8, spec => atom}}
+                                }}
+                            ],
+                            line => 7,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 7,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 7, spec => atom}}
                                 }}
                         }}
                     ],


### PR DESCRIPTION
`rufus_parse` has support to parse try/catch/after expressions with multiple catch clauses.