### PR TITLE
doc: Update examples

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 on: push
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ systems.
 ```rufus
 module main
 
-import "Fmt"
+import "fmt"
 
 func main() {
-    Fmt.Println("Hello, world!")
+    fmt.Println("Hello, world!")
 }
 ```
 
@@ -57,7 +57,7 @@ type Person struct {
     Age  int
 }
 alice = Person{Name => "Alice", Age => 34}
-Fmt.Printf("%s is age %d", [alice.Name, alice.Age])
+fmt.Printf("%s is age %d", [alice.Name, alice.Age])
 ```
 
 Function types:

--- a/example/echo_test.rf
+++ b/example/echo_test.rf
@@ -1,7 +1,10 @@
 module example
 
-import t "Testing"
+import (
+    "testing"
+    "testing/assert"
+)
 
-func TestEcho(c t.C) {
-    t.AssertEqual(c, "Hello, world!", Echo("Hello, world!"))
+func TestEcho(t testing.T) {
+    assert.Equal(t, "Hello, world!", Echo("Hello, world!"))
 }

--- a/rufus-lang.org/public/doc/rdr/nnnn-exported-identifiers.md
+++ b/rufus-lang.org/public/doc/rdr/nnnn-exported-identifiers.md
@@ -27,8 +27,8 @@ Rufus provide for users to manage encapsulation?
 ### Option 1
 
 Idenifiers for types, constants, and functions defined in the module block that
-start with an `_` or a Unicode lower case letter (Unicode class "Ll") are
-private. All other identifiers for types, constants, and functions are exported.
+start with a lower case letter are private. All other identifiers for types,
+constants, and functions are exported.
 
 Example: A public module called `math` with a public `Pi` constant and a private
 `quarter` constant, both `float`s:
@@ -98,12 +98,6 @@ filesystems. A private `math` module in `math.rf` could conflict with a public
 
 ## Decision outcome
 
-Chosen option: option 2, because it uses one unified pattern instead of two
-different patterns. It also has the benefit of making private modules more
-obvious when reading code because they start with an `_` or a lowercase letter.
-We will fail a build if two or more Rufus source files in the same directory
-have names that differ only by case. This will prevent collision issues on
-case-insensitive filesystems.
-
-Open question: will a leading `_` for module, type, constant, or function cause
-parser grammer conflicts with `_` in pattern matching syntax and semantics?
+Chosen option: option 1, because it avoids Rufus source files in the same
+directory have names that differ only by case, which is likely to lead to
+confusion.

--- a/rufus-lang.org/public/doc/spec.md
+++ b/rufus-lang.org/public/doc/spec.md
@@ -602,17 +602,17 @@ Here is a complete Rufus module that implements a prime sieve.
 ```rufus
 module main
 
-import "std/List"
+import "lists"
 
 sieve([] list[int]) list[int] {
     []
 }
 sieve([h|t] list[int]) list[int] {
-    result = List.Filter(func(n int) bool { n % h != 0 }, t)
+    result = lists.Filter(func(n int) bool { n % h != 0 }, t)
     [h|sieve(result)]
 }
 
 main() {
-    sieve(List.Seq(2, 30))
+    sieve(lists.Seq(2, 30))
 }
 ```

--- a/rufus-lang.org/public/index.md
+++ b/rufus-lang.org/public/index.md
@@ -3,10 +3,10 @@
 ```rufus
 module main
 
-import "Fmt"
+import "fmt"
 
 func main(args list[string]) {
-    Fmt.Println("Hello, world!")
+    fmt.Println("Hello, world!")
 }
 ```
 


### PR DESCRIPTION
Numerous examples have been updated to reference lowercase module names, and the _Exported Identifiers_ RDR has been updated to select that option with lowercase module names, that avoid collisions, and relies on an `internal` directory to isolate private modules.