### PR TITLE
compiler: Compile try/catch/after expressions

### DIFF
--- a/rf/Makefile
+++ b/rf/Makefile
@@ -22,3 +22,6 @@ dialyzer:
 build:
 	@rebar3 escriptize
 	@cp _build/default/bin/rf .
+
+fmt:
+	@erlfmt -w src/*erl test/*erl

--- a/rf/src/rufus_compile.erl
+++ b/rf/src/rufus_compile.erl
@@ -65,8 +65,8 @@ compile(ErlangForms) ->
 
 %% load creates or overwrites a module with a code binary.
 -spec load(atom(), binary()) ->
-    {ok, atom()} |
-    {error, badarg | badfile | nofile | not_purged | on_load_failure | sticky_directory}.
+    {ok, atom()}
+    | {error, badarg | badfile | nofile | not_purged | on_load_failure | sticky_directory}.
 load(Module, BinaryOrCode) ->
     case code:load_binary(Module, "nofile", BinaryOrCode) of
         {module, Module} ->

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -591,13 +591,19 @@ typecheck_and_annotate_catch_clause(
     Form = {catch_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}}
 ) ->
     CatchClauseStack = [Form | Stack],
-    {ok, NewLocals, [AnnotatedMatchExpr]} = typecheck_and_annotate(
-        [],
-        CatchClauseStack,
-        Globals,
-        Locals,
-        [MatchExpr]
-    ),
+    {ok, NewLocals, [AnnotatedMatchExpr]} =
+        case MatchExpr of
+            undefined ->
+                {ok, Locals, [undefined]};
+            _ ->
+                typecheck_and_annotate(
+                    [],
+                    CatchClauseStack,
+                    Globals,
+                    Locals,
+                    [MatchExpr]
+                )
+        end,
 
     {ok, _, AnnotatedExprs} = typecheck_and_annotate([], Stack, Globals, NewLocals, Exprs),
     AnnotatedForm1 =

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -16,6 +16,7 @@
     make_binary_op_left/1,
     make_binary_op_right/1,
     make_call/3,
+    make_catch_clause/2,
     make_catch_clause/3,
     make_cons/4,
     make_cons_head/1,
@@ -260,6 +261,9 @@ make_module(Spec, Line) ->
     {module, #{spec => Spec, line => Line}}.
 
 %% try/catch/after form builder API
+
+make_catch_clause(Exprs, Line) ->
+    make_catch_clause(undefined, Exprs, Line).
 
 make_catch_clause(MatchExpr, Exprs, Line) ->
     {catch_clause, #{match_expr => MatchExpr, exprs => Exprs, line => Line}}.

--- a/rf/src/rufus_forms.erl
+++ b/rf/src/rufus_forms.erl
@@ -23,7 +23,12 @@ each([Form = {call, #{args := Args}} | T], Fun) ->
     Fun(Form),
     each(T, Fun);
 each([Form = {catch_clause, #{match_expr := MatchExpr, exprs := Exprs}} | T], Fun) ->
-    Fun(MatchExpr),
+    case MatchExpr of
+        undefined ->
+            ok;
+        _ ->
+            Fun(MatchExpr)
+    end,
     each(Exprs, Fun),
     Fun(Form),
     each(T, Fun);
@@ -90,7 +95,13 @@ map(Acc, [{call, Context = #{args := Args}} | T], Fun) ->
     AnnotatedForm = Fun({call, Context#{args => AnnotatedArgs}}),
     map([AnnotatedForm | Acc], T, Fun);
 map(Acc, [{catch_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}} | T], Fun) ->
-    AnnotatedMatchExpr = Fun(MatchExpr),
+    AnnotatedMatchExpr =
+        case MatchExpr of
+            undefined ->
+                undefined;
+            _ ->
+                Fun(MatchExpr)
+        end,
     AnnotatedExprs = map(Exprs, Fun),
     AnnotatedForm = Fun(
         {catch_clause, Context#{match_expr => AnnotatedMatchExpr, exprs => AnnotatedExprs}}

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -120,6 +120,8 @@ expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], '$12', line('$1')).
 expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], [], line('$1')).
+expr  -> try '{' exprs '}' catch '{' exprs '}' after '{' exprs '}':
+                                   rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$7', line('$5'))], '$11', line('$1')).
 expr  -> try '{' exprs '}' catch '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$7', line('$5'))], [], line('$1')).
 expr  -> try '{' exprs '}' catch '{' catch_match_clauses '}' after '{' exprs '}' :

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -54,6 +54,10 @@ Left     40 'and'.
 Left     30 'or'.
 Left     20 '='.
 
+%% Give exprs higher precedence than catch_match_clause to prevent collisions
+%% between a bare catch and a catch with one or more matchers.
+Left     10 exprs.
+
 %%
 %% Grammar rules
 %%
@@ -116,6 +120,8 @@ expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], '$12', line('$1')).
 expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], [], line('$1')).
+expr  -> try '{' exprs '}' catch '{' exprs '}' :
+                                   rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$7', line('$5'))], [], line('$1')).
 expr  -> try '{' exprs '}' catch '{' catch_match_clauses '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', '$7', '$11', line('$1')).
 expr  -> try '{' exprs '}' catch '{' catch_match_clauses '}' :

--- a/rf/test/rufus_compile_try_catch_after_test.erl
+++ b/rf/test/rufus_compile_try_catch_after_test.erl
@@ -1,0 +1,16 @@
+-module(rufus_compile_try_catch_after_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+eval_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).

--- a/rf/test/rufus_compile_try_catch_after_test.erl
+++ b/rf/test/rufus_compile_try_catch_after_test.erl
@@ -2,7 +2,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-eval_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
+eval_function_with_bare_catch_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -10,6 +10,120 @@ eval_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
         "        :ok\n"
         "    } catch {\n"
         "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
+eval_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
+eval_function_with_try_and_catch_blocks_both_returning_a_bool_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() bool {\n"
+        "    try {\n"
+        "        true\n"
+        "    } catch :error {\n"
+        "        false\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(true, example:'Maybe'()).
+
+eval_function_with_try_and_catch_blocks_both_returning_a_float_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() float {\n"
+        "    try {\n"
+        "        42.0\n"
+        "    } catch :error {\n"
+        "        13.8\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(42.0, example:'Maybe'()).
+
+eval_function_with_try_and_catch_blocks_both_returning_an_int_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() int {\n"
+        "    try {\n"
+        "        42\n"
+        "    } catch :error {\n"
+        "        13\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(42, example:'Maybe'()).
+
+eval_function_with_try_and_catch_blocks_both_returning_a_string_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() string {\n"
+        "    try {\n"
+        "        \"ok\"\n"
+        "    } catch :error {\n"
+        "        \"error\"\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual({string, <<"ok">>}, example:'Maybe'()).
+
+eval_function_with_try_and_multiple_catch_blocks_returning_an_atom_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "    match :error ->\n"
+        "        :error\n"
+        "    match :failure ->\n"
+        "        :failure\n"
+        "    }\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
+eval_function_with_try_block_in_match_op_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    result = try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "    result\n"
+        "}\n",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
+eval_function_with_try_catch_and_after_blocks_accessing_variables_from_outer_scope_test() ->
+    RufusText =
+        "module example\n"
+        "func cleanup(value atom) atom { value }\n"
+        "func Maybe() atom {\n"
+        "    ok = :ok\n"
+        "    error = :error\n"
+        "    value = :cleanup\n"
+        "    try {\n"
+        "        ok\n"
+        "    } catch :error {\n"
+        "        error\n"
+        "    } after {\n"
+        "        cleanup(value)\n"
         "    }\n"
         "}\n",
     {ok, example} = rufus_compile:eval(RufusText),

--- a/rf/test/rufus_compile_try_catch_after_test.erl
+++ b/rf/test/rufus_compile_try_catch_after_test.erl
@@ -80,6 +80,20 @@ eval_function_with_try_and_catch_blocks_both_returning_a_string_literal_test() -
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"ok">>}, example:'Maybe'()).
 
+eval_function_with_try_after_block_test() ->
+    RufusText =
+        "module example\n"
+        "func cleanup() atom { :cleanup }\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
 eval_function_with_bare_catch_block_and_an_after_block_test() ->
     RufusText =
         "module example\n"

--- a/rf/test/rufus_compile_try_catch_after_test.erl
+++ b/rf/test/rufus_compile_try_catch_after_test.erl
@@ -80,6 +80,22 @@ eval_function_with_try_and_catch_blocks_both_returning_a_string_literal_test() -
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual({string, <<"ok">>}, example:'Maybe'()).
 
+eval_function_with_bare_catch_block_and_an_after_block_test() ->
+    RufusText =
+        "module example\n"
+        "func cleanup() atom { :cleanup }\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "        :error\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, example} = rufus_compile:eval(RufusText),
+    ?assertEqual(ok, example:'Maybe'()).
+
 eval_function_with_try_and_multiple_catch_blocks_returning_an_atom_literal_test() ->
     RufusText =
         "module example\n"

--- a/rf/test/rufus_erlang_try_catch_after_test.erl
+++ b/rf/test/rufus_erlang_try_catch_after_test.erl
@@ -62,3 +62,139 @@ forms_for_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test
         ]}
     ],
     ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_try_and_catch_blocks_both_returning_a_bool_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() bool {\n"
+        "    try {\n"
+        "        true\n"
+        "    } catch :error {\n"
+        "        false\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3, [{atom, 4, true}], [],
+                    [
+                        {clause, 5,
+                            [{tuple, 5, [{atom, 5, throw}, {atom, 5, error}, {var, 5, '_'}]}], [], [
+                                {atom, 6, false}
+                            ]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_try_and_catch_blocks_both_returning_a_float_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() float {\n"
+        "    try {\n"
+        "        42.0\n"
+        "    } catch :error {\n"
+        "        13.8\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3, [{float, 4, 42.0}], [],
+                    [
+                        {clause, 5,
+                            [{tuple, 5, [{atom, 5, throw}, {atom, 5, error}, {var, 5, '_'}]}], [], [
+                                {float, 6, 13.8}
+                            ]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_try_and_catch_blocks_both_returning_an_int_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() int {\n"
+        "    try {\n"
+        "        42\n"
+        "    } catch :error {\n"
+        "        13\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3, [{integer, 4, 42}], [],
+                    [
+                        {clause, 5,
+                            [{tuple, 5, [{atom, 5, throw}, {atom, 5, error}, {var, 5, '_'}]}], [], [
+                                {integer, 6, 13}
+                            ]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_try_and_catch_blocks_both_returning_a_string_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() string {\n"
+        "    try {\n"
+        "        \"ok\"\n"
+        "    } catch :error {\n"
+        "        \"error\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3,
+                    [
+                        {tuple, 4, [
+                            {atom, 4, string},
+                            {bin, 4, [{bin_element, 4, {string, 4, "ok"}, default, default}]}
+                        ]}
+                    ],
+                    [],
+                    [
+                        {clause, 5,
+                            [{tuple, 5, [{atom, 5, throw}, {atom, 5, error}, {var, 5, '_'}]}], [], [
+                                {tuple, 6, [
+                                    {atom, 6, string},
+                                    {bin, 6, [
+                                        {bin_element, 6, {string, 6, "error"}, default, default}
+                                    ]}
+                                ]}
+                            ]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_erlang_try_catch_after_test.erl
+++ b/rf/test/rufus_erlang_try_catch_after_test.erl
@@ -199,6 +199,32 @@ forms_for_function_with_try_and_catch_blocks_both_returning_a_string_literal_tes
     ],
     ?assertEqual(Expected, ErlangForms).
 
+forms_for_function_with_try_after_block_test() ->
+    RufusText =
+        "module example\n"
+        "func cleanup() atom { :cleanup }\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 3, export, [{'Maybe', 0}]},
+        {function, 3, 'Maybe', 0, [
+            {clause, 3, [], [], [
+                {'try', 4, [{atom, 5, ok}], [], [], [{call, 7, {atom, 7, cleanup}, []}]}
+            ]}
+        ]},
+        {function, 2, cleanup, 0, [{clause, 2, [], [], [{atom, 2, cleanup}]}]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
 forms_for_function_with_bare_catch_block_and_an_after_block_test() ->
     RufusText =
         "module example\n"

--- a/rf/test/rufus_erlang_try_catch_after_test.erl
+++ b/rf/test/rufus_erlang_try_catch_after_test.erl
@@ -1,0 +1,64 @@
+-module(rufus_erlang_try_catch_after_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+forms_for_function_with_bare_catch_block_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3, [{atom, 4, ok}], [],
+                    [
+                        {clause, 5, [{tuple, 5, [{atom, 5, throw}, {var, 5, '_'}, {var, 5, '_'}]}],
+                            [], [{atom, 6, error}]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).
+
+forms_for_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
+    RufusText =
+        "module example\n"
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch :error {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    Expected = [
+        {attribute, 1, module, example},
+        {attribute, 2, export, [{'Maybe', 0}]},
+        {function, 2, 'Maybe', 0, [
+            {clause, 2, [], [], [
+                {'try', 3, [{atom, 4, ok}], [],
+                    [
+                        {clause, 5,
+                            [{tuple, 5, [{atom, 5, throw}, {atom, 5, error}, {var, 5, '_'}]}], [], [
+                                {atom, 6, error}
+                            ]}
+                    ],
+                    []}
+            ]}
+        ]}
+    ],
+    ?assertEqual(Expected, ErlangForms).

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -4,7 +4,92 @@
 
 %% typecheck_and_annotate tests
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
+typecheck_and_annotate_function_with_bare_catch_block_test() ->
+    RufusText =
+        "module example\n"
+        "func MaybeDivideBy(n int) atom {\n"
+        "    try {\n"
+        "        1 / n\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "        :error\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 1, spec => example}},
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 7,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 7, spec => atom}}
+                                }}
+                            ],
+                            line => 6,
+                            match_expr => undefined,
+                            type => {type, #{line => 7, spec => atom}}
+                        }}
+                    ],
+                    line => 3,
+                    try_exprs => [
+                        {binary_op, #{
+                            left =>
+                                {int_lit, #{
+                                    line => 4,
+                                    spec => 1,
+                                    type => {type, #{line => 4, spec => int}}
+                                }},
+                            line => 4,
+                            op => '/',
+                            right =>
+                                {identifier, #{
+                                    line => 4,
+                                    spec => n,
+                                    type => {type, #{line => 2, spec => int}}
+                                }},
+                            type => {type, #{line => 4, spec => int}}
+                        }},
+                        {atom_lit, #{
+                            line => 5,
+                            spec => ok,
+                            type => {type, #{line => 5, spec => atom}}
+                        }}
+                    ],
+                    type => {type, #{line => 5, spec => atom}}
+                }}
+            ],
+            line => 2,
+            params => [
+                {param, #{
+                    line => 2,
+                    spec => n,
+                    type => {type, #{line => 2, spec => int}}
+                }}
+            ],
+            return_type => {type, #{line => 2, spec => atom}},
+            spec => 'MaybeDivideBy',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 2,
+                    param_types => [{type, #{line => 2, spec => int}}],
+                    return_type => {type, #{line => 2, spec => atom}},
+                    spec => 'func(int) atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -70,7 +155,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_atom_literal_
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_bool_literal_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_both_returning_a_bool_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() bool {\n"
@@ -136,7 +221,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_bool_literal_t
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_float_literal_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_both_returning_a_float_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() float {\n"
@@ -202,7 +287,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_float_literal_
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_int_literal_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_both_returning_an_int_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() int {\n"
@@ -267,7 +352,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_an_int_literal_t
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_string_literal_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_both_returning_a_string_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() string {\n"
@@ -333,7 +418,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_both_returning_a_string_literal
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_catch_block_matching_variable_test() ->
+typecheck_and_annotate_function_with_catch_block_matching_variable_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -399,7 +484,7 @@ typecheck_and_annotate_with_catch_block_matching_variable_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_catch_block_matching_cons_expression_test() ->
+typecheck_and_annotate_function_with_catch_block_matching_cons_expression_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -495,7 +580,7 @@ typecheck_and_annotate_with_catch_block_matching_cons_expression_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_catch_block_with_match_op_expression_test() ->
+typecheck_and_annotate_function_with_catch_block_with_match_op_expression_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -643,7 +728,7 @@ typecheck_and_annotate_with_catch_block_with_match_op_expression_test() ->
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_and_multiple_catch_blocks_returning_an_atom_literal_test() ->
+typecheck_and_annotate_function_with_try_and_multiple_catch_blocks_returning_an_atom_literal_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -730,7 +815,7 @@ typecheck_and_annotate_with_try_and_multiple_catch_blocks_returning_an_atom_lite
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_block_in_match_op_test() ->
+typecheck_and_annotate_function_with_try_block_in_match_op_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -817,7 +902,7 @@ typecheck_and_annotate_with_try_block_in_match_op_test() ->
 
 %% typecheck_and_annotate scope tests
 
-typecheck_and_annotate_with_try_catch_and_after_blocks_accessing_variables_from_outer_scope_test() ->
+typecheck_and_annotate_function_with_try_catch_and_after_blocks_accessing_variables_from_outer_scope_test() ->
     RufusText =
         "module example\n"
         "func cleanup(value atom) atom { value }\n"
@@ -990,7 +1075,7 @@ typecheck_and_annotate_with_try_catch_and_after_blocks_accessing_variables_from_
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
-typecheck_and_annotate_with_try_variable_accessed_outside_block_test() ->
+typecheck_and_annotate_function_with_try_variable_accessed_outside_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1082,7 +1167,7 @@ typecheck_and_annotate_with_try_variable_accessed_outside_block_test() ->
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_catch_variable_accessed_outside_block_test() ->
+typecheck_and_annotate_function_with_catch_variable_accessed_outside_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1175,7 +1260,7 @@ typecheck_and_annotate_with_catch_variable_accessed_outside_block_test() ->
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_after_variable_accessed_outside_block_test() ->
+typecheck_and_annotate_function_with_after_variable_accessed_outside_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1256,7 +1341,7 @@ typecheck_and_annotate_with_after_variable_accessed_outside_block_test() ->
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_try_variable_accessed_in_catch_block_test() ->
+typecheck_and_annotate_function_with_try_variable_accessed_in_catch_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1339,7 +1424,7 @@ typecheck_and_annotate_with_try_variable_accessed_in_catch_block_test() ->
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_try_variable_accessed_in_after_block_test() ->
+typecheck_and_annotate_function_with_try_variable_accessed_in_after_block_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1412,7 +1497,7 @@ typecheck_and_annotate_with_try_variable_accessed_in_after_block_test() ->
 
 %% typecheck_and_annotate failure mode tests
 
-typecheck_and_annotate_with_try_and_catch_blocks_with_mismatched_try_block_return_type_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_with_mismatched_try_block_return_type_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1469,7 +1554,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_with_mismatched_try_block_retur
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_try_and_catch_blocks_with_mismatched_catch_clause_return_type_test() ->
+typecheck_and_annotate_function_with_try_and_catch_blocks_with_mismatched_catch_clause_return_type_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"
@@ -1527,7 +1612,7 @@ typecheck_and_annotate_with_try_and_catch_blocks_with_mismatched_catch_clause_re
         rufus_expr:typecheck_and_annotate(Forms)
     ).
 
-typecheck_and_annotate_with_try_and_multiple_catch_blocks_with_a_mismatched_catch_clause_return_type_test() ->
+typecheck_and_annotate_function_with_try_and_multiple_catch_blocks_with_a_mismatched_catch_clause_return_type_test() ->
     RufusText =
         "module example\n"
         "func Maybe() atom {\n"

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -917,7 +917,6 @@ typecheck_and_annotate_function_with_try_catch_and_after_blocks_accessing_variab
         "    } after {\n"
         "        cleanup(value)\n"
         "    }\n"
-        "    ok\n"
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
@@ -1051,11 +1050,6 @@ typecheck_and_annotate_function_with_try_catch_and_after_blocks_accessing_variab
                             type => {type, #{line => 4, spec => atom}}
                         }}
                     ],
-                    type => {type, #{line => 4, spec => atom}}
-                }},
-                {identifier, #{
-                    line => 14,
-                    spec => ok,
                     type => {type, #{line => 4, spec => atom}}
                 }}
             ],

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -152,6 +152,30 @@ map_with_try_catch_after_test() ->
         rufus_forms:map([Form], fun annotate/1)
     ).
 
+map_with_try_catch_after_with_bare_catch_test() ->
+    TryExpr = rufus_form:make_identifier(j, 3),
+    CatchExpr = rufus_form:make_identifier(k, 3),
+    CatchClause = rufus_form:make_catch_clause([CatchExpr], 3),
+    AfterExpr = rufus_form:make_identifier(l, 3),
+    Form = rufus_form:make_try_catch_after([TryExpr], [CatchClause], [AfterExpr], 3),
+    ?assertMatch(
+        [
+            {try_catch_after, #{
+                try_exprs := [{_, #{annotated := true}}],
+                catch_clauses := [
+                    {catch_clause, #{
+                        match_expr := undefined,
+                        exprs := [{_, #{annotated := true}}],
+                        annotated := true
+                    }}
+                ],
+                after_exprs := [{_, #{annotated := true}}],
+                annotated := true
+            }}
+        ],
+        rufus_forms:map([Form], fun annotate/1)
+    ).
+
 annotate({FormType, Context}) ->
     {FormType, Context#{annotated => true}}.
 

--- a/rf/test/rufus_parse_try_catch_after_test.erl
+++ b/rf/test/rufus_parse_try_catch_after_test.erl
@@ -41,7 +41,8 @@ parse_function_with_bare_catch_block_test() ->
                                         {type, #{line => 6, spec => atom}}
                                 }}
                             ],
-                            line => 4
+                            line => 4,
+                            match_expr => undefined
                         }}
                     ],
                     line => 2,

--- a/rf/test/rufus_parse_try_catch_after_test.erl
+++ b/rf/test/rufus_parse_try_catch_after_test.erl
@@ -4,7 +4,7 @@
 
 parse_function_with_bare_catch_block_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -58,14 +58,14 @@ parse_function_with_bare_catch_block_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_atom_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch :error {\n"
@@ -125,14 +125,14 @@ parse_function_with_try_catch_block_with_single_atom_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_bool_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch true {\n"
@@ -192,14 +192,14 @@ parse_function_with_try_catch_block_with_single_bool_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_float_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch 42.0 {\n"
@@ -259,14 +259,14 @@ parse_function_with_try_catch_block_with_single_float_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_int_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch 42 {\n"
@@ -326,14 +326,14 @@ parse_function_with_try_catch_block_with_single_int_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_string_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch \"error\" {\n"
@@ -393,14 +393,14 @@ parse_function_with_try_catch_block_with_single_string_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_cons_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch list[atom]{:error|tail} {\n"
@@ -474,14 +474,14 @@ parse_function_with_try_catch_block_with_single_cons_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_identifier_and_type_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch errorCode atom {\n"
@@ -541,14 +541,14 @@ parse_function_with_try_catch_block_with_single_identifier_and_type_clause_test(
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_match_op_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch :error = errorCode atom {\n"
@@ -619,14 +619,14 @@ parse_function_with_try_catch_block_with_single_match_op_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_atom_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -674,14 +674,14 @@ parse_function_with_try_catch_block_with_single_atom_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_bool_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -729,14 +729,14 @@ parse_function_with_try_catch_block_with_single_bool_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_float_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -784,14 +784,14 @@ parse_function_with_try_catch_block_with_single_float_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_int_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -839,14 +839,14 @@ parse_function_with_try_catch_block_with_single_int_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_string_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -894,14 +894,14 @@ parse_function_with_try_catch_block_with_single_string_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_cons_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -963,14 +963,14 @@ parse_function_with_try_catch_block_with_single_cons_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_identifier_and_type_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1018,14 +1018,14 @@ parse_function_with_try_catch_block_with_single_identifier_and_type_match_clause
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_match_op_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1084,14 +1084,14 @@ parse_function_with_try_catch_block_with_single_match_op_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_multiple_clauses_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1172,14 +1172,14 @@ parse_function_with_try_catch_block_with_multiple_clauses_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_match_clause_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1227,14 +1227,14 @@ parse_function_with_try_catch_block_with_single_match_clause_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_after_block_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        doSomething()\n"
         "        :ok\n"
@@ -1268,14 +1268,64 @@ parse_function_with_try_after_block_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_bare_catch_block_and_an_after_block_test() ->
+    RufusText =
+        "func Maybe() atom {\n"
+        "    try {\n"
+        "        :ok\n"
+        "    } catch {\n"
+        "        :error\n"
+        "    } after {\n"
+        "        cleanup()\n"
+        "    }\n"
+        "}",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {try_catch_after, #{
+                    after_exprs => [{call, #{args => [], line => 7, spec => cleanup}}],
+                    catch_clauses => [
+                        {catch_clause, #{
+                            exprs => [
+                                {atom_lit, #{
+                                    line => 5,
+                                    spec => error,
+                                    type =>
+                                        {type, #{line => 5, spec => atom}}
+                                }}
+                            ],
+                            line => 4,
+                            match_expr => undefined
+                        }}
+                    ],
+                    line => 2,
+                    try_exprs => [
+                        {atom_lit, #{
+                            line => 3,
+                            spec => ok,
+                            type => {type, #{line => 3, spec => atom}}
+                        }}
+                    ]
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch :error {\n"
@@ -1326,14 +1376,14 @@ parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_single_match_clause_and_after_block_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1383,14 +1433,14 @@ parse_function_with_try_catch_block_with_single_match_clause_and_after_block_tes
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).
 
 parse_function_with_try_catch_block_with_multiple_clauses_and_after_block_test() ->
     RufusText =
-        "func example() atom {\n"
+        "func Maybe() atom {\n"
         "    try {\n"
         "        :ok\n"
         "    } catch {\n"
@@ -1460,7 +1510,7 @@ parse_function_with_try_catch_block_with_multiple_clauses_and_after_block_test()
             line => 1,
             params => [],
             return_type => {type, #{line => 1, spec => atom}},
-            spec => example
+            spec => 'Maybe'
         }}
     ],
     ?assertEqual(Expected, Forms).


### PR DESCRIPTION
`rufus_parse:parse/1` and `rufus_expr:typecheck_and_annotate/1` both support try/catch/after expressions with a bare catch clause. `rufus_erlang:forms/1` translates Rufus forms to Erlang forms.