### PR TITLE
compiler: Typecheck try/catch/after expressions

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -574,7 +574,10 @@ is_constant_expr(_Form) ->
 %% try/catch/after helpers
 
 %% typecheck_and_annotate_catch_clause typechecks and annotates the match
-%% expression and body expressions of a catch block.
+%% expression and body expressions of a catch block. Return values:
+%% - `{ok, AnnotatedForm}` if no issues are found. The catch_clause form is
+%%   annotated with type information.
+%% - An error is thrown is `rufus_type:resolve/3` returns an error.
 -spec typecheck_and_annotate_catch_clause(
     rufus_stack(),
     globals(),

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -585,15 +585,17 @@ typecheck_and_annotate_catch_clause(
     Stack,
     Globals,
     Locals,
-    {catch_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}}
+    Form = {catch_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}}
 ) ->
+    CatchClauseStack = [Form | Stack],
     {ok, NewLocals, [AnnotatedMatchExpr]} = typecheck_and_annotate(
         [],
-        Stack,
+        CatchClauseStack,
         Globals,
         Locals,
         [MatchExpr]
     ),
+
     {ok, _, AnnotatedExprs} = typecheck_and_annotate([], Stack, Globals, NewLocals, Exprs),
     AnnotatedForm1 =
         {catch_clause, Context#{

--- a/rf/src/rufus_forms.erl
+++ b/rf/src/rufus_forms.erl
@@ -66,6 +66,13 @@ map(Acc, [{call, Context = #{args := Args}} | T], Fun) ->
     AnnotatedArgs = map(Args, Fun),
     AnnotatedForm = Fun({call, Context#{args => AnnotatedArgs}}),
     map([AnnotatedForm | Acc], T, Fun);
+map(Acc, [{catch_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}} | T], Fun) ->
+    AnnotatedMatchExpr = Fun(MatchExpr),
+    AnnotatedExprs = map(Exprs, Fun),
+    AnnotatedForm = Fun(
+        {catch_clause, Context#{match_expr => AnnotatedMatchExpr, exprs => AnnotatedExprs}}
+    ),
+    map([AnnotatedForm | Acc], T, Fun);
 map(Acc, [{cons, Context = #{head := Head, tail := Tail}} | T], Fun) ->
     AnnotatedHead = Fun(Head),
     AnnotatedTail =
@@ -90,6 +97,30 @@ map(Acc, [{match_op, Context = #{left := Left, right := Right}} | T], Fun) ->
     AnnotatedLeft = Fun(Left),
     AnnotatedRight = Fun(Right),
     AnnotatedForm = Fun({match_op, Context#{left => AnnotatedLeft, right => AnnotatedRight}}),
+    map([AnnotatedForm | Acc], T, Fun);
+map(
+    Acc,
+    [
+        {try_catch_after,
+            Context = #{
+                try_exprs := TryExprs,
+                catch_clauses := CatchClauses,
+                after_exprs := AfterExprs
+            }}
+        | T
+    ],
+    Fun
+) ->
+    AnnotatedTryExprs = map(TryExprs, Fun),
+    AnnotatedCatchClauses = map(CatchClauses, Fun),
+    AnnotatedAfterExprs = map(AfterExprs, Fun),
+    AnnotatedForm = Fun(
+        {try_catch_after, Context#{
+            try_exprs => AnnotatedTryExprs,
+            catch_clauses => AnnotatedCatchClauses,
+            after_exprs => AnnotatedAfterExprs
+        }}
+    ),
     map([AnnotatedForm | Acc], T, Fun);
 map(Acc, [Form | T], Fun) ->
     AnnotatedForm = Fun(Form),

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -408,12 +408,14 @@ lookup_identifier_type([], Stack) ->
     throw({error, unknown_type, Data}).
 
 %% allow_variable_binding returns true if the identifier is part of an
-%% expression in a function parameter list or is part of the left operand of a match
-%% expression.
+%% expression in a function parameter list, is part of the left operand of a
+%% match expression, or is part of a catch clause expression.
 -spec allow_variable_binding(rufus_stack()) -> boolean().
 allow_variable_binding(Stack) ->
     lists:any(
         fun
+            ({catch_clause, _Context}) ->
+                true;
             ({func_params, _Context}) ->
                 true;
             ({match_op_left, _Context}) ->

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -42,10 +42,14 @@ resolve_type(Stack, Globals, Form = {binary_op, _Context}) ->
     resolve_binary_op_type(Stack, Globals, Form);
 resolve_type(Stack, Globals, Form = {call, _Context}) ->
     resolve_call_type(Stack, Globals, Form);
+resolve_type(Stack, Globals, Form = {catch_clause, _Context}) ->
+    resolve_catch_clause_type(Stack, Globals, Form);
 resolve_type(_Stack, _Globals, {func, #{return_type := Type}}) ->
     {ok, Type};
 resolve_type(Stack, Globals, Form = {identifier, _Context}) ->
-    resolve_identifier_type(Stack, Globals, Form).
+    resolve_identifier_type(Stack, Globals, Form);
+resolve_type(Stack, Globals, Form = {try_catch_after, _Context}) ->
+    resolve_try_catch_after_type(Stack, Globals, Form).
 
 %% binary_op form helpers
 
@@ -443,3 +447,16 @@ resolve_list_lit_type(Stack, Globals, Form = {list_lit, #{elements := Elements, 
             Data = #{form => Form},
             throw({error, unexpected_element_type, Data})
     end.
+
+%% %% try/catch/after helpers
+
+-spec resolve_catch_clause_type(rufus_stack(), globals(), catch_clause_form()) -> {ok, type_form()}.
+resolve_catch_clause_type(Stack, Globals, {catch_clause, #{exprs := Exprs}}) ->
+    LastExpr = lists:last(Exprs),
+    resolve_type(Stack, Globals, LastExpr).
+
+-spec resolve_try_catch_after_type(rufus_stack(), globals(), try_catch_after_form()) ->
+    {ok, type_form()}.
+resolve_try_catch_after_type(Stack, Globals, {try_catch_after, #{try_exprs := TryExprs}}) ->
+    LastTryExpr = lists:last(TryExprs),
+    resolve_type(Stack, Globals, LastTryExpr).

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -450,7 +450,7 @@ resolve_list_lit_type(Stack, Globals, Form = {list_lit, #{elements := Elements, 
             throw({error, unexpected_element_type, Data})
     end.
 
-%% %% try/catch/after helpers
+%% try/catch/after helpers
 
 -spec resolve_catch_clause_type(rufus_stack(), globals(), catch_clause_form()) -> {ok, type_form()}.
 resolve_catch_clause_type(Stack, Globals, {catch_clause, #{exprs := Exprs}}) ->

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -40,20 +40,20 @@
 -type cons_form() :: {cons, context()}.
 
 -type literal_form() ::
-    atom_lit_form() |
-    bool_lit_form() |
-    float_lit_form() |
-    int_lit_form() |
-    string_lit_form() |
-    list_lit_form() |
-    cons_form().
+    atom_lit_form()
+    | bool_lit_form()
+    | float_lit_form()
+    | int_lit_form()
+    | string_lit_form()
+    | list_lit_form()
+    | cons_form().
 
 -type literal() ::
-    atom |
-    bool |
-    float |
-    int |
-    string.
+    atom
+    | bool
+    | float
+    | int
+    | string.
 
 %% Operators
 
@@ -69,6 +69,7 @@
 -type binary_op_form() :: {binary_op, context()}.
 -type match_op_form() :: {match_op, context()}.
 -type call_form() :: {call, context()}.
+-type try_catch_after_form() :: {try_catch_after, context()}.
 
 %% Virtual forms
 
@@ -80,26 +81,28 @@
 -type func_params_form() :: {func_params, context()}.
 -type match_op_left_form() :: {match_op_left, context()}.
 -type match_op_right_form() :: {match_op_right, context()}.
+-type catch_clause_form() :: {catch_clause, context()}.
 
 %% Rufus forms
 
 %% rufus_form represents a node in the parse tree.
 -type rufus_form() ::
-    atom_lit_form() |
-    bool_lit_form() |
-    float_lit_form() |
-    int_lit_form() |
-    string_lit_form() |
-    list_lit_form() |
-    cons_form() |
-    module_form() |
-    func_form() |
-    param_form() |
-    identifier_form() |
-    type_form() |
-    binary_op_form() |
-    match_op_form() |
-    call_form().
+    atom_lit_form()
+    | bool_lit_form()
+    | float_lit_form()
+    | int_lit_form()
+    | string_lit_form()
+    | list_lit_form()
+    | cons_form()
+    | module_form()
+    | func_form()
+    | param_form()
+    | identifier_form()
+    | type_form()
+    | binary_op_form()
+    | match_op_form()
+    | call_form()
+    | try_catch_after_form().
 
 %% rufus_forms is a list of rufus_form instances and typically represents an
 %% entire module.
@@ -115,10 +118,10 @@
 -type unmatched_operand_type_error() :: unmatched_operand_type.
 -type unsupported_operand_type_error() :: unsupported_operand_type.
 -type rufus_error() ::
-    unknown_variable_error() |
-    unmatched_return_type_error() |
-    unmatched_operand_type_error() |
-    unsupported_operand_type_error().
+    unknown_variable_error()
+    | unmatched_return_type_error()
+    | unmatched_operand_type_error()
+    | unsupported_operand_type_error().
 
 %% Erlang forms
 
@@ -126,8 +129,8 @@
 -type erlang4_form() :: {_, _, _, _}.
 -type erlang5_form() :: {_, _, _, _, _}.
 -type erlang_form() ::
-    erlang3_form() |
-    erlang4_form() |
-    erlang5_form().
+    erlang3_form()
+    | erlang4_form()
+    | erlang5_form().
 
 -type export_attribute_erlang_form() :: {attribute, integer(), export, list()}.

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -70,6 +70,7 @@
 -type match_op_form() :: {match_op, context()}.
 -type call_form() :: {call, context()}.
 -type try_catch_after_form() :: {try_catch_after, context()}.
+-type catch_clause_form() :: {catch_clause, context()}.
 
 %% Virtual forms
 
@@ -81,7 +82,6 @@
 -type func_params_form() :: {func_params, context()}.
 -type match_op_left_form() :: {match_op_left, context()}.
 -type match_op_right_form() :: {match_op_right, context()}.
--type catch_clause_form() :: {catch_clause, context()}.
 
 %% Rufus forms
 

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -730,6 +730,91 @@ typecheck_and_annotate_with_try_and_multiple_catch_blocks_returning_an_atom_lite
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_with_try_block_in_match_op_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    result = try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "    result\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {match_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 3,
+                            locals => #{},
+                            spec => result,
+                            type => {type, #{line => 4, spec => atom}}
+                        }},
+                    line => 3,
+                    right =>
+                        {try_catch_after, #{
+                            after_exprs => [],
+                            catch_clauses => [
+                                {catch_clause, #{
+                                    exprs => [
+                                        {atom_lit, #{
+                                            line => 6,
+                                            spec => error,
+                                            type =>
+                                                {type, #{line => 6, spec => atom}}
+                                        }}
+                                    ],
+                                    line => 5,
+                                    match_expr =>
+                                        {atom_lit, #{
+                                            line => 5,
+                                            spec => error,
+                                            type =>
+                                                {type, #{line => 5, spec => atom}}
+                                        }},
+                                    type => {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 3,
+                            try_exprs => [
+                                {atom_lit, #{
+                                    line => 4,
+                                    spec => ok,
+                                    type => {type, #{line => 4, spec => atom}}
+                                }}
+                            ],
+                            type => {type, #{line => 4, spec => atom}}
+                        }},
+                    type => {type, #{line => 4, spec => atom}}
+                }},
+                {identifier, #{
+                    line => 8,
+                    spec => result,
+                    type => {type, #{line => 4, spec => atom}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => atom}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func() atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 %% typecheck_and_annotate scope tests
 
 typecheck_and_annotate_with_try_catch_and_after_blocks_accessing_variables_from_outer_scope_test() ->

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -495,6 +495,154 @@ typecheck_and_annotate_with_catch_block_matching_cons_expression_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_with_catch_block_with_match_op_expression_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch list[atom]{head|tail} = items list[atom] {\n"
+        "        head\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {identifier, #{
+                                    line => 6,
+                                    spec => head,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {match_op, #{
+                                    left =>
+                                        {cons, #{
+                                            head =>
+                                                {identifier, #{
+                                                    line => 5,
+                                                    locals => #{
+                                                        items => [
+                                                            {type, #{
+                                                                element_type =>
+                                                                    {type, #{
+                                                                        line => 5,
+                                                                        spec => atom
+                                                                    }},
+                                                                kind => list,
+                                                                line => 5,
+                                                                spec => 'list[atom]'
+                                                            }}
+                                                        ]
+                                                    },
+                                                    spec => head,
+                                                    type =>
+                                                        {type, #{line => 5, spec => atom}}
+                                                }},
+                                            line => 5,
+                                            tail =>
+                                                {identifier, #{
+                                                    line => 5,
+                                                    locals => #{
+                                                        head => [
+                                                            {type, #{line => 5, spec => atom}}
+                                                        ],
+                                                        items => [
+                                                            {type, #{
+                                                                element_type =>
+                                                                    {type, #{
+                                                                        line => 5,
+                                                                        spec => atom
+                                                                    }},
+                                                                kind => list,
+                                                                line => 5,
+                                                                spec => 'list[atom]'
+                                                            }}
+                                                        ]
+                                                    },
+                                                    spec => tail,
+                                                    type =>
+                                                        {type, #{
+                                                            element_type =>
+                                                                {type, #{line => 5, spec => atom}},
+                                                            kind => list,
+                                                            line => 5,
+                                                            spec => 'list[atom]'
+                                                        }}
+                                                }},
+                                            type =>
+                                                {type, #{
+                                                    element_type =>
+                                                        {type, #{line => 5, spec => atom}},
+                                                    kind => list,
+                                                    line => 5,
+                                                    spec => 'list[atom]'
+                                                }}
+                                        }},
+                                    line => 5,
+                                    right =>
+                                        {param, #{
+                                            line => 5,
+                                            spec => items,
+                                            type =>
+                                                {type, #{
+                                                    element_type =>
+                                                        {type, #{line => 5, spec => atom}},
+                                                    kind => list,
+                                                    line => 5,
+                                                    spec => 'list[atom]'
+                                                }}
+                                        }},
+                                    type =>
+                                        {type, #{
+                                            element_type =>
+                                                {type, #{line => 5, spec => atom}},
+                                            kind => list,
+                                            line => 5,
+                                            spec => 'list[atom]'
+                                        }}
+                                }},
+                            type => {type, #{line => 5, spec => atom}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 4,
+                            spec => ok,
+                            type => {type, #{line => 4, spec => atom}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => atom}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => atom}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func() atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_with_try_and_multiple_catch_blocks_returning_an_atom_literal_test() ->
     RufusText =
         "module example\n"

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -732,6 +732,179 @@ typecheck_and_annotate_with_try_and_multiple_catch_blocks_returning_an_atom_lite
 
 %% typecheck_and_annotate scope tests
 
+typecheck_and_annotate_with_try_catch_and_after_blocks_accessing_variables_from_outer_scope_test() ->
+    RufusText =
+        "module example\n"
+        "func cleanup(value atom) atom { value }\n"
+        "func Maybe() atom {\n"
+        "    ok = :ok\n"
+        "    error = :error\n"
+        "    value = :cleanup\n"
+        "    try {\n"
+        "        ok\n"
+        "    } catch :error {\n"
+        "        error\n"
+        "    } after {\n"
+        "        cleanup(value)\n"
+        "    }\n"
+        "    ok\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {identifier, #{
+                    line => 2,
+                    spec => value,
+                    type => {type, #{line => 2, spec => atom}}
+                }}
+            ],
+            line => 2,
+            params => [
+                {param, #{
+                    line => 2,
+                    spec => value,
+                    type => {type, #{line => 2, spec => atom}}
+                }}
+            ],
+            return_type => {type, #{line => 2, spec => atom}},
+            spec => cleanup,
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [{type, #{line => 2, spec => atom}}],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func(atom) atom'
+                }}
+        }},
+        {func, #{
+            exprs => [
+                {match_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 4,
+                            locals => #{},
+                            spec => ok,
+                            type => {type, #{line => 4, spec => atom}}
+                        }},
+                    line => 4,
+                    right =>
+                        {atom_lit, #{
+                            line => 4,
+                            spec => ok,
+                            type => {type, #{line => 4, spec => atom}}
+                        }},
+                    type => {type, #{line => 4, spec => atom}}
+                }},
+                {match_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 5,
+                            locals => #{ok => [{type, #{line => 4, spec => atom}}]},
+                            spec => error,
+                            type => {type, #{line => 5, spec => atom}}
+                        }},
+                    line => 5,
+                    right =>
+                        {atom_lit, #{
+                            line => 5,
+                            spec => error,
+                            type => {type, #{line => 5, spec => atom}}
+                        }},
+                    type => {type, #{line => 5, spec => atom}}
+                }},
+                {match_op, #{
+                    left =>
+                        {identifier, #{
+                            line => 6,
+                            locals => #{
+                                error => [{type, #{line => 5, spec => atom}}],
+                                ok => [{type, #{line => 4, spec => atom}}]
+                            },
+                            spec => value,
+                            type => {type, #{line => 6, spec => atom}}
+                        }},
+                    line => 6,
+                    right =>
+                        {atom_lit, #{
+                            line => 6,
+                            spec => cleanup,
+                            type => {type, #{line => 6, spec => atom}}
+                        }},
+                    type => {type, #{line => 6, spec => atom}}
+                }},
+                {try_catch_after, #{
+                    after_exprs => [
+                        {call, #{
+                            args => [
+                                {identifier, #{
+                                    line => 12,
+                                    spec => value,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 12,
+                            spec => cleanup,
+                            type => {type, #{line => 2, spec => atom}}
+                        }}
+                    ],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {identifier, #{
+                                    line => 10,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                            ],
+                            line => 9,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 9,
+                                    spec => error,
+                                    type => {type, #{line => 9, spec => atom}}
+                                }},
+                            type => {type, #{line => 5, spec => atom}}
+                        }}
+                    ],
+                    line => 7,
+                    try_exprs => [
+                        {identifier, #{
+                            line => 8,
+                            spec => ok,
+                            type => {type, #{line => 4, spec => atom}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => atom}}
+                }},
+                {identifier, #{
+                    line => 14,
+                    spec => ok,
+                    type => {type, #{line => 4, spec => atom}}
+                }}
+            ],
+            line => 3,
+            params => [],
+            return_type => {type, #{line => 3, spec => atom}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [],
+                    return_type => {type, #{line => 3, spec => atom}},
+                    spec => 'func() atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_with_try_variable_accessed_outside_block_test() ->
     RufusText =
         "module example\n"
@@ -962,6 +1135,77 @@ typecheck_and_annotate_with_try_variable_accessed_in_catch_block_test() ->
                                     }}
                             }}
                         ],
+                        line => 3,
+                        try_exprs => [
+                            {match_op, #{
+                                left =>
+                                    {identifier, #{line => 4, spec => ok}},
+                                line => 4,
+                                right =>
+                                    {atom_lit, #{
+                                        line => 4,
+                                        spec => ok,
+                                        type =>
+                                            {type, #{line => 4, spec => atom}}
+                                    }}
+                            }}
+                        ]
+                    }}
+                ],
+                line => 2,
+                locals => #{},
+                params => [],
+                return_type => {type, #{line => 2, spec => atom}},
+                spec => 'Maybe',
+                type =>
+                    {type, #{
+                        kind => func,
+                        line => 2,
+                        param_types => [],
+                        return_type => {type, #{line => 2, spec => atom}},
+                        spec => 'func() atom'
+                    }}
+            }}
+        ]
+    },
+    ?assertEqual(
+        {error, unknown_identifier, Data},
+        rufus_expr:typecheck_and_annotate(Forms)
+    ).
+
+typecheck_and_annotate_with_try_variable_accessed_in_after_block_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        ok = :ok\n"
+        "    } after {\n"
+        "        ok\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Data = #{
+        form => {identifier, #{line => 6, locals => #{}, spec => ok}},
+        globals => #{
+            'Maybe' => [
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func() atom'
+                }}
+            ]
+        },
+        locals => #{},
+        stack => [
+            {func_exprs, #{line => 2}},
+            {func, #{
+                exprs => [
+                    {try_catch_after, #{
+                        after_exprs => [{identifier, #{line => 6, spec => ok}}],
+                        catch_clauses => [],
                         line => 3,
                         try_exprs => [
                             {match_op, #{

--- a/rf/test/rufus_expr_try_catch_test.erl
+++ b/rf/test/rufus_expr_try_catch_test.erl
@@ -1,0 +1,71 @@
+-module(rufus_expr_try_catch_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% typecheck_and_annotate tests
+
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_atom_literals_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 6,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 4,
+                            spec => ok,
+                            type => {type, #{line => 4, spec => atom}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => atom}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => atom}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func() atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_try_catch_test.erl
+++ b/rf/test/rufus_expr_try_catch_test.erl
@@ -4,7 +4,7 @@
 
 %% typecheck_and_annotate tests
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_atom_literals_test() ->
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -38,9 +38,9 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_atom_literals_te
                                 {atom_lit, #{
                                     line => 5,
                                     spec => error,
-                                    type =>
-                                        {type, #{line => 5, spec => atom}}
-                                }}
+                                    type => {type, #{line => 5, spec => atom}}
+                                }},
+                            type => {type, #{line => 6, spec => atom}}
                         }}
                     ],
                     line => 3,
@@ -65,6 +65,269 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_atom_literals_te
                     param_types => [],
                     return_type => {type, #{line => 2, spec => atom}},
                     spec => 'func() atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_bool_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() bool {\n"
+        "    try {\n"
+        "        true\n"
+        "    } catch :error {\n"
+        "        false\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {bool_lit, #{
+                                    line => 6,
+                                    spec => false,
+                                    type =>
+                                        {type, #{line => 6, spec => bool}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type => {type, #{line => 5, spec => atom}}
+                                }},
+                            type => {type, #{line => 6, spec => bool}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {bool_lit, #{
+                            line => 4,
+                            spec => true,
+                            type => {type, #{line => 4, spec => bool}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => bool}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => bool}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => bool}},
+                    spec => 'func() bool'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_float_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() float {\n"
+        "    try {\n"
+        "        42.0\n"
+        "    } catch :error {\n"
+        "        13.8\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {float_lit, #{
+                                    line => 6,
+                                    spec => 13.8,
+                                    type =>
+                                        {type, #{line => 6, spec => float}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type => {type, #{line => 5, spec => atom}}
+                                }},
+                            type => {type, #{line => 6, spec => float}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {float_lit, #{
+                            line => 4,
+                            spec => 42.0,
+                            type => {type, #{line => 4, spec => float}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => float}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => float}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => float}},
+                    spec => 'func() float'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_int_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() int {\n"
+        "    try {\n"
+        "        42\n"
+        "    } catch :error {\n"
+        "        13\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {int_lit, #{
+                                    line => 6,
+                                    spec => 13,
+                                    type => {type, #{line => 6, spec => int}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type => {type, #{line => 5, spec => atom}}
+                                }},
+                            type => {type, #{line => 6, spec => int}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {int_lit, #{
+                            line => 4,
+                            spec => 42,
+                            type => {type, #{line => 4, spec => int}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => int}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => int}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => int}},
+                    spec => 'func() int'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_string_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() string {\n"
+        "    try {\n"
+        "        \"ok\"\n"
+        "    } catch :error {\n"
+        "        \"error\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {string_lit, #{
+                                    line => 6,
+                                    spec => <<"error">>,
+                                    type =>
+                                        {type, #{line => 6, spec => string}}
+                                }}
+                            ],
+                            line => 5,
+                            match_expr =>
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type => {type, #{line => 5, spec => atom}}
+                                }},
+                            type => {type, #{line => 6, spec => string}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {string_lit, #{
+                            line => 4,
+                            spec => <<"ok">>,
+                            type => {type, #{line => 4, spec => string}}
+                        }}
+                    ],
+                    type => {type, #{line => 4, spec => string}}
+                }}
+            ],
+            line => 2,
+            params => [],
+            return_type => {type, #{line => 2, spec => string}},
+            spec => 'Maybe',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [],
+                    return_type => {type, #{line => 2, spec => string}},
+                    spec => 'func() string'
                 }}
         }}
     ],

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -127,6 +127,31 @@ map_with_match_test() ->
         rufus_forms:map([Form], fun annotate/1)
     ).
 
+map_with_try_catch_after_test() ->
+    TryExpr = rufus_form:make_identifier(j, 3),
+    MatchExpr = rufus_form:make_identifier(k, 3),
+    CatchExpr = rufus_form:make_identifier(k, 3),
+    CatchClause = rufus_form:make_catch_clause(MatchExpr, [CatchExpr], 3),
+    AfterExpr = rufus_form:make_identifier(l, 3),
+    Form = rufus_form:make_try_catch_after([TryExpr], [CatchClause], [AfterExpr], 3),
+    ?assertMatch(
+        [
+            {try_catch_after, #{
+                try_exprs := [{_, #{annotated := true}}],
+                catch_clauses := [
+                    {catch_clause, #{
+                        match_expr := {_, #{annotated := true}},
+                        exprs := [{_, #{annotated := true}}],
+                        annotated := true
+                    }}
+                ],
+                after_exprs := [{_, #{annotated := true}}],
+                annotated := true
+            }}
+        ],
+        rufus_forms:map([Form], fun annotate/1)
+    ).
+
 annotate({FormType, Context}) ->
     {FormType, Context#{annotated => true}}.
 

--- a/rf/test/rufus_parse_try_catch_after_test.erl
+++ b/rf/test/rufus_parse_try_catch_after_test.erl
@@ -1,4 +1,4 @@
--module(rufus_parse_try_catch_test).
+-module(rufus_parse_try_catch_after_test).
 
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
`rufus_expr:typecheck_and_annotate/1` typechecks and annotates `try_catch_after` and `catch_clause` forms. `rufus_forms:each/2`, `rufus_forms:map/2`, and `rufus_type:resolve/3` all support `try_catch_after` and `catch_clause` forms.