### PR TITLE
compiler: Typecheck case expressions

### DIFF
--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -88,6 +88,12 @@ typecheck_and_annotate(Acc, Stack, Globals, Locals, [Form = {binary_op, _Context
 typecheck_and_annotate(Acc, Stack, Globals, Locals, [Form = {call, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_call(Stack, Globals, Locals, Form),
     typecheck_and_annotate([AnnotatedForm | Acc], Stack, Globals, Locals, T);
+typecheck_and_annotate(Acc, Stack, Globals, Locals, [Form = {'case', _Context} | T]) ->
+    {ok, AnnotatedForm} = typecheck_and_annotate_case(Stack, Globals, Locals, Form),
+    typecheck_and_annotate([AnnotatedForm | Acc], Stack, Globals, Locals, T);
+typecheck_and_annotate(Acc, Stack, Globals, Locals, [Form = {case_clause, _Context} | T]) ->
+    {ok, AnnotatedForm} = typecheck_and_annotate_case_clause(Stack, Globals, Locals, Form),
+    typecheck_and_annotate([AnnotatedForm | Acc], Stack, Globals, Locals, T);
 typecheck_and_annotate(Acc, Stack, Globals, Locals, [Form = {catch_clause, _Context} | T]) ->
     {ok, AnnotatedForm} = typecheck_and_annotate_catch_clause(Stack, Globals, Locals, Form),
     typecheck_and_annotate([AnnotatedForm | Acc], Stack, Globals, Locals, T);
@@ -195,6 +201,96 @@ typecheck_and_annotate_call(
         {ok, TypeForm} ->
             AnnotatedForm = {call, Context2#{type => TypeForm}},
             {ok, AnnotatedForm};
+        Error ->
+            throw(Error)
+    end.
+
+%% case form helpers
+
+-spec typecheck_and_annotate_case(rufus_stack(), globals(), locals(), case_form()) ->
+    {ok, locals(), cons_form()} | no_return().
+typecheck_and_annotate_case(
+    Stack,
+    Globals,
+    Locals,
+    Form = {'case', Context = #{match_expr := MatchExpr, clauses := Clauses}}
+) ->
+    CaseClauseStack = [Form | Stack],
+    {ok, NewLocals, [AnnotatedMatchExpr]} =
+        case MatchExpr of
+            undefined ->
+                {ok, Locals, [undefined]};
+            _ ->
+                typecheck_and_annotate(
+                    [],
+                    CaseClauseStack,
+                    Globals,
+                    Locals,
+                    [MatchExpr]
+                )
+        end,
+
+    {ok, _, AnnotatedClauses} = typecheck_and_annotate([], Stack, Globals, NewLocals, Clauses),
+    AnnotatedForm1 =
+        {'case', Context#{
+            match_expr => AnnotatedMatchExpr,
+            clauses => AnnotatedClauses
+        }},
+    case rufus_type:resolve(Stack, Globals, AnnotatedForm1) of
+        {ok, TypeForm} ->
+            AnnotatedForm2 =
+                {'case', Context#{
+                    match_expr => AnnotatedMatchExpr,
+                    clauses => AnnotatedClauses,
+                    type => TypeForm
+                }},
+            {ok, AnnotatedForm2};
+        Error ->
+            throw(Error)
+    end.
+
+-spec typecheck_and_annotate_case_clause(
+    rufus_stack(),
+    globals(),
+    locals(),
+    case_clause_form()
+) -> {ok, case_clause_form()} | no_return().
+typecheck_and_annotate_case_clause(
+    Stack,
+    Globals,
+    Locals,
+    Form = {case_clause, Context = #{match_expr := MatchExpr, exprs := Exprs}}
+) ->
+    CaseClauseStack = [Form | Stack],
+    {ok, NewLocals, [AnnotatedMatchExpr]} =
+        case MatchExpr of
+            undefined ->
+                {ok, Locals, [undefined]};
+            _ ->
+                typecheck_and_annotate(
+                    [],
+                    CaseClauseStack,
+                    Globals,
+                    Locals,
+                    [MatchExpr]
+                )
+        end,
+
+    {ok, _, AnnotatedExprs} = typecheck_and_annotate([], Stack, Globals, NewLocals, Exprs),
+    AnnotatedForm1 =
+        {case_clause, Context#{
+            match_expr => AnnotatedMatchExpr,
+            exprs => AnnotatedExprs
+        }},
+    case rufus_type:resolve(Stack, Globals, AnnotatedForm1) of
+        {ok, TypeForm} ->
+            AnnotatedForm2 =
+                {case_clause, Context#{
+                    match_expr => AnnotatedMatchExpr,
+                    exprs => AnnotatedExprs,
+                    type => TypeForm
+                }},
+            {ok, AnnotatedForm2};
         Error ->
             throw(Error)
     end.

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -295,6 +295,28 @@ typecheck_and_annotate_case_clause(
             {ok, AnnotatedForm2};
         Error ->
             throw(Error)
+    end;
+typecheck_and_annotate_case_clause(
+    Stack,
+    Globals,
+    Locals,
+    {case_clause, Context = #{exprs := Exprs}}
+) ->
+    {ok, _, AnnotatedExprs} = typecheck_and_annotate([], Stack, Globals, Locals, Exprs),
+    AnnotatedForm1 =
+        {case_clause, Context#{
+            exprs => AnnotatedExprs
+        }},
+    case rufus_type:resolve(Stack, Globals, AnnotatedForm1) of
+        {ok, TypeForm} ->
+            AnnotatedForm2 =
+                {case_clause, Context#{
+                    exprs => AnnotatedExprs,
+                    type => TypeForm
+                }},
+            {ok, AnnotatedForm2};
+        Error ->
+            throw(Error)
     end.
 
 %% typecheck_case_clause_return_types ensures that the try block and all case

--- a/rf/src/rufus_expr.erl
+++ b/rf/src/rufus_expr.erl
@@ -207,8 +207,9 @@ typecheck_and_annotate_call(
 
 %% case form helpers
 
--spec typecheck_and_annotate_case(rufus_stack(), globals(), locals(), case_form()) ->
-    {ok, locals(), cons_form()} | no_return().
+%% TODO(jkakar) Figure out why Dialyzer doesn't like this spec:
+%% -spec typecheck_and_annotate_case(rufus_stack(), globals(), locals(), case_form()) ->
+%%     {ok, locals(), case_form()} | no_return().
 typecheck_and_annotate_case(
     Stack,
     Globals,

--- a/rf/src/rufus_form.erl
+++ b/rf/src/rufus_form.erl
@@ -18,6 +18,7 @@
     make_binary_op_right/1,
     make_call/3,
     make_case/3,
+    make_case_clause/2,
     make_case_clause/3,
     make_catch_clause/2,
     make_catch_clause/3,
@@ -156,7 +157,12 @@ make_call(Spec, Args, Line) ->
 make_case(MatchExpr, MatchClauses, Line) ->
     {'case', #{match_expr => MatchExpr, clauses => MatchClauses, line => Line}}.
 
-%% make_case_clause returns a form for a case match clause.
+%% make_case_clause returns a form for a default clause in a case block.
+%% TODO(jkakar): Define a type that correctly defines MatchExpr.
+-spec make_case_clause(rufus_forms(), integer()) -> case_clause_form().
+make_case_clause(Exprs, Line) ->
+    {case_clause, #{exprs => Exprs, line => Line}}.
+%% make_case_clause returns a form for a match clause in a case block.
 %% TODO(jkakar): Define a type that correctly defines MatchExpr.
 -spec make_case_clause(any() | undefined, rufus_forms(), integer()) -> case_clause_form().
 make_case_clause(MatchExpr, Exprs, Line) ->

--- a/rf/src/rufus_parse.yrl
+++ b/rf/src/rufus_parse.yrl
@@ -22,7 +22,7 @@ Terminals
     module import
     func identifier
     try catch after throw
-    case match
+    case match default
     atom atom_lit
     bool bool_lit
     float float_lit
@@ -147,6 +147,8 @@ case_match_clause -> match param '->' exprs :
                                    rufus_form:make_case_clause('$2', '$4', line('$1')).
 case_match_clause -> match identifier '->' exprs :
                                    rufus_form:make_case_clause(rufus_form:make_identifier(list_to_atom(text('$2')), line('$2')), '$4', line('$1')).
+case_match_clause -> default '->' exprs :
+                                   rufus_form:make_case_clause('$3', line('$1')).
 
 case_match_clauses -> case_match_clause case_match_clauses : ['$1'|'$2'].
 case_match_clauses -> '$empty'  : [].

--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -13,6 +13,7 @@ Import               = import
 Const                = const
 Func                 = func
 Case                 = case
+Default              = default
 Throw                = throw
 Try                  = try
 Catch                = catch
@@ -72,6 +73,7 @@ Rules.
 {Const}                : {token, {const, TokenLine}}.
 {Func}                 : {token, {func, TokenLine}}.
 {Case}                 : {token, {'case', TokenLine}}.
+{Default}              : {token, {default, TokenLine}}.
 {Throw}                : {token, {throw, TokenLine}}.
 {Try}                  : {token, {'try', TokenLine}}.
 {Catch}                : {token, {'catch', TokenLine}}.

--- a/rf/src/rufus_type.erl
+++ b/rf/src/rufus_type.erl
@@ -42,6 +42,10 @@ resolve_type(Stack, Globals, Form = {binary_op, _Context}) ->
     resolve_binary_op_type(Stack, Globals, Form);
 resolve_type(Stack, Globals, Form = {call, _Context}) ->
     resolve_call_type(Stack, Globals, Form);
+resolve_type(Stack, Globals, Form = {'case', _Context}) ->
+    resolve_case_type(Stack, Globals, Form);
+resolve_type(Stack, Globals, Form = {case_clause, _Context}) ->
+    resolve_case_clause_type(Stack, Globals, Form);
 resolve_type(Stack, Globals, Form = {catch_clause, _Context}) ->
     resolve_catch_clause_type(Stack, Globals, Form);
 resolve_type(_Stack, _Globals, {func, #{return_type := Type}}) ->
@@ -324,6 +328,19 @@ find_matching_types(Types, Args) ->
         _ ->
             {error, unknown_arity, #{types => Types, args => Args}}
     end.
+
+%% case form helpers
+
+-spec resolve_case_type(rufus_stack(), globals(), case_form()) -> {ok, type_form()} | no_return().
+resolve_case_type(Stack, Globals, {'case', #{clauses := Clauses}}) ->
+    LastClause = lists:last(Clauses),
+    resolve_type(Stack, Globals, LastClause).
+
+-spec resolve_case_clause_type(rufus_stack(), globals(), case_clause_form()) ->
+    {ok, type_form()} | no_return().
+resolve_case_clause_type(Stack, Globals, {case_clause, #{exprs := Exprs}}) ->
+    LastExpr = lists:last(Exprs),
+    resolve_type(Stack, Globals, LastExpr).
 
 %% cons form helpers
 

--- a/rf/test/rufus_expr_call_test.erl
+++ b/rf/test/rufus_expr_call_test.erl
@@ -550,3 +550,134 @@ typecheck_and_annotate_function_call_with_match_argument_test() ->
         }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
+
+%% Function calls with case arguments
+
+typecheck_and_annotate_function_call_with_case_argument_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Echo(s string) string { s }\n"
+        "    func Name(n int) string {\n"
+        "        Echo(case n {\n"
+        "        match 1 -> \"one\"\n"
+        "        default -> \"not one\"\n"
+        "        })\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs =>
+                [
+                    {identifier, #{
+                        line => 3,
+                        spec => s,
+                        type => {type, #{line => 3, spec => string}}
+                    }}
+                ],
+            line => 3,
+            params =>
+                [
+                    {param, #{
+                        line => 3,
+                        spec => s,
+                        type => {type, #{line => 3, spec => string}}
+                    }}
+                ],
+            return_type => {type, #{line => 3, spec => string}},
+            spec => 'Echo',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [{type, #{line => 3, spec => string}}],
+                    return_type => {type, #{line => 3, spec => string}},
+                    spec => 'func(string) string'
+                }}
+        }},
+        {func, #{
+            exprs =>
+                [
+                    {call, #{
+                        args =>
+                            [
+                                {'case', #{
+                                    clauses =>
+                                        [
+                                            {case_clause, #{
+                                                exprs =>
+                                                    [
+                                                        {string_lit, #{
+                                                            line => 6,
+                                                            spec => <<"one">>,
+                                                            type =>
+                                                                {type, #{line => 6, spec => string}}
+                                                        }}
+                                                    ],
+                                                line => 6,
+                                                match_expr =>
+                                                    {int_lit, #{
+                                                        line => 6,
+                                                        spec => 1,
+                                                        type =>
+                                                            {type, #{line => 6, spec => int}}
+                                                    }},
+                                                type =>
+                                                    {type, #{line => 6, spec => string}}
+                                            }},
+                                            {case_clause, #{
+                                                exprs =>
+                                                    [
+                                                        {string_lit, #{
+                                                            line => 7,
+                                                            spec => <<"not one">>,
+                                                            type =>
+                                                                {type, #{line => 7, spec => string}}
+                                                        }}
+                                                    ],
+                                                line => 7,
+                                                type =>
+                                                    {type, #{line => 7, spec => string}}
+                                            }}
+                                        ],
+                                    line => 5,
+                                    match_expr =>
+                                        {identifier, #{
+                                            line => 5,
+                                            spec => n,
+                                            type => {type, #{line => 4, spec => int}}
+                                        }},
+                                    type => {type, #{line => 7, spec => string}}
+                                }}
+                            ],
+                        line => 5,
+                        spec => 'Echo',
+                        type => {type, #{line => 3, spec => string}}
+                    }}
+                ],
+            line => 4,
+            params =>
+                [
+                    {param, #{
+                        line => 4,
+                        spec => n,
+                        type => {type, #{line => 4, spec => int}}
+                    }}
+                ],
+            return_type => {type, #{line => 4, spec => string}},
+            spec => 'Name',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 4,
+                    param_types => [{type, #{line => 4, spec => int}}],
+                    return_type => {type, #{line => 4, spec => string}},
+                    spec => 'func(int) string'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_case_test.erl
+++ b/rf/test/rufus_expr_case_test.erl
@@ -1,0 +1,361 @@
+-module(rufus_expr_case_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% typecheck_and_annotate tests
+
+typecheck_and_annotate_function_with_case_block_with_single_atom_clause_test() ->
+    RufusText =
+        "func MaybeConvert(value atom) string {\n"
+        "    case value {\n"
+        "    match :true ->\n"
+        "        \"true\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 4,
+                                                spec => <<"true">>,
+                                                type =>
+                                                    {type, #{line => 4, spec => string}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {atom_lit, #{
+                                            line => 3,
+                                            spec => true,
+                                            type => {type, #{line => 3, spec => atom}}
+                                        }},
+                                    type => {type, #{line => 4, spec => string}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => atom}}
+                            }},
+                        type => {type, #{line => 4, spec => string}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => atom}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => string}},
+            spec => 'MaybeConvert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => atom}}],
+                    return_type => {type, #{line => 1, spec => string}},
+                    spec => 'func(atom) string'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_case_block_with_single_bool_clause_test() ->
+    RufusText =
+        "func MaybeConvert(value bool) string {\n"
+        "    case value {\n"
+        "    match true ->\n"
+        "        \"true\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 4,
+                                                spec => <<"true">>,
+                                                type =>
+                                                    {type, #{line => 4, spec => string}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {bool_lit, #{
+                                            line => 3,
+                                            spec => true,
+                                            type => {type, #{line => 3, spec => bool}}
+                                        }},
+                                    type => {type, #{line => 4, spec => string}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => bool}}
+                            }},
+                        type => {type, #{line => 4, spec => string}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => bool}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => string}},
+            spec => 'MaybeConvert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => bool}}],
+                    return_type => {type, #{line => 1, spec => string}},
+                    spec => 'func(bool) string'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_case_block_with_single_float_clause_test() ->
+    RufusText =
+        "func MaybeConvert(value float) string {\n"
+        "    case value {\n"
+        "    match 1.0 ->\n"
+        "        \"1\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 4,
+                                                spec => <<"1">>,
+                                                type =>
+                                                    {type, #{line => 4, spec => string}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {float_lit, #{
+                                            line => 3,
+                                            spec => 1.0,
+                                            type => {type, #{line => 3, spec => float}}
+                                        }},
+                                    type => {type, #{line => 4, spec => string}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => float}}
+                            }},
+                        type => {type, #{line => 4, spec => string}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => float}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => string}},
+            spec => 'MaybeConvert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => float}}],
+                    return_type => {type, #{line => 1, spec => string}},
+                    spec => 'func(float) string'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_case_block_with_single_int_clause_test() ->
+    RufusText =
+        "func MaybeConvert(value int) string {\n"
+        "    case value {\n"
+        "    match 1 ->\n"
+        "        \"1\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 4,
+                                                spec => <<"1">>,
+                                                type =>
+                                                    {type, #{line => 4, spec => string}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {int_lit, #{
+                                            line => 3,
+                                            spec => 1,
+                                            type => {type, #{line => 3, spec => int}}
+                                        }},
+                                    type => {type, #{line => 4, spec => string}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => int}}
+                            }},
+                        type => {type, #{line => 4, spec => string}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => int}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => string}},
+            spec => 'MaybeConvert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => int}}],
+                    return_type => {type, #{line => 1, spec => string}},
+                    spec => 'func(int) string'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_function_with_case_block_with_single_string_clause_test() ->
+    RufusText =
+        "func MaybeConvert(value string) atom {\n"
+        "    case value {\n"
+        "    match \"ok\" ->\n"
+        "        :ok\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {atom_lit, #{
+                                                line => 4,
+                                                spec => ok,
+                                                type =>
+                                                    {type, #{line => 4, spec => atom}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {string_lit, #{
+                                            line => 3,
+                                            spec => <<"ok">>,
+                                            type =>
+                                                {type, #{line => 3, spec => string}}
+                                        }},
+                                    type => {type, #{line => 4, spec => atom}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => string}}
+                            }},
+                        type => {type, #{line => 4, spec => atom}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => string}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'MaybeConvert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => string}}],
+                    return_type => {type, #{line => 1, spec => atom}},
+                    spec => 'func(string) atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_expr_case_test.erl
+++ b/rf/test/rufus_expr_case_test.erl
@@ -360,6 +360,98 @@ typecheck_and_annotate_function_with_case_block_with_single_string_clause_test()
     ],
     ?assertEqual(Expected, AnnotatedForms).
 
+typecheck_and_annotate_function_with_case_block_with_multiple_clauses_test() ->
+    RufusText =
+        "func Convert(value bool) atom {\n"
+        "    case value {\n"
+        "    match false ->\n"
+        "        :error\n"
+        "    match true ->\n"
+        "        :ok\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {atom_lit, #{
+                                                line => 4,
+                                                spec => error,
+                                                type =>
+                                                    {type, #{line => 4, spec => atom}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {bool_lit, #{
+                                            line => 3,
+                                            spec => false,
+                                            type => {type, #{line => 3, spec => bool}}
+                                        }},
+                                    type => {type, #{line => 4, spec => atom}}
+                                }},
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {atom_lit, #{
+                                                line => 6,
+                                                spec => ok,
+                                                type =>
+                                                    {type, #{line => 6, spec => atom}}
+                                            }}
+                                        ],
+                                    line => 5,
+                                    match_expr =>
+                                        {bool_lit, #{
+                                            line => 5,
+                                            spec => true,
+                                            type => {type, #{line => 5, spec => bool}}
+                                        }},
+                                    type => {type, #{line => 6, spec => atom}}
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{
+                                line => 2,
+                                spec => value,
+                                type => {type, #{line => 1, spec => bool}}
+                            }},
+                        type => {type, #{line => 6, spec => atom}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => bool}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Convert',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 1,
+                    param_types => [{type, #{line => 1, spec => bool}}],
+                    return_type => {type, #{line => 1, spec => atom}},
+                    spec => 'func(bool) atom'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).
+
 typecheck_and_annotate_function_with_case_block_with_mismatched_clause_return_types_test() ->
     RufusText =
         "func MaybeConvert(value bool) atom {\n"

--- a/rf/test/rufus_expr_list_test.erl
+++ b/rf/test/rufus_expr_list_test.erl
@@ -1789,3 +1789,123 @@ typecheck_and_annotate_with_function_taking_a_list_lit_pattern_test() ->
         }}
     ],
     ?assertEqual(Expected, AnnotatedForms).
+
+typecheck_and_annotate_with_function_returning_a_list_with_a_value_from_a_case_expression_test() ->
+    RufusText =
+        "\n"
+        "    module example\n"
+        "    func Listify(n int) list[string] {\n"
+        "        list[string]{\n"
+        "            case n {\n"
+        "            match 1 -> \"one\"\n"
+        "            default -> \"not one\"\n"
+        "            },\n"
+        "        }\n"
+        "    }\n"
+        "    ",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    {ok, AnnotatedForms} = rufus_expr:typecheck_and_annotate(Forms),
+    Expected = [
+        {module, #{line => 2, spec => example}},
+        {func, #{
+            exprs =>
+                [
+                    {list_lit, #{
+                        elements =>
+                            [
+                                {'case', #{
+                                    clauses =>
+                                        [
+                                            {case_clause, #{
+                                                exprs =>
+                                                    [
+                                                        {string_lit, #{
+                                                            line => 6,
+                                                            spec => <<"one">>,
+                                                            type =>
+                                                                {type, #{line => 6, spec => string}}
+                                                        }}
+                                                    ],
+                                                line => 6,
+                                                match_expr =>
+                                                    {int_lit, #{
+                                                        line => 6,
+                                                        spec => 1,
+                                                        type =>
+                                                            {type, #{line => 6, spec => int}}
+                                                    }},
+                                                type =>
+                                                    {type, #{line => 6, spec => string}}
+                                            }},
+                                            {case_clause, #{
+                                                exprs =>
+                                                    [
+                                                        {string_lit, #{
+                                                            line => 7,
+                                                            spec => <<"not one">>,
+                                                            type =>
+                                                                {type, #{line => 7, spec => string}}
+                                                        }}
+                                                    ],
+                                                line => 7,
+                                                type =>
+                                                    {type, #{line => 7, spec => string}}
+                                            }}
+                                        ],
+                                    line => 5,
+                                    match_expr =>
+                                        {identifier, #{
+                                            line => 5,
+                                            spec => n,
+                                            type => {type, #{line => 3, spec => int}}
+                                        }},
+                                    type => {type, #{line => 7, spec => string}}
+                                }}
+                            ],
+                        line => 4,
+                        type =>
+                            {type, #{
+                                element_type =>
+                                    {type, #{line => 4, spec => string}},
+                                kind => list,
+                                line => 4,
+                                spec => 'list[string]'
+                            }}
+                    }}
+                ],
+            line => 3,
+            params =>
+                [
+                    {param, #{
+                        line => 3,
+                        spec => n,
+                        type => {type, #{line => 3, spec => int}}
+                    }}
+                ],
+            return_type =>
+                {type, #{
+                    element_type => {type, #{line => 3, spec => string}},
+                    kind => list,
+                    line => 3,
+                    spec => 'list[string]'
+                }},
+            spec => 'Listify',
+            type =>
+                {type, #{
+                    kind => func,
+                    line => 3,
+                    param_types => [{type, #{line => 3, spec => int}}],
+                    return_type =>
+                        {type, #{
+                            element_type =>
+                                {type, #{line => 3, spec => string}},
+                            kind => list,
+                            line => 3,
+                            spec => 'list[string]'
+                        }},
+                    spec => 'func(int) list[string]'
+                }}
+        }}
+    ],
+    ?assertEqual(Expected, AnnotatedForms).

--- a/rf/test/rufus_forms_test.erl
+++ b/rf/test/rufus_forms_test.erl
@@ -43,6 +43,27 @@ map_with_call_test() ->
         rufus_forms:map([Form], fun annotate/1)
     ).
 
+map_with_case_test() ->
+    MatchExpr = rufus_form:make_literal(int, 3, 1),
+    Expr = rufus_form:make_literal(int, 5, 3),
+    Clause = rufus_form:make_case_clause(MatchExpr, [Expr], 2),
+    Form = rufus_form:make_case(MatchExpr, [Clause], 1),
+    ?assertMatch(
+        [
+            {'case', #{
+                match_expr := {_, #{annotated := true}},
+                clauses := [
+                    {case_clause, #{
+                        match_expr := {_, #{annotated := true}},
+                        exprs := [{_, #{annotated := true}}]
+                    }}
+                ],
+                annotated := true
+            }}
+        ],
+        rufus_forms:map([Form], fun annotate/1)
+    ).
+
 map_with_cons_test() ->
     Line = 17,
     Type = rufus_form:make_type(list, rufus_form:make_type(int, Line), Line),

--- a/rf/test/rufus_parse_case_test.erl
+++ b/rf/test/rufus_parse_case_test.erl
@@ -523,3 +523,74 @@ parse_function_with_case_block_with_match_clause_test() ->
         }}
     ],
     ?assertEqual(Expected, Forms).
+
+parse_function_with_case_block_with_default_clause_test() ->
+    RufusText =
+        "func Convert(value atom) string {\n"
+        "    case value {\n"
+        "    match :true ->\n"
+        "        \"true\"\n"
+        "    default ->\n"
+        "        \"false\"\n"
+        "    }\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs =>
+                [
+                    {'case', #{
+                        clauses =>
+                            [
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 4,
+                                                spec => <<"true">>,
+                                                type =>
+                                                    {type, #{line => 4, spec => string}}
+                                            }}
+                                        ],
+                                    line => 3,
+                                    match_expr =>
+                                        {atom_lit, #{
+                                            line => 3,
+                                            spec => true,
+                                            type =>
+                                                {type, #{line => 3, spec => atom}}
+                                        }}
+                                }},
+                                {case_clause, #{
+                                    exprs =>
+                                        [
+                                            {string_lit, #{
+                                                line => 6,
+                                                spec => <<"false">>,
+                                                type =>
+                                                    {type, #{line => 6, spec => string}}
+                                            }}
+                                        ],
+                                    line => 5
+                                }}
+                            ],
+                        line => 2,
+                        match_expr =>
+                            {identifier, #{line => 2, spec => value}}
+                    }}
+                ],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => atom}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => string}},
+            spec => 'Convert'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_case_test.erl
+++ b/rf/test/rufus_raw_tokenize_case_test.erl
@@ -59,3 +59,35 @@ string_with_case_block_with_multiple_clauses_test() ->
         ],
         Tokens
     ).
+
+string_with_case_block_with_default_clause_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "case n {\n"
+        "match 42 ->\n"
+        "    :pass\n"
+        "default ->\n"
+        "    :fail\n"
+        "}\n"
+    ),
+    ?assertEqual(
+        [
+            {'case', 1},
+            {identifier, 1, "n"},
+            {'{', 1},
+            {eol, 1},
+            {match, 2},
+            {int_lit, 2, 42},
+            {'->', 2},
+            {eol, 2},
+            {atom_lit, 3, pass},
+            {eol, 3},
+            {default, 4},
+            {'->', 4},
+            {eol, 4},
+            {atom_lit, 5, fail},
+            {eol, 5},
+            {'}', 6},
+            {eol, 6}
+        ],
+        Tokens
+    ).


### PR DESCRIPTION
`rufus_expr:typecheck_and_annotate/1` typechecks and annotates `case` and `case_clause` forms. `rufus_raw_tokenize:string/1` and `rufus_parse:parse/1` both have support for `default` case clauses. `rufus_forms:each/2`, `rufus_forms:map/2`, and `rufus_type:resolve/3` all support `case` and `case_clause` forms.