### PR TITLE
compiler: Typecheck annotate forms in Erlang form tests

### DIFF
--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -69,44 +69,70 @@ resolve_binary_op_type(
     {AllowType, AllowTypePair} =
         case Op of
             '+' ->
-                {fun allow_type_with_mathematical_operator/2,
-                    fun allow_type_pair_with_mathematical_operator/2};
+                {
+                    fun allow_type_with_mathematical_operator/2,
+                    fun allow_type_pair_with_mathematical_operator/2
+                };
             '-' ->
-                {fun allow_type_with_mathematical_operator/2,
-                    fun allow_type_pair_with_mathematical_operator/2};
+                {
+                    fun allow_type_with_mathematical_operator/2,
+                    fun allow_type_pair_with_mathematical_operator/2
+                };
             '*' ->
-                {fun allow_type_with_mathematical_operator/2,
-                    fun allow_type_pair_with_mathematical_operator/2};
+                {
+                    fun allow_type_with_mathematical_operator/2,
+                    fun allow_type_pair_with_mathematical_operator/2
+                };
             '/' ->
-                {fun allow_type_with_mathematical_operator/2,
-                    fun allow_type_pair_with_mathematical_operator/2};
+                {
+                    fun allow_type_with_mathematical_operator/2,
+                    fun allow_type_pair_with_mathematical_operator/2
+                };
             '%' ->
-                {fun allow_type_with_mathematical_operator/2,
-                    fun allow_type_pair_with_mathematical_operator/2};
+                {
+                    fun allow_type_with_mathematical_operator/2,
+                    fun allow_type_pair_with_mathematical_operator/2
+                };
             'and' ->
-                {fun allow_type_with_conditional_operator/2,
-                    fun allow_type_pair_with_conditional_operator/2};
+                {
+                    fun allow_type_with_conditional_operator/2,
+                    fun allow_type_pair_with_conditional_operator/2
+                };
             'or' ->
-                {fun allow_type_with_conditional_operator/2,
-                    fun allow_type_pair_with_conditional_operator/2};
+                {
+                    fun allow_type_with_conditional_operator/2,
+                    fun allow_type_pair_with_conditional_operator/2
+                };
             '==' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2};
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                };
             '!=' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2};
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                };
             '<' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2};
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                };
             '<=' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2};
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                };
             '>' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2};
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                };
             '>=' ->
-                {fun allow_type_with_comparison_operator/2,
-                    fun allow_type_pair_with_comparison_operator/2}
+                {
+                    fun allow_type_with_comparison_operator/2,
+                    fun allow_type_pair_with_comparison_operator/2
+                }
         end,
 
     ok =

