### PR TITLE
compiler: Tokenizer reads code comments

### DIFF
--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -6,8 +6,9 @@ Semicolon            = \;
 Underscore           = _
 UnicodeLetter        = [A-Za-z]
 Digit                = [0-9]
-Letter               = ({UnicodeLetter}|'_')
+Letter               = {UnicodeLetter}|'_'
 Whitespace           = [\s\t]
+Comment              = //.*
 
 Module               = module
 Import               = import
@@ -31,7 +32,7 @@ StringType           = string
 ListType             = {List}\[Identifier\]
 
 AtomLiteral          = {Colon}({UnicodeLetter}+({Digit}|{UnicodeLetter})?|\'({Digit}|{UnicodeLetter}|{Whitespace})+\')
-BoolLiteral          = (true|false)
+BoolLiteral          = true|false
 Exponent             = (e|E)?(\+|\-)?{Digit}+
 FloatLiteral         = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
 IntLiteral           = (\+|\-)?{Digit}+
@@ -67,6 +68,7 @@ Rules.
 {Whitespace}+          : skip_token.
 {Newline}+             : {token, {eol, TokenLine}}.
 {Semicolon}+           : {token, {';', TokenLine}}.
+{Comment}              : {token, {comment, TokenLine, TokenChars}}.
 
 {Module}               : {token, {module, TokenLine}}.
 {Import}               : {token, {import, TokenLine}}.

--- a/rf/src/rufus_tokenize.erl
+++ b/rf/src/rufus_tokenize.erl
@@ -29,7 +29,7 @@
 string(RufusText) ->
     case rufus_raw_tokenize:string(RufusText) of
         {ok, Tokens, _Lines} ->
-            insert_semicolons(Tokens);
+            insert_semicolons(discard_comments(Tokens));
         {error, Reason, _LineNumber} ->
             {error, Reason}
     end.
@@ -43,6 +43,18 @@ terminate(Acc = [{';', _TokenLine1} | _T], _TokenLine2) ->
     Acc;
 terminate(Acc, TokenLine) ->
     [make_semicolon_token(TokenLine) | Acc].
+
+%% discard_comments discards comment tokens.
+-spec discard_comments(list(tuple())) -> list(tuple()).
+discard_comments(Tokens) ->
+    discard_comments([], Tokens).
+
+discard_comments(Acc, [{comment, _TokenLine, _TokenChars} | T]) ->
+    discard_comments(Acc, T);
+discard_comments(Acc, [Token | T]) ->
+    discard_comments([Token | Acc], T);
+discard_comments(Acc, []) ->
+    lists:reverse(Acc).
 
 %% insert_semicolons inserts `;` tokens after some `eol` tokens to terminate
 %% expressions. All `eol` tokens are discarded in the resulting list of tokens.

--- a/rf/test/rufus_parse_comment_test.erl
+++ b/rf/test/rufus_parse_comment_test.erl
@@ -1,0 +1,51 @@
+-module(rufus_parse_comment_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_function_with_module_level_comment_test() ->
+    RufusText =
+        "// echo module contains a server that returns the messages it receives\n"
+        "module echo\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 2, spec => echo}}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_module_level_end_of_line_comment_test() ->
+    RufusText =
+        "module echo // echo module exposes an echo server\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    io:format("tokens => ~p~n", [Tokens]),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {module, #{line => 1, spec => echo}}
+    ],
+    ?assertEqual(Expected, Forms).
+
+parse_function_with_comment_in_function_block_test() ->
+    RufusText =
+        "func Echo(value atom) atom {\n"
+        "    // Echo returns the value it receives\n"
+        "    value\n"
+        "}\n",
+    {ok, Tokens} = rufus_tokenize:string(RufusText),
+    {ok, Forms} = rufus_parse:parse(Tokens),
+    Expected = [
+        {func, #{
+            exprs => [{identifier, #{line => 3, spec => value}}],
+            line => 1,
+            params =>
+                [
+                    {param, #{
+                        line => 1,
+                        spec => value,
+                        type => {type, #{line => 1, spec => atom}}
+                    }}
+                ],
+            return_type => {type, #{line => 1, spec => atom}},
+            spec => 'Echo'
+        }}
+    ],
+    ?assertEqual(Expected, Forms).

--- a/rf/test/rufus_raw_tokenize_comment_test.erl
+++ b/rf/test/rufus_raw_tokenize_comment_test.erl
@@ -1,0 +1,72 @@
+-module(rufus_raw_tokenize_comment_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+string_with_comment_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("// rufus programming language"),
+    ?assertEqual([{comment, 1, "// rufus programming language"}], Tokens).
+
+string_with_multiline_comment_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "// The rufus programming language is\n"
+        "// implemented in Erlang and runs on the BEAM\n"
+    ),
+    ?assertEqual(
+        [
+            {comment, 1, "// The rufus programming language is"},
+            {eol, 1},
+            {comment, 2, "// implemented in Erlang and runs on the BEAM"},
+            {eol, 2}
+        ],
+        Tokens
+    ).
+
+string_with_end_of_line_comment_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "i = 1// index\n"
+        "j = 2\n"
+    ),
+    ?assertEqual(
+        [
+            {identifier, 1, "i"},
+            {'=', 1},
+            {int_lit, 1, 1},
+            {comment, 1, "// index"},
+            {eol, 1},
+            {identifier, 2, "j"},
+            {'=', 2},
+            {int_lit, 2, 2},
+            {eol, 2}
+        ],
+        Tokens
+    ).
+
+string_with_commented_our_source_text_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("// func number() int { 42 }"),
+    ?assertEqual([{comment, 1, "// func number() int { 42 }"}], Tokens).
+
+string_with_commented_our_source_text_and_newline_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("// func number() int { 42 }\n"),
+    ?assertEqual([{comment, 1, "// func number() int { 42 }"}, {eol, 1}], Tokens).
+
+string_with_docstring_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "// Random returns a randomly generated number.\n"
+        "func Random() int { 42 }\n"
+    ),
+    ?assertEqual(
+        [
+            {comment, 1, "// Random returns a randomly generated number."},
+            {eol, 1},
+            {func, 2},
+            {identifier, 2, "Random"},
+            {'(', 2},
+            {')', 2},
+            {int, 2},
+            {'{', 2},
+            {int_lit, 2, 42},
+            {'}', 2},
+            {eol, 2}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_tokenize_test.erl
+++ b/rf/test/rufus_tokenize_test.erl
@@ -26,6 +26,32 @@ string_inserts_semicolon_after_last_identifier_in_line_test() ->
         Tokens
     ).
 
+string_discards_last_comment_in_source_text_test() ->
+    {ok, Tokens} = rufus_tokenize:string("const Name = \"Rufus\" // name"),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {string_lit, 1, "Rufus"},
+            {';', 1}
+        ],
+        Tokens
+    ).
+
+string_discards_comment_in_line_test() ->
+    {ok, Tokens} = rufus_tokenize:string("const Name = \"Rufus\" // name\n"),
+    ?assertEqual(
+        [
+            {const, 1},
+            {identifier, 1, "Name"},
+            {'=', 1},
+            {string_lit, 1, "Rufus"},
+            {';', 1}
+        ],
+        Tokens
+    ).
+
 string_inserts_semicolon_after_last_atom_lit_in_source_text_test() ->
     {ok, Tokens} = rufus_tokenize:string("const Name = :rufus"),
     ?assertEqual(


### PR DESCRIPTION
`rufus_raw_tokenize:string/1` reads code comments and expresses them as `comment` tokens. `rufus_tokenize:string/1` discards comments so that downstream stages are unaffected by them.