### PR TITLE
compiler: Parse strings with non-alphanumeric characters

### DIFF
--- a/rf/src/rufus_raw_tokenize.xrl
+++ b/rf/src/rufus_raw_tokenize.xrl
@@ -36,7 +36,7 @@ BoolLiteral          = true|false
 Exponent             = (e|E)?(\+|\-)?{Digit}+
 FloatLiteral         = (\+|\-)?{Digit}+\.{Digit}+{Exponent}?
 IntLiteral           = (\+|\-)?{Digit}+
-StringLiteral        = \"({Digit}|{UnicodeLetter}|{Whitespace})+\"
+StringLiteral        = \"(\\.|[^"\\])*\"
 
 LeftBrace            = \{
 RightBrace           = \}

--- a/rf/test/rufus_raw_tokenize_func_test.erl
+++ b/rf/test/rufus_raw_tokenize_func_test.erl
@@ -176,10 +176,38 @@ string_with_function_takes_an_int_and_a_string_and_returning_a_float_test() ->
         Tokens
     ).
 
-%% TODO(jkakar): Implement these tests:
-%%
-%% string_with_function_takes_an_unused_argument_test() ->
-%%     {ok, Tokens, _} = rufus_raw_tokenize:string("func unused(_ int) int { 0 }")
-%%
-%% string_with_function_takes_an_unused_named_argument_test() ->
-%%     {ok, Tokens, _} = rufus_raw_tokenize:string("func unused(_num int) int { 0 }")
+string_with_function_takes_an_unused_argument_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("func unused(_ int) int { 0 }"),
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "unused"},
+            {'(', 1},
+            {identifier, 1, "_"},
+            {int, 1},
+            {')', 1},
+            {int, 1},
+            {'{', 1},
+            {int_lit, 1, 0},
+            {'}', 1}
+        ],
+        Tokens
+    ).
+
+string_with_function_takes_an_unused_named_argument_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("func unused(_num int) int { 0 }"),
+    ?assertEqual(
+        [
+            {func, 1},
+            {identifier, 1, "unused"},
+            {'(', 1},
+            {identifier, 1, "_num"},
+            {int, 1},
+            {')', 1},
+            {int, 1},
+            {'{', 1},
+            {int_lit, 1, 0},
+            {'}', 1}
+        ],
+        Tokens
+    ).

--- a/rf/test/rufus_raw_tokenize_literal_test.erl
+++ b/rf/test/rufus_raw_tokenize_literal_test.erl
@@ -1,0 +1,21 @@
+-module(rufus_raw_tokenize_literal_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+string_with_alphabetic_characters_in_string_literal_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string(
+        "\"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\""
+    ),
+    ?assertEqual([{string_lit, 1, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"}], Tokens).
+
+string_with_numeric_characters_in_string_literal_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("\"0123456789\""),
+    ?assertEqual([{string_lit, 1, "0123456789"}], Tokens).
+
+string_with_whitespace_characters_in_string_literal_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("\" 	\""),
+    ?assertEqual([{string_lit, 1, " \t"}], Tokens).
+
+string_with_punctuation_characters_in_string_literal_test() ->
+    {ok, Tokens, _} = rufus_raw_tokenize:string("\"!@#$%^&*()-+_={}[];':,<>.?|/~`\""),
+    ?assertEqual([{string_lit, 1, "!@#$%^&*()-+_={}[];':,<>.?|/~`"}], Tokens).


### PR DESCRIPTION
`rufus_raw_tokenizer` has been extended to parse strings with punctuation and whitespace. Escaped double quotes may still not be parsed correctly.