--- a/rf/test/rufus_erlang_binary_op_test.erl
+++ b/rf/test/rufus_erlang_binary_op_test.erl
@@ -12,7 +12,8 @@ forms_for_function_returning_a_sum_of_int_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '+', {integer, 3, 19}, {integer, 3, 23}},
     Expected = [
         {attribute, 2, module, example},
@@ -48,7 +49,8 @@ forms_for_function_returning_a_sum_of_float_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '+', {float, 3, 1.0}, {float, 3, 2.14159265359}},
     Expected = [
         {attribute, 2, module, example},
@@ -67,7 +69,8 @@ forms_for_function_returning_a_difference_of_int_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '-', {integer, 3, 55}, {integer, 3, 13}},
     Expected = [
         {attribute, 2, module, example},
@@ -103,7 +106,8 @@ forms_for_function_returning_a_difference_of_float_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '-', {float, 3, 4.14159265359}, {float, 3, 1.0}},
     Expected = [
         {attribute, 2, module, example},
@@ -122,7 +126,8 @@ forms_for_function_returning_a_product_of_int_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '*', {integer, 3, 3}, {integer, 3, 14}},
     Expected = [
         {attribute, 2, module, example},
@@ -158,7 +163,8 @@ forms_for_function_returning_a_product_of_float_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '*', {float, 3, 1.0}, {float, 3, 3.14159265359}},
     Expected = [
         {attribute, 2, module, example},
@@ -177,7 +183,8 @@ forms_for_function_returning_a_division_of_int_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, 'div', {integer, 3, 84}, {integer, 3, 2}},
     Expected = [
         {attribute, 2, module, example},
@@ -213,7 +220,8 @@ forms_for_function_returning_a_division_of_float_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, '/', {float, 3, 5.5}, {float, 3, 2.0}},
     Expected = [
         {attribute, 2, module, example},
@@ -232,7 +240,8 @@ forms_for_function_returning_a_remainder_of_int_literals_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, 'rem', {integer, 3, 27}, {integer, 3, 7}},
     Expected = [
         {attribute, 2, module, example},
@@ -270,7 +279,8 @@ forms_for_function_returning_a_boolean_from_an_and_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, 'andalso', {atom, 3, true}, {atom, 3, false}},
     Expected = [
         {attribute, 2, module, example},
@@ -288,7 +298,8 @@ forms_for_function_returning_a_boolean_from_an_and_operation_with_a_call_operand
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 4, 'andalso', {atom, 4, true}, {call, 4, {atom, 4, 'False'}, []}},
     Expected = [
         {attribute, 2, module, example},
@@ -307,7 +318,8 @@ forms_for_function_returning_a_boolean_from_an_or_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     BinaryOpExpr = {op, 3, 'orelse', {atom, 3, true}, {atom, 3, false}},
     Expected = [
         {attribute, 2, module, example},
@@ -366,7 +378,8 @@ forms_for_function_with_an_equality_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
@@ -384,7 +397,8 @@ forms_for_function_with_an_inequality_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
@@ -402,7 +416,8 @@ forms_for_function_with_a_less_than_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
@@ -420,7 +435,8 @@ forms_for_function_with_a_less_than_or_equal_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
@@ -438,7 +454,8 @@ forms_for_function_with_a_greater_than_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},
@@ -456,7 +473,8 @@ forms_for_function_with_a_greater_than_or_equal_comparison_operation_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Truthy', 0}]},

--- a/rf/test/rufus_erlang_func_test.erl
+++ b/rf/test/rufus_erlang_func_test.erl
@@ -12,7 +12,8 @@ forms_for_function_returning_an_atom_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     AtomExpr = {atom, 3, pong},
     Expected = [
         {attribute, 2, module, example},
@@ -29,7 +30,8 @@ forms_for_function_returning_a_bool_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'False', 0}]},
@@ -45,7 +47,8 @@ forms_for_function_returning_a_float_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Pi', 0}]},
@@ -61,7 +64,8 @@ forms_for_function_returning_an_int_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Number', 0}]},
@@ -77,7 +81,8 @@ forms_for_function_returning_a_string_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     StringExpr = {bin, 3, [{bin_element, 3, {string, 3, "Hello"}, default, default}]},
     BoxedStringExpr = {tuple, 3, [{atom, 3, string}, StringExpr]},
     Expected = [
@@ -100,7 +105,8 @@ forms_for_function_with_multiple_expressions_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Exprs = [{integer, 4, 42}, {atom, 5, fortytwo}],
     Expected = [
         {attribute, 2, module, example},
@@ -121,7 +127,8 @@ forms_for_function_with_multiple_expressions_with_blank_lines_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Exprs = [{integer, 4, 42}, {atom, 6, fortytwo}],
     Expected = [
         {attribute, 2, module, example},
@@ -140,7 +147,8 @@ forms_for_function_taking_an_unused_atom_and_returning_an_atom_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'Ping', 1}]},
@@ -161,8 +169,8 @@ forms_for_function_taking_an_unused_bool_and_returning_a_bool_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
-
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
@@ -182,7 +190,8 @@ forms_for_function_taking_an_unused_float_and_returning_a_float_literal_test() -
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
@@ -203,7 +212,8 @@ forms_for_function_taking_an_unused_int_and_returning_an_int_literal_test() ->
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 2, module, example},
         {attribute, 3, export, [{'MaybeEcho', 1}]},
@@ -223,7 +233,8 @@ forms_for_function_taking_an_unused_string_and_returning_a_string_literal_test()
         "    ",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     StringExpr = {bin_element, 3, {string, 3, "Hello"}, default, default},
     Expected = [
         {attribute, 2, module, example},

--- a/rf/test/rufus_erlang_try_catch_after_test.erl
+++ b/rf/test/rufus_erlang_try_catch_after_test.erl
@@ -44,7 +44,8 @@ forms_for_function_with_try_and_catch_blocks_both_returning_an_atom_literal_test
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 2, export, [{'Maybe', 0}]},
@@ -75,7 +76,8 @@ forms_for_function_with_try_and_catch_blocks_both_returning_a_bool_literal_test(
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 2, export, [{'Maybe', 0}]},
@@ -106,7 +108,8 @@ forms_for_function_with_try_and_catch_blocks_both_returning_a_float_literal_test
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 2, export, [{'Maybe', 0}]},
@@ -137,7 +140,8 @@ forms_for_function_with_try_and_catch_blocks_both_returning_an_int_literal_test(
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 2, export, [{'Maybe', 0}]},
@@ -168,7 +172,8 @@ forms_for_function_with_try_and_catch_blocks_both_returning_a_string_literal_tes
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 2, export, [{'Maybe', 0}]},
@@ -212,7 +217,8 @@ forms_for_function_with_try_after_block_test() ->
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 3, export, [{'Maybe', 0}]},
@@ -240,7 +246,8 @@ forms_for_function_with_bare_catch_block_and_an_after_block_test() ->
         "}\n",
     {ok, Tokens} = rufus_tokenize:string(RufusText),
     {ok, Forms} = rufus_parse:parse(Tokens),
-    {ok, ErlangForms} = rufus_erlang:forms(Forms),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    {ok, ErlangForms} = rufus_erlang:forms(AnnotatedForms),
     Expected = [
         {attribute, 1, module, example},
         {attribute, 3, export, [{'Maybe', 0}]},


### PR DESCRIPTION
All tests for `rufus_erlang:forms/1` typecheck and annotate Rufus forms before transforming them into Erlang forms. This isn't strictly necessary for all code paths, but it makes the tests match the runtime environment where Rufus forms are always typechecked and annotated before being transformed into Erlang forms.