### PR TITLE
compiler: Parse throw expressions

### DIFF
--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -263,17 +263,28 @@ make_module(Spec, Line) ->
 
 %% throw form builder API
 
+%% make_throw returns a form for a throw expression.
+-spec make_throw(rufus_form(), integer()) -> throw_form().
 make_throw(Expr, Line) ->
     {'throw', #{expr => Expr, line => Line}}.
 
 %% try/catch/after form builder API
 
+%% make_catch_clause returns a form for a catch clause that matches any error.
+%% TODO(jkakar) Figure out why Dialyzer doesn't like this spec:
+%% -spec make_catch_clause(any(), integer()) -> catch_clause_form().
 make_catch_clause(Exprs, Line) ->
     make_catch_clause(undefined, Exprs, Line).
 
+%% make_catch_clause returns a form for a catch clause.
+%% TODO(jkakar): Define a type that correctly defines MatchExpr.
+-spec make_catch_clause(any() | undefined, rufus_forms(), integer()) -> catch_clause_form().
 make_catch_clause(MatchExpr, Exprs, Line) ->
     {catch_clause, #{match_expr => MatchExpr, exprs => Exprs, line => Line}}.
 
+%% make_try_catch_after returns a form for a try/catch/after expression.
+-spec make_try_catch_after(rufus_forms(), list(catch_clause_form()), rufus_forms(), integer()) ->
+    try_catch_after_form().
 make_try_catch_after(TryExprs, CatchClauses, AfterExprs, Line) ->
     {try_catch_after, #{
         try_exprs => TryExprs,

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -261,6 +261,11 @@ make_match_op_right({match_op, #{line := Line}}) ->
 make_module(Spec, Line) ->
     {module, #{spec => Spec, line => Line}}.
 
+%% throw form builder API
+
+make_throw(Expr, Line) ->
+    {'throw', #{expr => Expr, line => Line}}.
+
 %% try/catch/after form builder API
 
 make_catch_clause(Exprs, Line) ->
@@ -268,9 +273,6 @@ make_catch_clause(Exprs, Line) ->
 
 make_catch_clause(MatchExpr, Exprs, Line) ->
     {catch_clause, #{match_expr => MatchExpr, exprs => Exprs, line => Line}}.
-
-make_throw(Expr, Line) ->
-    {'throw', #{expr => Expr, line => Line}}.
 
 make_try_catch_after(TryExprs, CatchClauses, AfterExprs, Line) ->
     {try_catch_after, #{

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -34,6 +34,7 @@
     make_match_op_right/1,
     make_module/2,
     make_param/3,
+    make_throw/2,
     make_try_catch_after/4,
     make_type/2,
     make_type/3,
@@ -267,6 +268,9 @@ make_catch_clause(Exprs, Line) ->
 
 make_catch_clause(MatchExpr, Exprs, Line) ->
     {catch_clause, #{match_expr => MatchExpr, exprs => Exprs, line => Line}}.
+
+make_throw(Expr, Line) ->
+    {'throw', #{expr => Expr, line => Line}}.
 
 make_try_catch_after(TryExprs, CatchClauses, AfterExprs, Line) ->
     {try_catch_after, #{

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -5,7 +5,7 @@
 Nonterminals
     root decl
     type types block param params args
-    expr exprs literal_expr
+    expr exprs literal_expr throw_expr
     catch_expr catch_match_clause catch_match_clauses
     binary_op call cons match_op match_op_param
     list_lit list_type.
@@ -20,7 +20,7 @@ Terminals
     '->'
     module import
     func identifier
-    try catch after
+    try catch after throw
     match
     atom atom_lit
     bool bool_lit
@@ -105,29 +105,31 @@ literal_expr -> string_lit       : rufus_form:make_literal(string, list_to_binar
 
 catch_expr -> param              : '$1'.
 
-expr  -> literal_expr            : '$1'.
-expr  -> identifier              : rufus_form:make_identifier(list_to_atom(text('$1')), line('$1')).
-expr  -> binary_op               : '$1'.
-expr  -> cons                    : '$1'.
-expr  -> match_op                : '$1'.
-expr  -> call                    : '$1'.
-expr  -> list_lit                : '$1'.
-expr  -> func '(' params ')' type '{' exprs '}' :
+expr -> literal_expr             : '$1'.
+expr -> identifier               : rufus_form:make_identifier(list_to_atom(text('$1')), line('$1')).
+expr -> binary_op                : '$1'.
+expr -> cons                     : '$1'.
+expr -> match_op                 : '$1'.
+expr -> call                     : '$1'.
+expr -> list_lit                 : '$1'.
+expr -> func '(' params ')' type '{' exprs '}' :
                                    rufus_form:make_func('$3', '$5', '$7', line('$1')).
-expr  -> try '{' exprs '}' after '{' exprs '}' :
+expr -> try '{' exprs '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [], '$7', line('$1')).
-expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' after '{' exprs '}' :
+expr -> try '{' exprs '}' catch catch_expr '{' exprs '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], '$12', line('$1')).
-expr  -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
+expr -> try '{' exprs '}' catch catch_expr '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$6', '$8', line('$5'))], [], line('$1')).
-expr  -> try '{' exprs '}' catch '{' exprs '}' after '{' exprs '}':
+expr -> try '{' exprs '}' catch '{' exprs '}' after '{' exprs '}':
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$7', line('$5'))], '$11', line('$1')).
-expr  -> try '{' exprs '}' catch '{' exprs '}' :
+expr -> try '{' exprs '}' catch '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', [rufus_form:make_catch_clause('$7', line('$5'))], [], line('$1')).
-expr  -> try '{' exprs '}' catch '{' catch_match_clauses '}' after '{' exprs '}' :
+expr -> try '{' exprs '}' catch '{' catch_match_clauses '}' after '{' exprs '}' :
                                    rufus_form:make_try_catch_after('$3', '$7', '$11', line('$1')).
-expr  -> try '{' exprs '}' catch '{' catch_match_clauses '}' :
+expr -> try '{' exprs '}' catch '{' catch_match_clauses '}' :
                                    rufus_form:make_try_catch_after('$3', '$7', [], line('$1')).
+
+throw_expr -> throw expr         : rufus_form:make_throw('$2', line('$1')).
 
 catch_match_clause -> match param '->' exprs :
                                    rufus_form:make_catch_clause('$2', '$4', line('$1')).
@@ -137,6 +139,8 @@ catch_match_clauses -> '$empty'  : [].
 
 exprs -> expr ';' exprs          : ['$1'|'$3'].
 exprs -> expr                    : ['$1'].
+exprs -> throw_expr ';' exprs    : ['$1'|'$3'].
+exprs -> throw_expr              : ['$1'].
 exprs -> '$empty'                : [].
 
 list_lit -> list_type '{' args '}' :

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -12,6 +12,7 @@ Module               = module
 Import               = import
 Const                = const
 Func                 = func
+Throw                = throw
 Try                  = try
 Catch                = catch
 After                = after
@@ -69,6 +70,7 @@ Rules.
 {Import}               : {token, {import, TokenLine}}.
 {Const}                : {token, {const, TokenLine}}.
 {Func}                 : {token, {func, TokenLine}}.
+{Throw}                : {token, {'throw', TokenLine}}.
 {Try}                  : {token, {'try', TokenLine}}.
 {Catch}                : {token, {'catch', TokenLine}}.
 {After}                : {token, {'after', TokenLine}}.

--- a/rf/src/rufus_type.hrl
+++ b/rf/src/rufus_type.hrl
@@ -69,6 +69,7 @@
 -type binary_op_form() :: {binary_op, context()}.
 -type match_op_form() :: {match_op, context()}.
 -type call_form() :: {call, context()}.
+-type throw_form() :: {'throw', context()}.
 -type try_catch_after_form() :: {try_catch_after, context()}.
 -type catch_clause_form() :: {catch_clause, context()}.
 
@@ -102,6 +103,7 @@
     | binary_op_form()
     | match_op_form()
     | call_form()
+    | throw_form()
     | try_catch_after_form().
 
 %% rufus_forms is a list of rufus_form instances and typically represents an

--- a/rf/test/rufus_compile_try_catch_after_test.erl
+++ b/rf/test/rufus_compile_try_catch_after_test.erl
@@ -90,7 +90,7 @@ eval_function_with_try_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(ok, example:'Maybe'()).
 
@@ -106,7 +106,7 @@ eval_function_with_bare_catch_block_and_an_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, example} = rufus_compile:eval(RufusText),
     ?assertEqual(ok, example:'Maybe'()).
 

--- a/rf/test/rufus_erlang_try_catch_after_test.erl
+++ b/rf/test/rufus_erlang_try_catch_after_test.erl
@@ -209,7 +209,7 @@ forms_for_function_with_try_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),
@@ -237,7 +237,7 @@ forms_for_function_with_bare_catch_block_and_an_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, ErlangForms} = rufus_erlang:forms(Forms),

--- a/rf/test/rufus_expr_try_catch_after_test.erl
+++ b/rf/test/rufus_expr_try_catch_after_test.erl
@@ -912,7 +912,7 @@ typecheck_and_annotate_function_with_bare_catch_block_and_an_after_block_test() 
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),

--- a/rf/test/rufus_form_test.erl
+++ b/rf/test/rufus_form_test.erl
@@ -328,6 +328,13 @@ make_module_test() ->
         }},
     ?assertEqual(Expected, rufus_form:make_module(example, 1)).
 
+make_throw_test() ->
+    Expr = rufus_form:make_literal(bool, true, 7),
+    ?assertEqual(
+        {'throw', #{expr => Expr, line => 7}},
+        rufus_form:make_throw(Expr, 7)
+    ).
+
 make_type_test() ->
     ?assertEqual(
         {type, #{spec => int, line => 4}},

--- a/rf/test/rufus_parse_throw_test.erl
+++ b/rf/test/rufus_parse_throw_test.erl
@@ -1,0 +1,235 @@
+-module(rufus_parse_throw_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_function_that_throws_an_atom_literal_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw :kaboom\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {atom_lit, #{
+                            line => 2,
+                            spec => kaboom,
+                            type => {type, #{line => 2, spec => atom}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_a_bool_literal_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw true\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {bool_lit, #{
+                            line => 2,
+                            spec => true,
+                            type => {type, #{line => 2, spec => bool}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_a_float_literal_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw 42.0\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {float_lit, #{
+                            line => 2,
+                            spec => 42.0,
+                            type => {type, #{line => 2, spec => float}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_an_int_literal_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw 42\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {int_lit, #{
+                            line => 2,
+                            spec => 42,
+                            type => {type, #{line => 2, spec => int}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_a_string_literal_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw \"kaboom\"\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {string_lit, #{
+                            line => 2,
+                            spec => <<"kaboom">>,
+                            type => {type, #{line => 2, spec => string}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_a_cons_expression_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw list[int]{2|tail}\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {cons, #{
+                            head =>
+                                {int_lit, #{
+                                    line => 2,
+                                    spec => 2,
+                                    type => {type, #{line => 2, spec => int}}
+                                }},
+                            line => 2,
+                            tail => {identifier, #{line => 2, spec => tail}},
+                            type =>
+                                {type, #{
+                                    element_type =>
+                                        {type, #{line => 2, spec => int}},
+                                    kind => list,
+                                    line => 2,
+                                    spec => 'list[int]'
+                                }}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_an_identifier_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw kaboom\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr => {identifier, #{line => 2, spec => kaboom}},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_that_throws_a_match_op_expression_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    throw a = b\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [
+                {throw, #{
+                    expr =>
+                        {match_op, #{
+                            left => {identifier, #{line => 2, spec => a}},
+                            line => 2,
+                            right => {identifier, #{line => 2, spec => b}}
+                        }},
+                    line => 2
+                }}
+            ],
+            line => 1,
+            params => [],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Explode'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_parse_throw_test.erl
+++ b/rf/test/rufus_parse_throw_test.erl
@@ -233,3 +233,13 @@ parse_function_that_throws_a_match_op_expression_test() ->
         }}
     ],
     ?assertEqual(Expected, Forms).
+
+%% Failure mode tests
+
+parse_function_with_throw_used_in_another_expression_test() ->
+    RufusText =
+        "func Explode() atom {\n"
+        "    a = throw :kaboom\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    ?assertMatch({error, _}, rufus_parse:parse(Tokens)).

--- a/rf/test/rufus_parse_try_catch_after_test.erl
+++ b/rf/test/rufus_parse_try_catch_after_test.erl
@@ -11,7 +11,7 @@ parse_function_with_bare_catch_block_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -72,7 +72,7 @@ parse_function_with_try_catch_block_with_single_atom_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -139,7 +139,7 @@ parse_function_with_try_catch_block_with_single_bool_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -206,7 +206,7 @@ parse_function_with_try_catch_block_with_single_float_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -273,7 +273,7 @@ parse_function_with_try_catch_block_with_single_int_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -340,7 +340,7 @@ parse_function_with_try_catch_block_with_single_string_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -407,7 +407,7 @@ parse_function_with_try_catch_block_with_single_cons_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -488,7 +488,7 @@ parse_function_with_try_catch_block_with_single_identifier_and_type_clause_test(
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -555,7 +555,7 @@ parse_function_with_try_catch_block_with_single_match_op_clause_test() ->
         "        log(\"oh no\")\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -633,7 +633,7 @@ parse_function_with_try_catch_block_with_single_atom_match_clause_test() ->
         "    match :error ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -688,7 +688,7 @@ parse_function_with_try_catch_block_with_single_bool_match_clause_test() ->
         "    match false ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -743,7 +743,7 @@ parse_function_with_try_catch_block_with_single_float_match_clause_test() ->
         "    match 42.0 ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -798,7 +798,7 @@ parse_function_with_try_catch_block_with_single_int_match_clause_test() ->
         "    match 42 ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -853,7 +853,7 @@ parse_function_with_try_catch_block_with_single_string_match_clause_test() ->
         "    match \"error\" ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -908,7 +908,7 @@ parse_function_with_try_catch_block_with_single_cons_match_clause_test() ->
         "    match list[atom]{:error|tail} ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -977,7 +977,7 @@ parse_function_with_try_catch_block_with_single_identifier_and_type_match_clause
         "    match errorCode atom ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1032,7 +1032,7 @@ parse_function_with_try_catch_block_with_single_match_op_match_clause_test() ->
         "    match :error = errorCode atom ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1101,7 +1101,7 @@ parse_function_with_try_catch_block_with_multiple_clauses_test() ->
         "    match :failure ->\n"
         "        :failure\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1186,7 +1186,7 @@ parse_function_with_try_catch_block_with_single_match_clause_test() ->
         "    match :error ->\n"
         "        :error\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1242,7 +1242,7 @@ parse_function_with_try_after_block_test() ->
         "        firstCleanup()\n"
         "        secondCleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1283,7 +1283,7 @@ parse_function_with_bare_catch_block_and_an_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1333,7 +1333,7 @@ parse_function_with_try_catch_block_with_single_clause_and_after_block_test() ->
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1392,7 +1392,7 @@ parse_function_with_try_catch_block_with_single_match_clause_and_after_block_tes
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [
@@ -1451,7 +1451,7 @@ parse_function_with_try_catch_block_with_multiple_clauses_and_after_block_test()
         "    } after {\n"
         "        cleanup()\n"
         "    }\n"
-        "}",
+        "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
     Expected = [

--- a/rf/test/rufus_raw_tokenize_throw_test.erl
+++ b/rf/test/rufus_raw_tokenize_throw_test.erl
@@ -1,0 +1,14 @@
+-module(rufus_raw_tokenize_throw_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+string_with_throw_expression_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("throw :kaboom\n"),
+    ?assertEqual(
+        [
+            {throw, 1},
+            {atom_lit, 1, kaboom},
+            {eol, 1}
+        ],
+        Tokens
+    ).


### PR DESCRIPTION
`rufus_raw_tokenize:string/1` and `rufus_parse:parse/1` both support `throw` expressions.